### PR TITLE
feat(view): 實作剖面視圖重新命名與幾何座標獲取，並註冊 MCP 工具

### DIFF
--- a/MCP-Server/src/tools/base-tools.ts
+++ b/MCP-Server/src/tools/base-tools.ts
@@ -54,7 +54,7 @@ export const baseTools: Tool[] = [
     },
     {
         name: "get_selected_elements",
-        description: "取得使用者目前在 Revit 中選取的所有元素的基本資訊（ID、名稱、品類）。",
+        description: "取得使用者目前在 Revit 中選取的所有元素的基本資訊（ID、名稱、品類）。若是視圖或剖面標記，會一併回傳 Origin (X,Y,Z) 供空間排序使用。",
         inputSchema: { type: "object", properties: {} },
     },
 
@@ -84,6 +84,18 @@ export const baseTools: Tool[] = [
                 viewId: { type: "number", description: "要切換的視圖 Element ID" },
             },
             required: ["viewId"],
+        },
+    },
+    {
+        name: "rename_view",
+        description: "重新命名指定的 Revit 視圖（包含剖面圖、平面圖等），此工具不受軟體語系本地化影響。",
+        inputSchema: {
+            type: "object",
+            properties: {
+                viewId: { type: "number", description: "視圖的 Element ID" },
+                newName: { type: "string", description: "新的視圖名稱" },
+            },
+            required: ["viewId", "newName"],
         },
     },
     {

--- a/MCP/Core/CommandExecutor.cs
+++ b/MCP/Core/CommandExecutor.cs
@@ -158,6 +158,10 @@ namespace RevitMCP.Core
                         result = GetActiveView();
                         break;
                     
+                    case "rename_view":
+                        result = RenameView(parameters);
+                        break;
+                    
                     case "set_active_view":
                         result = SetActiveView(parameters);
                         break;
@@ -3774,12 +3778,40 @@ namespace RevitMCP.Core
             var elements = selection.Select(id =>
             {
                 Element e = doc.GetElement(id);
-                return new
+                var elemData = new JObject
                 {
-                    Id = e.Id.GetIdValue(),
-                    Name = e.Name,
-                    Category = e.Category?.Name ?? "Unknown"
+                    ["Id"] = e.Id.GetIdValue(),
+                    ["Name"] = e.Name,
+                    ["Category"] = e.Category?.Name ?? "Unknown"
                 };
+
+                // 如果是視圖或是剖面標記，嘗試取得它的 Origin
+                if (e is View v && v.Origin != null)
+                {
+                    elemData["Origin"] = new JObject
+                    {
+                        ["X"] = Math.Round(v.Origin.X * 304.8, 2),
+                        ["Y"] = Math.Round(v.Origin.Y * 304.8, 2),
+                        ["Z"] = Math.Round(v.Origin.Z * 304.8, 2)
+                    };
+                }
+                else if (e.Category?.Name == "Views" || e.Category?.Name == "視圖" || e.Category?.Name == "Sections" || e.Category?.Name == "剖面")
+                {
+                    // 若選取到標記元素，其 Element.Name 等同於視圖名稱。若該 Element 有 BoundingBox 也可取中心點作為 Origin
+                    BoundingBoxXYZ bbox = e.get_BoundingBox(doc.ActiveView);
+                    if (bbox != null)
+                    {
+                        XYZ center = (bbox.Min + bbox.Max) / 2.0;
+                        elemData["Origin"] = new JObject
+                        {
+                            ["X"] = Math.Round(center.X * 304.8, 2),
+                            ["Y"] = Math.Round(center.Y * 304.8, 2),
+                            ["Z"] = Math.Round(center.Z * 304.8, 2)
+                        };
+                    }
+                }
+
+                return elemData;
             }).ToList();
 
             return new

--- a/MCP/Core/Commands/CommandExecutor.ViewOps.cs
+++ b/MCP/Core/Commands/CommandExecutor.ViewOps.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Linq;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using Newtonsoft.Json.Linq;
+
+#if REVIT2025_OR_GREATER
+using IdType = System.Int64;
+#else
+using IdType = System.Int32;
+#endif
+
+namespace RevitMCP.Core
+{
+    public partial class CommandExecutor
+    {
+        /// <summary>
+        /// 重新命名視圖（包含剖面圖、平面圖等）
+        /// </summary>
+        private object RenameView(JObject parameters)
+        {
+            Document doc = _uiApp.ActiveUIDocument.Document;
+            IdType viewId = parameters["viewId"]?.Value<IdType>() ?? 0;
+            string newName = parameters["newName"]?.Value<string>();
+
+            if (string.IsNullOrEmpty(newName))
+                throw new Exception("請指定新的視圖名稱");
+
+            Element elem = doc.GetElement(new ElementId(viewId));
+            if (elem == null)
+                throw new Exception($"找不到元素 ID: {viewId}");
+
+            View view = elem as View;
+            if (view == null)
+            {
+                // 如果選取的元素是剖面標記等非 View 物件，利用其與視圖同名的特性，在模型中尋找同名的 View 物件
+                string viewName = elem.Name;
+                view = new FilteredElementCollector(doc)
+                    .OfClass(typeof(View))
+                    .Cast<View>()
+                    .FirstOrDefault(v => v.Name == viewName);
+            }
+
+            if (view == null)
+                throw new Exception($"找不到視圖 ID: {viewId}，且無法對應到同名的視圖物件");
+
+            using (Transaction trans = new Transaction(doc, "重新命名視圖"))
+            {
+                trans.Start();
+                view.Name = newName;
+                trans.Commit();
+            }
+
+            return new
+            {
+                ViewId = viewId,
+                NewName = newName,
+                Message = $"成功將視圖重新命名為: {newName}"
+            };
+        }
+    }
+}

--- a/domain/section-auto-numbering.md
+++ b/domain/section-auto-numbering.md
@@ -1,0 +1,78 @@
+---
+name: section-auto-numbering
+description: "剖面自動編排與命名 SOP：根據剖面標記在視圖中的空間幾何位置，單一方向（如由左至右）進行排序，並可自訂前綴自動重新命名。當使用者提到剖面重新命名、剖面編號、section numbering、自動編排剖面時觸發。"
+metadata:
+  version: "1.0"
+  updated: "2026-05-20"
+  created: "2026-05-20"
+  contributors:
+    - "AI Assistant"
+  references: [] 
+  related: ["parking-auto-numbering.md"]
+  referenced_by: []
+  tags: [Revit, Automation, Section, MCP, 剖面自動命名, section numbering]
+---
+
+# 剖面自動編排與命名標準作業程序 (Section Auto-Numbering SOP)
+
+## 1. 目的
+自動化地對 Revit 中選取的剖面視圖（或平面圖上的剖面標記），根據其在平面上的幾何座標位置進行順序編排，並統一套用自訂前綴進行重新命名。
+
+## 2. 適用對象
+- Revit 中的剖面視圖 (`ViewSection`) 或平面上的剖面標記元件 (`SectionMarker`)。
+- 工程師希望將平面上散亂的剖面符號（如：剖面 1、剖面 5、剖面 2）整理為有條理的名稱（如：`剖面-牆面開口-4F-剖面-1`、`剖面-牆面開口-4F-剖面-2` ...）。
+
+## 3. 前置準備
+- Revit 專案已開啟，且使用者**已在視圖中手動選取**需要重新命名的剖面標記。
+
+## 4. 作業流程 (AI 執行步驟)
+
+### Step 1: 取得選取元素與幾何座標
+- 呼叫 `get_selected_elements` 取得目前選取的元素。
+- 過濾出 `Category` 為 "Views"、"視圖"、"Sections"、"剖面" 的元素，並取得其回傳的 `Origin` (X, Y, Z) 幾何座標。
+
+### Step 2: 前綴名稱自動推論與格式化
+- 檢視選取元素的現有名稱，自動分析並推導最長共同前綴。
+- 格式化前綴，移除數字尾綴，並在末端適當補上連字號 `-` 以確保產出如 `剖面-牆面開口-4F-剖面-1` 的格式。
+- 若無法自動推論，則預設為 `剖面-`，或於文字對話中向使用者確認。
+
+### Step 3: 排帶式幾何空間排序演算法 (Row-major Grouping)
+為了讓排序最契合人類的「看圖與閱讀習慣（從上至下，從左至右）」，採用**「橫排分組，排內左至右排序」**的演算法：
+1. **高度分帶**：依據 Y 座標將剖面劃分為橫向分組帶（例如區分為 4 排高度區間：Row 1 至 Row 4）。
+   - **防橋接 (Chaining) 容錯**：不採用單純的「相鄰差值聚類」，以防大量密集剖面產生橋接滾雪球效應，導致不同排的剖面被融合成同一組。改用**固定高度帶劃分法**（例如以 `28500 mm`, `18500 mm`, `8500 mm` 為界線分出 4 個高度帶）。
+2. **排內由左至右**：在每一個高度帶（Row）內部，將裡面的剖面依據 **X 座標由小到大（由左至右）** 進行精準排序。
+3. **最終合併**：將 Row 1 (最上方) 到 Row 4 (最下方) 排序後的陣列依次合併，生成最終的命名編號順序。
+
+### Step 4: 雙階段 (Two-Pass) 重新命名交易
+為了徹底解決 Revit 視圖「名稱在專案中必須唯一 (Name must be unique)」的底層限制，重新命名必須拆分為兩個階段執行：
+*   **第一階段 (臨時重命名)**：
+    *   依次將所有選取的剖面暫時重新命名為加上時間戳與索引的**絕對唯一臨時名稱**（例如：`{原名稱}_temp_{timestamp}_{index}`）。
+    *   這能完全釋放原本被佔用的目標名稱空間，防止直接命名時與同組其他剖面發生名稱重複錯誤。
+*   **第二階段 (正式重命名)**：
+    *   將已暫時重命名的視圖，依次修改為正式的連續編號名稱（如：`剖面-牆面開口-4F-剖面-1`）。
+    *   此時由於目標名稱已被全部釋放，將 100% 不會發生衝突。
+
+---
+
+## 5. 常見問題與處理
+
+### 1. 選取到的不是 `View` 而是 `SectionMarker` (剖面標記)
+- **現象**：使用者在平面圖框選的是剖面符號，在 C# 中其底層型別是 `Element` 而非 `View` 物件，直接類型轉換會回傳 `null`，導致無法使用 `view.Name = newName` 修改名稱。
+- **處理方法**：在 C# [CommandExecutor.ViewOps.cs](file:///c:/Users/sn698/Desktop/REVIT_MCP_study/MCP/Core/Commands/CommandExecutor.ViewOps.cs) 的 `RenameView` 函數中加入類型檢索容錯：
+  ```csharp
+  View view = elem as View;
+  if (view == null)
+  {
+      // 若選取到剖面標記元件，利用其與對應視圖「名稱同名」的特性，在所有 View 中尋找同名視圖
+      string viewName = elem.Name;
+      view = new FilteredElementCollector(doc)
+          .OfClass(typeof(View))
+          .Cast<View>()
+          .FirstOrDefault(v => v.Name == viewName);
+  }
+  ```
+  如此即可完美對應，順利修改該剖面標記背後的視圖名稱。
+
+### 2. 名稱重複衝突 (Name must be unique)
+- 必須遵循上述 **Step 4** 的 Two-Pass 兩階段命名法，嚴禁在單一階段直接覆寫可能已被同組其他成員佔用的名稱。
+- 臨時命名階段使用的隨機尾綴必須包含時間戳與唯一 index，以保證絕對不重複。


### PR DESCRIPTION
## 🎯 功能概述 (Overview)
本 PR 實作了**「剖面視圖重新命名與空間座標獲取」**功能 (`rename_view`)。
由於 Revit 底層對於視圖名稱有「專案內必須唯一 (Unique)」的嚴格限制，本功能與專案 SOP 搭配，採用**兩階段雙防衝突命名 (Two-Pass Renaming)** 與**排帶式橫向幾何分群 (Row-major Grouping) 空間排序演算法**，讓 AI 能依照人類看圖習慣（由上至下、由左至右）進行無衝突的自動重新編號與命名。

---

## 🛠️ 主要異動 (Key Changes)

### 1. Revit 插件核心與介面優化 (C#)
*   **`MCP/Core/Commands/CommandExecutor.ViewOps.cs`**：
    *   實作 `RenameView` 核心邏輯。針對選取物件為剖面標記 (SectionMarker) 而非 View 時，自動藉由同名特性於模型中檢索對應的 View 物件，提供高容錯命名交易。
*   **`MCP/Core/CommandExecutor.cs`**：
    *   對接 `rename_view` 指令入口。
    *   優化 `get_selected_elements` 命令：若選取對象為視圖或剖面時，會自動計算其 `Origin` 空間座標 (X, Y, Z)，以毫米 (mm) 為單位回傳給 AI 進行高度帶排序。

### 2. MCP Server 工具註冊 (TypeScript)
*   **`MCP-Server/src/tools/base-tools.ts`**：
    *   註冊 `rename_view` 的 MCP Tool schema。
    *   更新 `get_selected_elements` 描述，提醒 AI 會一併回傳空間座標 Origin，供幾何排序演算法使用。

### 3. 領域知識文件 (Documentation)
*   **`domain/section-auto-numbering.md`**：
    *   新增自動命名的 SOP 規格文件，詳細記錄了「高度帶分群」、「防橋接容錯分界」與「Two-Pass 命名邏輯」的設計。

---

## 🧪 測試與驗證 (Testing)
*   **座標獲取測試**：驗證在 Revit 中選取多個剖面後，透過 `get_selected_elements` 能精準取得各自的 Origin 座標。
*   **命名與排序測試**：AI 能基於 Origin 進行 Row-major Grouping 排序，並透過 `rename_view` 工具以 Two-Pass（臨時重新命名 ➔ 正式命名）順利完成大批次剖面連續更名，期間無任何名稱重複報錯。
*   **乾淨度驗證**：已剔除 `CLAUDE.md` 及無關檔案，確保 PR 僅限於剖面重新命名的核心改動。
