### PR TITLE
[二月PR: 新增可分析有分支的走廊工作流程]的實作檔與優化

### DIFF
--- a/MCP-Server/src/tools/corridor-analysis-tools.ts
+++ b/MCP-Server/src/tools/corridor-analysis-tools.ts
@@ -1,0 +1,20 @@
+/**
+ * 走廊分析工具
+ */
+
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export const corridorAnalysisTools: Tool[] = [
+    {
+        name: "analyze_corridor_width",
+        description: "分析走廊寬度。使用 Revit 端的房間邊界線段找出平行牆對，回傳實測寬度、最小寬度與各區段檢討結果。",
+        inputSchema: {
+            type: "object",
+            properties: {
+                roomId: { type: "number", description: "房間 Element ID（選填）" },
+                roomName: { type: "string", description: "房間名稱（選填）" },
+                minWidth: { type: "number", description: "最小寬度門檻（mm）", default: 1200 },
+            },
+        },
+    },
+];

--- a/MCP-Server/src/tools/index.ts
+++ b/MCP-Server/src/tools/index.ts
@@ -11,6 +11,7 @@ import { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { baseTools } from "./base-tools.js";
 import { wallTools } from "./wall-tools.js";
 import { roomTools } from "./room-tools.js";
+import { corridorAnalysisTools } from "./corridor-analysis-tools.js";
 import { visualizationTools } from "./visualization-tools.js";
 import { scheduleTools } from "./schedule-tools.js";
 import { mepTools } from "./mep-tools.js";
@@ -28,11 +29,11 @@ import { clashTools } from "./clash-tools.js";
  * Profile 對照表：每個 profile 包含哪些模組
  */
 const PROFILE_MODULES: Record<string, Tool[][]> = {
-    full: [baseTools, wallTools, roomTools, visualizationTools, scheduleTools, mepTools, curtainWallTools, smokeExhaustTools, STAIR_COMPLIANCE_TOOLS, sheetTools, detailComponentTools, dimensionTools, dependentViewTools, clashTools],
-    architect: [baseTools, wallTools, roomTools, visualizationTools, scheduleTools, curtainWallTools, STAIR_COMPLIANCE_TOOLS, sheetTools, detailComponentTools, dimensionTools, dependentViewTools],
+    full: [baseTools, wallTools, roomTools, corridorAnalysisTools, visualizationTools, scheduleTools, mepTools, curtainWallTools, smokeExhaustTools, STAIR_COMPLIANCE_TOOLS, sheetTools, detailComponentTools, dimensionTools, dependentViewTools, clashTools],
+    architect: [baseTools, wallTools, roomTools, corridorAnalysisTools, visualizationTools, scheduleTools, curtainWallTools, STAIR_COMPLIANCE_TOOLS, sheetTools, detailComponentTools, dimensionTools, dependentViewTools],
     mep: [baseTools, mepTools, scheduleTools, visualizationTools, smokeExhaustTools, clashTools],
     structural: [baseTools, wallTools, visualizationTools, clashTools],
-    "fire-safety": [baseTools, roomTools, visualizationTools, smokeExhaustTools],
+    "fire-safety": [baseTools, roomTools, corridorAnalysisTools, visualizationTools, smokeExhaustTools],
 };
 
 /**

--- a/MCP-Server/src/utils/corridor-geometry.js
+++ b/MCP-Server/src/utils/corridor-geometry.js
@@ -1,0 +1,346 @@
+/**
+ * 走廊幾何計算模組
+ * 用於計算走廊實際寬度 (支援任意角度)
+ */
+
+/**
+ * 計算走廊實際寬度
+ * @param {Array} segments - 邊界線段 [{StartX, StartY, EndX, EndY, Length}]
+ * @param {Object} bbox - BoundingBox fallback {MinX, MinY, MaxX, MaxY}
+ * @returns {Object} { width: number, method: string, details: object }
+ */
+export function calculateCorridorWidth(segments, bbox) {
+    if (!segments || segments.length === 0) {
+        return calculateBBoxWidth(bbox);
+    }
+
+    // 1. 找出最長的兩條平行線段
+    const parallelPairs = findParallelSegments(segments);
+
+    if (parallelPairs.length === 0) {
+        console.warn('⚠️  找不到平行線段,使用 BoundingBox 估算');
+        return calculateBBoxWidth(bbox);
+    }
+
+    // 2. 計算最短垂直距離
+    const bestPair = parallelPairs[0];
+    const width = calculatePerpendicularDistance(bestPair.seg1, bestPair.seg2);
+
+    return {
+        width,
+        method: 'boundary_accurate',
+        details: {
+            segmentCount: segments.length,
+            parallelPairs: parallelPairs.length,
+            longestPairLength: Math.round(bestPair.avgLength)
+        }
+    };
+}
+
+/**
+ * 找出平行線段對 (角度差 < 5°)
+ * @param {Array} segments
+ * @returns {Array} 按平均長度排序的平行線段對
+ */
+function findParallelSegments(segments) {
+    const ANGLE_THRESHOLD = 5; // 度
+    const pairs = [];
+
+    for (let i = 0; i < segments.length; i++) {
+        for (let j = i + 1; j < segments.length; j++) {
+            const seg1 = segments[i];
+            const seg2 = segments[j];
+
+            const angle1 = calculateAngle(seg1);
+            const angle2 = calculateAngle(seg2);
+
+            // 計算角度差 (考慮 0°/180° 的循環)
+            let angleDiff = Math.abs(angle1 - angle2);
+            if (angleDiff > 180) angleDiff = 360 - angleDiff;
+            if (angleDiff > 90) angleDiff = 180 - angleDiff;
+
+            if (angleDiff < ANGLE_THRESHOLD) {
+                pairs.push({
+                    seg1,
+                    seg2,
+                    avgLength: (seg1.Length + seg2.Length) / 2,
+                    angleDiff
+                });
+            }
+        }
+    }
+
+    // 按平均長度排序 (最長的平行線段對最可能是走廊兩側牆)
+    return pairs.sort((a, b) => b.avgLength - a.avgLength);
+}
+
+/**
+ * 計算線段角度 (0-360°)
+ */
+export function calculateAngle(seg) {
+    const dx = seg.EndX - seg.StartX;
+    const dy = seg.EndY - seg.StartY;
+    let angle = Math.atan2(dy, dx) * 180 / Math.PI;
+    if (angle < 0) angle += 360;
+    return angle;
+}
+
+/**
+ * 計算兩條平行線段之間的垂直距離
+ * 使用點到線的距離公式
+ */
+function calculatePerpendicularDistance(seg1, seg2) {
+    // 使用 seg1 的起點到 seg2 的垂直距離
+    const distance = pointToLineDistance(
+        { x: seg1.StartX, y: seg1.StartY },
+        { x: seg2.StartX, y: seg2.StartY },
+        { x: seg2.EndX, y: seg2.EndY }
+    );
+
+    return distance;
+}
+
+/**
+ * 點到線的垂直距離
+ * @param {Object} point - {x, y}
+ * @param {Object} lineStart - {x, y}
+ * @param {Object} lineEnd - {x, y}
+ */
+export function pointToLineDistance(point, lineStart, lineEnd) {
+    const dx = lineEnd.x - lineStart.x;
+    const dy = lineEnd.y - lineStart.y;
+
+    // 線段長度
+    const lineLength = Math.sqrt(dx * dx + dy * dy);
+
+    if (lineLength === 0) {
+        // 線段退化為點
+        return Math.sqrt(
+            Math.pow(point.x - lineStart.x, 2) +
+            Math.pow(point.y - lineStart.y, 2)
+        );
+    }
+
+    // 點到直線的距離公式: |ax + by + c| / sqrt(a^2 + b^2)
+    // 直線方程: (y2-y1)x - (x2-x1)y + (x2-x1)y1 - (y2-y1)x1 = 0
+    const numerator = Math.abs(
+        dy * point.x - dx * point.y +
+        dx * lineStart.y - dy * lineStart.x
+    );
+
+    return numerator / lineLength;
+}
+
+/**
+ * BoundingBox 降級方法
+ */
+function calculateBBoxWidth(bbox) {
+    if (!bbox) {
+        return {
+            width: 0,
+            method: 'error',
+            details: { error: 'No BoundingBox data' }
+        };
+    }
+
+    const widthX = Math.abs(bbox.MaxX - bbox.MinX);
+    const widthY = Math.abs(bbox.MaxY - bbox.MinY);
+
+    return {
+        width: Math.min(widthX, widthY),
+        method: 'bbox_estimate',
+        details: { widthX, widthY }
+    };
+}
+
+// ============================================================
+// 多區段走廊分析 (支援 L/T/十字型走廊)
+// ============================================================
+
+/**
+ * 分析多區段走廊 (採用線段優先分析法)
+ * 1. 線段篩選: 計算每條線段的 Ratio = 長度 / 寬度, 若 < 1.0 則剔除
+ * 2. 配對分析: 對剩餘有效線段進行配對, 找出走廊區段
+ *
+ * @param {Array} boundarySegments - 邊界線段
+ * @param {number} minWidth - 最小寬度要求 (mm)
+ * @returns {Object} 分析結果
+ */
+export function analyzeMultiSegmentCorridor(boundarySegments, minWidth = 1200) {
+    if (!boundarySegments || boundarySegments.length === 0) {
+        return {
+            segments: [],
+            minWidth: 0,
+            allPass: false,
+            failedSegments: [],
+            error: 'No boundary segments'
+        };
+    }
+
+    // 1. 線段預處理與篩選
+    const analyzedSegments = boundarySegments.map((seg, index) => {
+        // 找出與此線段平行的所有線段
+        const parallelSegs = findParallelSegmentsForOne(seg, boundarySegments);
+
+        let width = 0;
+        let closestSeg = null;
+
+        if (parallelSegs.length > 0) {
+            // 計算距離並排序
+            const distances = parallelSegs.map(pSeg => {
+                const dist = calculatePerpendicularDistance(seg, pSeg);
+                return { seg: pSeg, dist };
+            })
+                // 過濾掉極近的線段 (例如共線的牆壁分段, 距離接近0)
+                // 這些不是走廊的寬度, 而是同一側牆壁的延伸
+                .filter(d => d.dist > 100) // 100mm 閾值
+                .sort((a, b) => a.dist - b.dist);
+
+            if (distances.length > 0) {
+                // 取最近的距離
+                width = distances[0].dist;
+                closestSeg = distances[0].seg;
+            }
+        }
+
+        const ratio = width > 0 ? seg.Length / width : 0;
+
+        return {
+            ...seg,
+            originalIndex: index,
+            width,
+            ratio,
+            closestSeg,
+            isValid: ratio >= 1.0 // 長寬比 >= 1.0 視為有效長邊
+        };
+    });
+
+    const validSegments = analyzedSegments.filter(s => s.isValid);
+
+    if (validSegments.length === 0) {
+        return {
+            segments: [],
+            minWidth: 0,
+            allPass: false,
+            failedSegments: [],
+            error: 'No valid corridor segments found (all segments are short edges)'
+        };
+    }
+
+    // 2. 建立走廊區段 (由有效線段配對而成)
+    const corridorSegments = [];
+    const processedPairs = new Set(); // 避免重複配對
+
+    validSegments.forEach(seg1 => {
+        // 找出所有與 seg1 平行的有效線段
+        const validParallelSegs = validSegments.filter(s =>
+            s.originalIndex !== seg1.originalIndex &&
+            isParallel(seg1, s)
+        );
+
+        validParallelSegs.forEach(seg2 => {
+            // 產生唯一 ID 避免重複
+            const pairId = [seg1.originalIndex, seg2.originalIndex].sort().join('-');
+
+            if (!processedPairs.has(pairId)) {
+                // 檢查投影重疊 (確認線段面對面)
+                if (checkProjectionOverlap(seg1, seg2)) {
+                    processedPairs.add(pairId);
+
+                    const width = calculatePerpendicularDistance(seg1, seg2);
+
+                    // 再次過濾極近距離 (雙重保險)
+                    if (width > 100) {
+                        // 計算區段中心點
+                        const centerPoint = {
+                            x: (seg1.StartX + seg1.EndX + seg2.StartX + seg2.EndX) / 4,
+                            y: (seg1.StartY + seg1.EndY + seg2.StartY + seg2.EndY) / 4
+                        };
+
+                        // 計算長度 (取平均長度)
+                        const length = (seg1.Length + seg2.Length) / 2;
+
+                        // 計算方向
+                        const direction = calculateAngle(seg1);
+
+                        corridorSegments.push({
+                            segmentIndex: corridorSegments.length,
+                            width: Math.round(width * 10) / 10,
+                            direction: Math.round(direction),
+                            length: Math.round(length),
+                            status: width >= minWidth ? 'PASS' : 'FAIL',
+                            centerPoint,
+                            boundaries: [seg1, seg2]
+                        });
+                    }
+                }
+            }
+        });
+    });
+
+    if (corridorSegments.length === 0) {
+        return {
+            segments: [],
+            minWidth: 0,
+            allPass: false,
+            failedSegments: [],
+            error: 'No valid parallel pairs found among long edges'
+        };
+    }
+
+    const minWidthValue = Math.min(...corridorSegments.map(r => r.width));
+    const failedSegments = corridorSegments.filter(r => r.status === 'FAIL');
+
+    return {
+        segments: corridorSegments,
+        minWidth: minWidthValue,
+        allPass: failedSegments.length === 0,
+        failedSegments,
+        totalSegments: corridorSegments.length,
+        debugInfo: {
+            totalSegments: analyzedSegments.length,
+            validSegments: validSegments.length,
+            rejectedSegments: analyzedSegments.filter(s => !s.isValid).map(s => ({
+                index: s.originalIndex,
+                length: Math.round(s.Length),
+                width: Math.round(s.width),
+                ratio: s.ratio.toFixed(2)
+            }))
+        }
+    };
+}
+
+/**
+ * 找出與特定線段平行的所有線段
+ */
+function findParallelSegmentsForOne(targetSeg, allSegments) {
+    return allSegments.filter(seg => {
+        if (seg === targetSeg) return false;
+
+        return isParallel(targetSeg, seg);
+    });
+}
+
+/**
+ * 判斷兩線段是否平行
+ */
+function isParallel(seg1, seg2) {
+    const ANGLE_THRESHOLD = 5; // 允許 5 度誤差
+    const angle1 = calculateAngle(seg1);
+    const angle2 = calculateAngle(seg2);
+
+    let angleDiff = Math.abs(angle1 - angle2);
+    if (angleDiff > 180) angleDiff = 360 - angleDiff;
+    if (angleDiff > 90) angleDiff = 180 - angleDiff;
+
+    return angleDiff < ANGLE_THRESHOLD;
+}
+
+/**
+ * 檢查兩線段是否有投影重疊
+ * 用於確認兩平行線段是否真正「面對面」構成走廊
+ */
+function checkProjectionOverlap(seg1, seg2) {
+    // 簡化版: 暫時回傳 true
+    return true;
+}

--- a/MCP/Core/CommandExecutor.cs
+++ b/MCP/Core/CommandExecutor.cs
@@ -169,6 +169,9 @@ namespace RevitMCP.Core
                     case "create_corridor_dimension":
                         result = CreateCorridorDimension(parameters);
                         break;
+                    case "analyze_corridor_width":
+                        result = AnalyzeCorridorWidth(parameters);
+                        break;
 
                     case "query_walls_by_location":
                         result = QueryWallsByLocation(parameters);
@@ -1286,7 +1289,8 @@ namespace RevitMCP.Core
                     MinY = Math.Round(bbox.Min.Y * 304.8, 2),
                     MaxX = Math.Round(bbox.Max.X * 304.8, 2),
                     MaxY = Math.Round(bbox.Max.Y * 304.8, 2)
-                } : null
+                } : null,
+                BoundarySegments = GetRoomBoundarySegments(room)
             };
         }
 
@@ -2131,6 +2135,189 @@ namespace RevitMCP.Core
                 AllPass_1600 = widthValues.All(w => w >= 1600),
                 AllPass_1200 = widthValues.All(w => w >= 1200),
                 Segments = measurements
+            };
+        }
+
+        /// <summary>
+        /// 走廊寬度分析 — 使用房間邊界線段找平行牆對，回傳寬度與各區段檢討結果
+        /// </summary>
+        private object AnalyzeCorridorWidth(JObject parameters)
+        {
+            Document doc = _uiApp.ActiveUIDocument.Document;
+            IdType? roomId = parameters["roomId"]?.Value<IdType>();
+            string roomName = parameters["roomName"]?.Value<string>();
+            double minWidth = parameters["minWidth"]?.Value<double>() ?? 1200;
+
+            Room room = null;
+
+            if (roomId.HasValue && roomId.Value > 0)
+            {
+                room = doc.GetElement(new ElementId(roomId.Value)) as Room;
+            }
+            else if (!string.IsNullOrEmpty(roomName))
+            {
+                room = new FilteredElementCollector(doc)
+                    .OfCategory(BuiltInCategory.OST_Rooms)
+                    .WhereElementIsNotElementType()
+                    .Cast<Room>()
+                    .FirstOrDefault(r => r.Name.Contains(roomName) ||
+                                         r.get_Parameter(BuiltInParameter.ROOM_NAME)?.AsString()?.Contains(roomName) == true);
+            }
+
+            if (room == null)
+            {
+                throw new Exception(roomId.HasValue
+                    ? $"找不到房間 ID: {roomId}"
+                    : $"找不到房間名稱包含: {roomName}");
+            }
+
+            var bOptions = new SpatialElementBoundaryOptions();
+            bOptions.SpatialElementBoundaryLocation = SpatialElementBoundaryLocation.Finish;
+            var segmentLoops = room.GetBoundarySegments(bOptions);
+
+            if (segmentLoops == null || segmentLoops.Count == 0)
+                throw new Exception("房間無邊界線段");
+
+            var lines = new List<Line>();
+            foreach (var seg in segmentLoops[0])
+            {
+                var curve = seg.GetCurve();
+                if (curve is Line line && line.Length > 0.3)
+                    lines.Add(line);
+            }
+
+            if (lines.Count < 2)
+                throw new Exception($"邊界線段不足（僅 {lines.Count} 條直線）");
+
+            var pairs = new List<int[]>();
+            var pairWidths = new List<double>();
+            var pairAvgLens = new List<double>();
+
+            for (int i = 0; i < lines.Count; i++)
+            {
+                XYZ dir1 = lines[i].Direction.Normalize();
+                double len1 = lines[i].Length;
+
+                for (int j = i + 1; j < lines.Count; j++)
+                {
+                    XYZ dir2 = lines[j].Direction.Normalize();
+                    double len2 = lines[j].Length;
+
+                    double dot = Math.Abs(dir1.DotProduct(dir2));
+                    if (dot < 0.996) continue;
+
+                    XYZ perp = new XYZ(-dir1.Y, dir1.X, 0).Normalize();
+                    XYZ diff = lines[j].GetEndPoint(0).Subtract(lines[i].GetEndPoint(0));
+                    double dist = Math.Abs(diff.DotProduct(perp));
+
+                    if (dist < 100.0 / 304.8) continue;
+
+                    double avgLen = (len1 + len2) / 2;
+                    if (avgLen < dist) continue;
+
+                    double s1a = lines[i].GetEndPoint(0).DotProduct(dir1);
+                    double s1b = lines[i].GetEndPoint(1).DotProduct(dir1);
+                    double s2a = lines[j].GetEndPoint(0).DotProduct(dir1);
+                    double s2b = lines[j].GetEndPoint(1).DotProduct(dir1);
+
+                    double min1 = Math.Min(s1a, s1b), max1 = Math.Max(s1a, s1b);
+                    double min2 = Math.Min(s2a, s2b), max2 = Math.Max(s2a, s2b);
+                    double oStart = Math.Max(min1, min2);
+                    double oEnd = Math.Min(max1, max2);
+                    if (oEnd <= oStart + 0.01) continue;
+
+                    pairs.Add(new[] { i, j });
+                    pairWidths.Add(dist);
+                    pairAvgLens.Add(avgLen);
+                }
+            }
+
+            if (pairs.Count == 0)
+                throw new Exception("找不到平行牆面對（可能不是走廊形狀）");
+
+            var sorted = Enumerable.Range(0, pairs.Count)
+                .OrderByDescending(k => pairAvgLens[k])
+                .ToList();
+
+            var segments = new List<object>();
+            var widthValues = new List<double>();
+
+            foreach (int k in sorted)
+            {
+                var line1 = lines[pairs[k][0]];
+                var line2 = lines[pairs[k][1]];
+                XYZ dir = line1.Direction.Normalize();
+
+                double s1a = line1.GetEndPoint(0).DotProduct(dir);
+                double s1b = line1.GetEndPoint(1).DotProduct(dir);
+                double s2a = line2.GetEndPoint(0).DotProduct(dir);
+                double s2b = line2.GetEndPoint(1).DotProduct(dir);
+
+                double min1 = Math.Min(s1a, s1b), max1 = Math.Max(s1a, s1b);
+                double min2 = Math.Min(s2a, s2b), max2 = Math.Max(s2a, s2b);
+                double oMid = (Math.Max(min1, min2) + Math.Min(max1, max2)) / 2;
+
+                double t1 = (s1b != s1a) ? (oMid - s1a) / (s1b - s1a) : 0.5;
+                double t2 = (s2b != s2a) ? (oMid - s2a) / (s2b - s2a) : 0.5;
+                t1 = Math.Max(0.01, Math.Min(0.99, t1));
+                t2 = Math.Max(0.01, Math.Min(0.99, t2));
+
+                XYZ p1 = line1.Evaluate(t1, true);
+                XYZ p2 = line2.Evaluate(t2, true);
+
+                double widthMm = Math.Round(pairWidths[k] * 304.8, 1);
+                double lengthMm = Math.Round(pairAvgLens[k] * 304.8, 1);
+                widthValues.Add(widthMm);
+
+                segments.Add(new
+                {
+                    SegmentIndex = segments.Count + 1,
+                    Width = widthMm,
+                    Length = lengthMm,
+                    Method = "boundary_accurate",
+                    Status = widthMm >= minWidth ? "PASS" : "FAIL",
+                    CenterPoint = new
+                    {
+                        X = Math.Round((p1.X + p2.X) * 304.8 / 2, 1),
+                        Y = Math.Round((p1.Y + p2.Y) * 304.8 / 2, 1)
+                    },
+                    Point1 = new
+                    {
+                        X = Math.Round(p1.X * 304.8, 1),
+                        Y = Math.Round(p1.Y * 304.8, 1)
+                    },
+                    Point2 = new
+                    {
+                        X = Math.Round(p2.X * 304.8, 1),
+                        Y = Math.Round(p2.Y * 304.8, 1)
+                    }
+                });
+            }
+
+            string resolvedRoomName = room.get_Parameter(BuiltInParameter.ROOM_NAME)?.AsString() ?? room.Name;
+            string roomNumber = room.Number ?? "";
+
+            return new
+            {
+                Room = new
+                {
+                    ElementId = room.Id.GetIdValue(),
+                    Name = resolvedRoomName,
+                    Number = roomNumber,
+                    Level = doc.GetElement(room.LevelId)?.Name
+                },
+                Input = new
+                {
+                    MinWidth = minWidth,
+                    BoundarySegmentCount = lines.Count
+                },
+                Summary = new
+                {
+                    TotalSegments = segments.Count,
+                    MinWidth = widthValues.Count > 0 ? widthValues.Min() : 0,
+                    AllPass = widthValues.All(w => w >= minWidth)
+                },
+                Segments = segments
             };
         }
 
@@ -3018,6 +3205,48 @@ namespace RevitMCP.Core
                 TotalPairs = storedCount,
                 Message = $"已恢復 {rejoinedCount} 個接合關係"
             };
+        }
+
+        /// <summary>
+        /// 取得房間邊界線段 (用於精確計算走廊寬度)
+        /// </summary>
+        private List<object> GetRoomBoundarySegments(Room room)
+        {
+            var segments = new List<object>();
+            var options = new SpatialElementBoundaryOptions();
+
+            try
+            {
+                var boundarySegments = room.GetBoundarySegments(options);
+                if (boundarySegments == null || boundarySegments.Count == 0)
+                    return segments;
+
+                foreach (var loop in boundarySegments)
+                {
+                    foreach (BoundarySegment seg in loop)
+                    {
+                        var curve = seg.GetCurve();
+                        var start = curve.GetEndPoint(0);
+                        var end = curve.GetEndPoint(1);
+
+                        segments.Add(new
+                        {
+                            StartX = Math.Round(start.X * 304.8, 2),
+                            StartY = Math.Round(start.Y * 304.8, 2),
+                            EndX = Math.Round(end.X * 304.8, 2),
+                            EndY = Math.Round(end.Y * 304.8, 2),
+                            Length = Math.Round(curve.Length * 304.8, 2)
+                        });
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                // 某些房間可能無法取得邊界 (未封閉、未放置等)
+                // 回傳空陣列,讓 JS 端使用 BoundingBox fallback
+            }
+
+            return segments;
         }
 
         #endregion

--- a/domain/corridor-analysis-protocol.md
+++ b/domain/corridor-analysis-protocol.md
@@ -29,24 +29,26 @@ metadata:
 3. **分析 (Analysis)**:
    - 檢查寬度是否符合建築技術規則（1.2m 與 1.6m 閥值）。
 4. **標註 (Annotation)**:
-   - 使用 `create_dimension` 在房間 BoundingBox 的中心線上建立標註。
-   - 必須指定與房間一致的樓層 (`LevelId`) 並選擇正確的視圖。
+   - 優先使用 `analyze_corridor_width` 做純分析，再視需要呼叫 `create_corridor_dimension` 建立標註。
+   - 必須指定與房間一致的樓層並選擇正確的平面視圖。
 
 ## 🛠️ 成功工具組合範例
 ```javascript
 // 取得當前樓層走廊
-const rooms = await call('get_rooms_by_level', { levelId: currentLevelId });
-const corridor = rooms.find(r => r.name.includes('廊下'));
+const rooms = await call('get_rooms_by_level', { level: currentLevelName });
+const corridor = rooms.Rooms.find(r => r.Name?.includes('走廊') || r.Name?.includes('Corridor'));
 
-// 根據 BoundingBox 中心點建立尺寸標註線
-const centerStart = { x: min.x, y: (min.y + max.y) / 2, z: 0 };
-const centerEnd = { x: max.x, y: (min.y + max.y) / 2, z: 0 };
+const analysis = await call('analyze_corridor_width', {
+    roomId: corridor.ElementId,
+    minWidth: 1200
+});
 
-await call('create_dimension', {
-    elements: [corridor.id],
-    type: 'Linear',
-    viewId: activeViewId,
-    line: { start: centerStart, end: centerEnd }
+console.log(`最小寬度: ${analysis.Summary.MinWidth} mm`);
+console.log(`是否合規: ${analysis.Summary.AllPass ? 'PASS' : 'FAIL'}`);
+
+await call('create_corridor_dimension', {
+    roomId: corridor.ElementId,
+    viewId: activeViewId
 });
 ```
 
@@ -80,15 +82,14 @@ await call('create_dimension', {
    - `method: "bbox_estimate"` - 估算 (不精確)
 
 ```javascript
-import { calculateCorridorWidth } from '../src/utils/corridor-geometry.js';
+const result = await call('analyze_corridor_width', {
+    roomId: corridorRoomId,
+    minWidth: 1200
+});
 
-const result = calculateCorridorWidth(
-    roomData.BoundarySegments, 
-    roomData.BoundingBox
-);
-
-console.log(`寬度: ${result.width.toFixed(1)} mm`);
-console.log(`方法: ${result.method}`);
+console.log(`最小寬度: ${result.Summary.MinWidth} mm`);
+console.log(`區段數量: ${result.Summary.TotalSegments}`);
+console.log(`整體結果: ${result.Summary.AllPass ? 'PASS' : 'FAIL'}`);
 ```
 
 ## 🔀 多區段走廊分析 (Segment-First Algorithm)
@@ -131,6 +132,10 @@ console.log(`方法: ${result.method}`);
 - **幾何直觀**: 直接基於走廊「細長形」的本質特徵進行分析。
 
 ### 使用範例 (SDK)
+
+> Note:
+> `corridor-geometry.js` 目前保留為演算法參考/備用實作。
+> 正式工具流程以 `analyze_corridor_width` 與 `create_corridor_dimension` 為主。
 
 ```javascript
 import { analyzeMultiSegmentCorridor } from '../src/utils/corridor-geometry.js';


### PR DESCRIPTION
老師您好:
因為之前都以為contribute只能提domain一個檔案，所以都沒有把實作的部分pr，這次把我前3個月提的pr中的實作檔都補上，這個pr是二月針對走廊分析的實作檔:

那因為為了避免去動到目前專案的原始程式碼，這次有做一些修改，讓這個呼叫的實作工具是獨立出來的，雖然還是有幾個檔案有小幅度增減，目前檢測下來不會影響到原始功能，再麻煩您檢閱審核，謝謝您。

## 變更目的

這個 PR 新增正式的走廊寬度分析工具 `analyze_corridor_width`，讓走廊檢討流程可以先做純分析，再依需要建立尺寸標註，而不是只能直接走標註流程。

## 主要變更

### 1. 新增 `analyze_corridor_width` MCP tool

- 新增獨立 tool 檔：
  - `MCP-Server/src/tools/corridor-analysis-tools.ts`
- 讓走廊寬度分析成為正式可呼叫的 MCP tool
- 工具輸入支援：
  - `roomId`
  - `roomName`
  - `minWidth`

### 2. 在 Revit 端新增正式分析邏輯

- 在 `MCP/Core/CommandExecutor.cs` 新增：
  - `case "analyze_corridor_width"`
  - `AnalyzeCorridorWidth(...)`
- 分析方法會：
  - 讀取房間 boundary segments
  - 找出平行牆對
  - 計算垂直距離作為走廊寬度
  - 進行長寬比與投影重疊檢查
  - 回傳各區段寬度、最小寬度與 PASS/FAIL 結果

### 3. 擴充 `get_room_info` 的輸出內容

- 在 `MCP/Core/CommandExecutor.cs` 的 `GetRoomInfo(...)` 中新增：
  - `BoundarySegments`
- 新增 helper：
  - `GetRoomBoundarySegments(Room room)`
- 目的：
  - 讓房間資訊除了 BoundingBox 外，也能提供精確邊界線段資料
  - 方便後續走廊分析與其他幾何檢討功能重用

### 4. 保留 `corridor-geometry.js` 作為參考實作

- 保留檔案：
  - `MCP-Server/src/utils/corridor-geometry.js`
- 用途：
  - 作為演算法參考
  - 作為備用 / 後續可能擴充的 JS 幾何實作
- 目前正式執行主流程仍以 Revit 端 `AnalyzeCorridorWidth(...)` 為主

### 5. 更新走廊分析流程文件

- 更新檔案：
  - `domain/corridor-analysis-protocol.md`
- 主要調整：
  - 主流程改成優先呼叫 `analyze_corridor_width`
  - 需要標註時再呼叫 `create_corridor_dimension`
  - 把 `corridor-geometry.js` 改標示為補充 / 參考實作，而不是正式主流程入口

## 設計原則

這次調整刻意遵守以下原則：

- 不修改 `MCP-Server/src/tools/revit-tools.ts`
- 不修改 `MCP-Server/src/tools/room-tools.ts`
- 以新增獨立 tool 檔的方式擴充功能
- 保留目前 `main` 上其他開發者已加入的內容，不用舊版 `CommandExecutor.cs` 覆蓋主線後續開發

## 工具使用方式

### 1. 先做純分析

```javascript
await call('analyze_corridor_width', {
  roomId: corridorRoomId,
  minWidth: 1200
});
```

### 2. 需要標註時再建立尺寸

```javascript
await call('create_corridor_dimension', {
  roomId: corridorRoomId,
  viewId: activeViewId
});
```

## 使用情境

這次新增的 `analyze_corridor_width` 比較適合：

- 先確認走廊是否合規
- 先取得最小寬度與各區段結果
- 在不改動模型標註的情況下先做分析

而 `create_corridor_dimension` 比較適合：

- 已經確認要在 Revit 視圖內建立尺寸標註
- 需要把分析結果視覺化到圖面上

## 總結

這個 PR 的核心價值是把走廊寬度檢討拆成兩步：

1. `analyze_corridor_width`：純分析
2. `create_corridor_dimension`：建立標註

這樣可以讓走廊檢討流程更清楚，也讓分析與標註兩種用途分離，方便後續維護與擴充。