### PR TITLE
fix: 修正 PR#14 引入的 4 處編譯錯誤 — Logger.Instance 與 Room namespace

### DIFF
--- a/MCP/Core/Commands/CommandExecutor.DependentView.cs
+++ b/MCP/Core/Commands/CommandExecutor.DependentView.cs
@@ -145,7 +145,7 @@ namespace RevitMCP.Core
 
                     string newName = $"{parentView.Name}-{finalSuffix}";
                     try { newView.Name = newName; }
-                    catch (Exception ex) { Logger.Instance.Log($"視圖命名失敗: {ex.Message}"); }
+                    catch (Exception ex) { Logger.Debug($"視圖命名失敗: {ex.Message}"); }
 
                     newView.CropBoxActive = true;
                     newView.CropBoxVisible = true;

--- a/MCP/Core/Commands/CommandExecutor.Dimension.cs
+++ b/MCP/Core/Commands/CommandExecutor.Dimension.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Architecture;
 using Autodesk.Revit.UI;
 using Newtonsoft.Json.Linq;
 

--- a/MCP/Core/Commands/CommandExecutor.Sheet.cs
+++ b/MCP/Core/Commands/CommandExecutor.Sheet.cs
@@ -202,7 +202,7 @@ namespace RevitMCP.Core
                     {
                         string original = s.SheetNumber.Replace("_MCPFIX", "");
                         try { s.SheetNumber = original; }
-                        catch (Exception ex) { Logger.Instance.Log($"還原 _MCPFIX 失敗: {ex.Message}"); }
+                        catch (Exception ex) { Logger.Debug($"還原 _MCPFIX 失敗: {ex.Message}"); }
                     }
                     tFix.Commit();
                 }

--- a/MCP/Core/Commands/CommandExecutor.WallType.cs
+++ b/MCP/Core/Commands/CommandExecutor.WallType.cs
@@ -150,7 +150,7 @@ namespace RevitMCP.Core
                 }
                 catch (Exception ex)
                 {
-                    Logger.Instance.Log($"GetLineStyles 跳過樣式: {ex.Message}");
+                    Logger.Debug($"GetLineStyles 跳過樣式: {ex.Message}");
                 }
             }
 


### PR DESCRIPTION
## Summary

合併 main 後執行 `dotnet build -c Release.R24` 發現 5 個編譯錯誤，來自 PR #14（`f6b0816 feat: 整合 PR#14 fork 18 個工具`）。

### 問題 1：`Logger.Instance.Log()` 不存在（3 處）

- 專案的 `Logger` 是公用靜態工具，可以直接呼叫，不需要透過 `.Instance` 取得
- 造成的問題：**編譯失敗**，整個 DLL 無法產出，所有工具都無法使用
- 修正：`Logger.Instance.Log()` → `Logger.Debug()`

| 檔案 | 行號 |
|------|------|
| `CommandExecutor.DependentView.cs` | 148 |
| `CommandExecutor.Sheet.cs` | 205 |
| `CommandExecutor.WallType.cs` | 153 |

### 問題 2：`Room` 型別找不到（1 處）

- `CommandExecutor.Dimension.cs` 使用了 `Room` 但沒有引入它所屬的命名空間
- 造成的問題：**編譯失敗**，等於用了一個 Revit 功能但忘了告訴程式去哪裡找
- 修正：加入 `using Autodesk.Revit.DB.Architecture`

## Test plan

- [x] `dotnet build -c Release.R24` 編譯成功（0 errors, warnings only）
- [ ] Revit 2024 載入 add-in 正常運作

🤖 Generated with [Claude Code](https://claude.com/claude-code)