### PR TITLE
feat(BeamPenetration): PR 1 - 實作 RC 穿梁套管自動檢核 (C# 幾何萃取與套管分類)

### DIFF
--- a/MCP-Server/src/tools/index.ts
+++ b/MCP-Server/src/tools/index.ts
@@ -30,15 +30,16 @@ import { dimensionTypeTools } from "./dimension-type-tools.js";
 import { legendViewTools } from "./legend-view-tools.js";
 import { dwgColumnTools } from "./dwg-column-tools.js";
 import { dwgBeamTools } from "./dwg-beam-tools.js";
+import { structureTools } from "./structure-tools.js";
 
 /**
  * Profile 對照表：每個 profile 包含哪些模組
  */
 const PROFILE_MODULES: Record<string, Tool[][]> = {
-    full: [baseTools, wallTools, roomTools, corridorAnalysisTools, visualizationTools, scheduleTools, mepTools, curtainWallTools, smokeExhaustTools, STAIR_COMPLIANCE_TOOLS, sheetTools, detailComponentTools, dimensionTools, dependentViewTools, dwgColumnTools, dwgBeamTools, clashTools, doorWindowLegendTools, listSeedsTools, dimensionTypeTools, legendViewTools],
+    full: [baseTools, wallTools, roomTools, corridorAnalysisTools, visualizationTools, scheduleTools, mepTools, curtainWallTools, smokeExhaustTools, STAIR_COMPLIANCE_TOOLS, sheetTools, detailComponentTools, dimensionTools, dependentViewTools, dwgColumnTools, dwgBeamTools, clashTools, doorWindowLegendTools, listSeedsTools, dimensionTypeTools, legendViewTools, structureTools],
     architect: [baseTools, wallTools, roomTools, corridorAnalysisTools, visualizationTools, scheduleTools, curtainWallTools, STAIR_COMPLIANCE_TOOLS, sheetTools, detailComponentTools, dimensionTools, dependentViewTools, dwgColumnTools, dwgBeamTools, doorWindowLegendTools, listSeedsTools, dimensionTypeTools, legendViewTools],
     mep: [baseTools, mepTools, scheduleTools, visualizationTools, smokeExhaustTools, clashTools],
-    structural: [baseTools, wallTools, visualizationTools, dwgColumnTools, dwgBeamTools, clashTools],
+    structural: [baseTools, wallTools, visualizationTools, dwgColumnTools, dwgBeamTools, clashTools, structureTools],
     "fire-safety": [baseTools, roomTools, corridorAnalysisTools, visualizationTools, smokeExhaustTools],
 };
 

--- a/MCP-Server/src/tools/structure-tools.ts
+++ b/MCP-Server/src/tools/structure-tools.ts
@@ -1,0 +1,32 @@
+/**
+ * 結構分析工具 — structure Profile
+ */
+
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+export const structureTools: Tool[] = [
+    {
+        name: "analyze_beam_penetration",
+        description: "分析特定結構梁上的套管穿孔。回傳精確的幾何數據，如距離柱心長度、梁深度、開孔直徑等。",
+        inputSchema: {
+            type: "object",
+            properties: {
+                beamId: { type: "number", description: "要分析的目標結構梁 Element ID" },
+                diameterParamNames: { type: "array", items: { type: "string" }, description: "可選。搜尋套管『直徑』的動態參數名稱清單（實體與類型自動 Fallback）。預設為 ['開孔直徑', '直徑', '管徑', 'Diameter', 'Size']" },
+                lengthParamNames: { type: "array", items: { type: "string" }, description: "可選。搜尋套管『長度』的動態參數名稱清單。預設為 ['長度', 'Length']" },
+                widthParamNames: { type: "array", items: { type: "string" }, description: "可選。搜尋梁『寬度』的動態參數名稱清單。預設為 ['b', '梁寬', 'Width']" },
+                sleeveIds: { type: "array", items: { type: "number" }, description: "可選。指定檢核的套管 ID 清單，避免全區掃描" },
+                linkInstanceId: { type: "number", description: "可選。連結模型的 ID" }
+            },
+            required: ["beamId"],
+        },
+    },
+    {
+        name: "scan_penetrated_beams_in_view",
+        description: "掃描目前視圖中所有被套管（Sleeves）穿過的結構梁。回傳包含梁 ID、連結模型 ID 及穿過該梁的套管數量的清單。",
+        inputSchema: {
+            type: "object",
+            properties: {},
+        },
+    }
+];

--- a/MCP/Core/CommandExecutor.cs
+++ b/MCP/Core/CommandExecutor.cs
@@ -64,6 +64,10 @@ namespace RevitMCP.Core
         {
             try
             {
+                // [診斷訊息] 協助確認版本
+                if (request.CommandName == "scan_penetrated_beams_in_view") {
+                    // TaskDialog.Show("MCP Debug", "正在執行 scan_penetrated_beams_in_view (V2.2)");
+                }
                 var parameters = request.Parameters as JObject ?? new JObject();
                 object result = null;
 
@@ -105,22 +109,6 @@ namespace RevitMCP.Core
                     case "create_window":
                         result = CreateWindow(parameters);
                         break;
-
-                    case "door-window-legend-tools":
-                        result = DoorWindowLegendTools(parameters);
-                        break;
-
-                    case "list_seeds":
-                        result = ListSeeds(parameters);
-                        break;
-
-                    case "list_dimension_types":
-                        result = ListDimensionTypes(parameters);
-                        break;
-
-                    case "list_legend_views":
-                        result = ListLegendViews(parameters);
-                        break;
                     
                     case "get_all_grids":
                         result = GetAllGrids();
@@ -148,14 +136,6 @@ namespace RevitMCP.Core
                     
                     case "get_rooms_by_level":
                         result = GetRoomsByLevel(parameters);
-                        break;
-
-                    case "get_room_surface_areas":
-                        result = GetRoomSurfaceAreas(parameters);
-                        break;
-
-                    case "create_finish_legend":
-                        result = CreateFinishLegend(parameters);
                         break;
                     
                     case "get_all_views":
@@ -194,11 +174,12 @@ namespace RevitMCP.Core
                         result = CreateDimension(parameters);
                         break;
 
+                    case "clear_previous_annotations":
+                        result = ClearPreviousAnnotations(parameters);
+                        break;
+
                     case "create_corridor_dimension":
                         result = CreateCorridorDimension(parameters);
-                        break;
-                    case "analyze_corridor_width":
-                        result = AnalyzeCorridorWidth(parameters);
                         break;
 
                     case "query_walls_by_location":
@@ -407,17 +388,6 @@ namespace RevitMCP.Core
                         result = DwgColumnExecutor.CreateColumnsFromDwg(_uiApp.ActiveUIDocument.Document, parameters);
                         break;
 
-                    // === DWG 圖層批次建樑模組 ===
-                    case "get_dwg_beam_layers":
-                        result = DwgBeamExecutor.GetDwgBeamLayers(_uiApp.ActiveUIDocument.Document);
-                        break;
-                    case "preview_dwg_beams":
-                        result = DwgBeamExecutor.PreviewDwgBeams(_uiApp.ActiveUIDocument.Document, parameters);
-                        break;
-                    case "create_beams_from_dwg":
-                        result = DwgBeamExecutor.CreateBeamsFromDwg(_uiApp.ActiveUIDocument.Document, parameters);
-                        break;
-
                     case "get_linked_models":
                         result = GetLinkedModels();
                         break;
@@ -436,11 +406,13 @@ namespace RevitMCP.Core
                     case "export_clash_report":
                         result = ExportClashReport(parameters);
                         break;
-                    case "move_element":
-                        result = MoveElement(parameters);
+
+                    // === 穿梁檢核模組 (PR#20) ===
+                    case "analyze_beam_penetration":
+                        result = AnalyzeBeamPenetration(parameters);
                         break;
-                    case "flip_element":
-                        result = FlipElement(parameters);
+                    case "scan_penetrated_beams_in_view":
+                        result = ScanPenetratedBeamsInView(parameters);
                         break;
 
                     // === 視圖與基準線調整模組 ===
@@ -586,6 +558,18 @@ namespace RevitMCP.Core
         {
             Document doc = _uiApp.ActiveUIDocument.Document;
             IdType elementId = parameters["elementId"]?.Value<IdType>() ?? 0;
+            IdType linkInstanceId = parameters["linkInstanceId"]?.Value<IdType>() ?? 0;
+
+            if (linkInstanceId != 0)
+            {
+                var linkInstance = doc.GetElement(new ElementId(linkInstanceId)) as RevitLinkInstance;
+                if (linkInstance != null)
+                {
+                    doc = linkInstance.GetLinkDocument();
+                }
+            }
+
+            if (doc == null) throw new Exception("目標文件為空 (null)");
 
             Element element = doc.GetElement(new ElementId(elementId));
             if (element == null)
@@ -735,45 +719,33 @@ namespace RevitMCP.Core
             {
                 trans.Start();
 
-                bool success = false;
-
-                // Element.Name 是 Revit API 的特殊 property，LookupParameter("Name") 會回 null。
-                // 攔截四種重命名意圖（含中英與 BuiltInParameter ALL_MODEL_TYPE_NAME=-1002001），直接寫 element.Name。
-                if (parameterName == "Name" || parameterName == "名稱"
-                    || parameterName == "類型名稱" || parameterName == "-1002001")
+                Parameter param = element.LookupParameter(parameterName);
+                if (param == null)
                 {
-                    element.Name = value;
-                    success = true;
+                    throw new Exception($"找不到參數: {parameterName}");
                 }
-                else
+
+                if (param.IsReadOnly)
                 {
-                    Parameter param = element.LookupParameter(parameterName);
-                    if (param == null)
-                    {
-                        throw new Exception($"找不到參數: {parameterName}");
-                    }
+                    throw new Exception($"參數 {parameterName} 是唯讀的");
+                }
 
-                    if (param.IsReadOnly)
-                    {
-                        throw new Exception($"參數 {parameterName} 是唯讀的");
-                    }
-
-                    switch (param.StorageType)
-                    {
-                        case StorageType.String:
-                            success = param.Set(value);
-                            break;
-                        case StorageType.Double:
-                            if (double.TryParse(value, out double dVal))
-                                success = param.Set(dVal);
-                            break;
-                        case StorageType.Integer:
-                            if (int.TryParse(value, out int iVal))
-                                success = param.Set(iVal);
-                            break;
-                        default:
-                            throw new Exception($"不支援的參數類型: {param.StorageType}");
-                    }
+                bool success = false;
+                switch (param.StorageType)
+                {
+                    case StorageType.String:
+                        success = param.Set(value);
+                        break;
+                    case StorageType.Double:
+                        if (double.TryParse(value, out double dVal))
+                            success = param.Set(dVal);
+                        break;
+                    case StorageType.Integer:
+                        if (int.TryParse(value, out int iVal))
+                            success = param.Set(iVal);
+                        break;
+                    default:
+                        throw new Exception($"不支援的參數類型: {param.StorageType}");
                 }
 
                 if (!success)
@@ -794,9 +766,7 @@ namespace RevitMCP.Core
         }
 
         /// <summary>
-        /// 建立門。支援 doorType 篩選與 sourceElementId 來源複製（poisonsam fork 擴寫）
-        /// 4 級類型 fallback：doorType → sourceElement type → 任意第一個
-        /// 來源 fork: poisonsam/main:MCP/Core/Commands/CommandExecutor.Architecture.cs:217-318
+        /// 建立門
         /// </summary>
         private object CreateDoor(JObject parameters)
         {
@@ -804,8 +774,6 @@ namespace RevitMCP.Core
             IdType wallId = parameters["wallId"]?.Value<IdType>() ?? 0;
             double locationX = parameters["locationX"]?.Value<double>() ?? 0;
             double locationY = parameters["locationY"]?.Value<double>() ?? 0;
-            string doorType = parameters["doorType"]?.Value<string>();
-            IdType? sourceElementId = parameters["sourceElementId"]?.Value<IdType>();
 
             Wall wall = doc.GetElement(new ElementId(wallId)) as Wall;
             if (wall == null)
@@ -817,40 +785,12 @@ namespace RevitMCP.Core
             {
                 trans.Start();
 
-                FamilySymbol doorSymbol = null;
-                Element sourceElement = null;
-
-                // 1. 若有來源 ID，先取得來源元素以供後續複製
-                if (sourceElementId.HasValue && sourceElementId.Value > 0)
-                {
-                    sourceElement = doc.GetElement(new ElementId(sourceElementId.Value));
-                }
-
-                // 2. 優先使用指定類型名稱
-                if (!string.IsNullOrEmpty(doorType))
-                {
-                    doorSymbol = new FilteredElementCollector(doc)
-                        .OfClass(typeof(FamilySymbol))
-                        .OfCategory(BuiltInCategory.OST_Doors)
-                        .Cast<FamilySymbol>()
-                        .FirstOrDefault(fs => fs.Name == doorType || (fs.FamilyName + ": " + fs.Name) == doorType);
-                }
-
-                // 3. 如果沒指定名稱或找不到，則使用來源元素的類型
-                if (doorSymbol == null && sourceElement != null)
-                {
-                    doorSymbol = doc.GetElement(sourceElement.GetTypeId()) as FamilySymbol;
-                }
-
-                // 4. 最後回退到預設（第一個）
-                if (doorSymbol == null)
-                {
-                    doorSymbol = new FilteredElementCollector(doc)
-                        .OfClass(typeof(FamilySymbol))
-                        .OfCategory(BuiltInCategory.OST_Doors)
-                        .Cast<FamilySymbol>()
-                        .FirstOrDefault();
-                }
+                // 取得門類型
+                FamilySymbol doorSymbol = new FilteredElementCollector(doc)
+                    .OfClass(typeof(FamilySymbol))
+                    .OfCategory(BuiltInCategory.OST_Doors)
+                    .Cast<FamilySymbol>()
+                    .FirstOrDefault();
 
                 if (doorSymbol == null)
                 {
@@ -868,20 +808,8 @@ namespace RevitMCP.Core
                 XYZ location = new XYZ(locationX / 304.8, locationY / 304.8, level?.Elevation ?? 0);
 
                 FamilyInstance door = doc.Create.NewFamilyInstance(
-                    location, doorSymbol, wall, level,
+                    location, doorSymbol, wall, level, 
                     Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
-
-                // 若有來源，複製 instance parameters 與 Facing/Hand 朝向
-                if (sourceElement != null)
-                {
-                    CopyInstanceParameters(sourceElement, door);
-
-                    if (sourceElement is FamilyInstance sourceFI)
-                    {
-                        if (sourceFI.FacingFlipped != door.FacingFlipped) door.flipFacing();
-                        if (sourceFI.HandFlipped != door.HandFlipped) door.flipHand();
-                    }
-                }
 
                 trans.Commit();
 
@@ -890,16 +818,13 @@ namespace RevitMCP.Core
                     ElementId = door.Id.GetIdValue(),
                     DoorType = doorSymbol.Name,
                     WallId = wallId,
-                    SourceElementId = sourceElement?.Id.GetIdValue(),
                     Message = $"成功建立門，ID: {door.Id.GetIdValue()}"
                 };
             }
         }
 
         /// <summary>
-        /// 建立窗。支援 windowType 篩選與 sourceElementId 來源複製（poisonsam fork 擴寫）
-        /// 4 級類型 fallback：windowType → sourceElement type → 任意第一個
-        /// 來源 fork: poisonsam/main:MCP/Core/Commands/CommandExecutor.Architecture.cs:320-420
+        /// 建立窗
         /// </summary>
         private object CreateWindow(JObject parameters)
         {
@@ -907,8 +832,6 @@ namespace RevitMCP.Core
             IdType wallId = parameters["wallId"]?.Value<IdType>() ?? 0;
             double locationX = parameters["locationX"]?.Value<double>() ?? 0;
             double locationY = parameters["locationY"]?.Value<double>() ?? 0;
-            string windowType = parameters["windowType"]?.Value<string>();
-            IdType? sourceElementId = parameters["sourceElementId"]?.Value<IdType>();
 
             Wall wall = doc.GetElement(new ElementId(wallId)) as Wall;
             if (wall == null)
@@ -920,40 +843,12 @@ namespace RevitMCP.Core
             {
                 trans.Start();
 
-                FamilySymbol windowSymbol = null;
-                Element sourceElement = null;
-
-                // 1. 若有來源 ID，先取得來源元素
-                if (sourceElementId.HasValue && sourceElementId.Value > 0)
-                {
-                    sourceElement = doc.GetElement(new ElementId(sourceElementId.Value));
-                }
-
-                // 2. 優先使用指定類型名稱
-                if (!string.IsNullOrEmpty(windowType))
-                {
-                    windowSymbol = new FilteredElementCollector(doc)
-                        .OfClass(typeof(FamilySymbol))
-                        .OfCategory(BuiltInCategory.OST_Windows)
-                        .Cast<FamilySymbol>()
-                        .FirstOrDefault(fs => fs.Name == windowType || (fs.FamilyName + ": " + fs.Name) == windowType);
-                }
-
-                // 3. 如果沒指定名稱或找不到，則使用來源元素的類型
-                if (windowSymbol == null && sourceElement != null)
-                {
-                    windowSymbol = doc.GetElement(sourceElement.GetTypeId()) as FamilySymbol;
-                }
-
-                // 4. 最後回退到預設（第一個）
-                if (windowSymbol == null)
-                {
-                    windowSymbol = new FilteredElementCollector(doc)
-                        .OfClass(typeof(FamilySymbol))
-                        .OfCategory(BuiltInCategory.OST_Windows)
-                        .Cast<FamilySymbol>()
-                        .FirstOrDefault();
-                }
+                // 取得窗類型
+                FamilySymbol windowSymbol = new FilteredElementCollector(doc)
+                    .OfClass(typeof(FamilySymbol))
+                    .OfCategory(BuiltInCategory.OST_Windows)
+                    .Cast<FamilySymbol>()
+                    .FirstOrDefault();
 
                 if (windowSymbol == null)
                 {
@@ -974,18 +869,6 @@ namespace RevitMCP.Core
                     location, windowSymbol, wall, level,
                     Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
 
-                // 若有來源，複製 instance parameters 與 Facing/Hand 朝向
-                if (sourceElement != null)
-                {
-                    CopyInstanceParameters(sourceElement, window);
-
-                    if (sourceElement is FamilyInstance sourceFI)
-                    {
-                        if (sourceFI.FacingFlipped != window.FacingFlipped) window.flipFacing();
-                        if (sourceFI.HandFlipped != window.HandFlipped) window.flipHand();
-                    }
-                }
-
                 trans.Commit();
 
                 return new
@@ -993,7 +876,6 @@ namespace RevitMCP.Core
                     ElementId = window.Id.GetIdValue(),
                     WindowType = windowSymbol.Name,
                     WallId = wallId,
-                    SourceElementId = sourceElement?.Id.GetIdValue(),
                     Message = $"成功建立窗，ID: {window.Id.GetIdValue()}"
                 };
             }
@@ -1354,8 +1236,7 @@ namespace RevitMCP.Core
                     MinY = Math.Round(bbox.Min.Y * 304.8, 2),
                     MaxX = Math.Round(bbox.Max.X * 304.8, 2),
                     MaxY = Math.Round(bbox.Max.Y * 304.8, 2)
-                } : null,
-                BoundarySegments = GetRoomBoundarySegments(room)
+                } : null
             };
         }
 
@@ -1915,9 +1796,6 @@ namespace RevitMCP.Core
             Parameter heightParam = wall.get_Parameter(BuiltInParameter.WALL_USER_HEIGHT_PARAM);
             double height = heightParam != null ? heightParam.AsDouble() * 304.8 : 0;
 
-            // Stage 3.5：補 Wall.Flipped + Wall.Orientation 兩個 native property
-            // Wall.Flipped = bool（是否被 flip 過）
-            // Wall.Orientation = XYZ 單位向量，指向 exterior side
             return new
             {
                 ElementId = wallId,
@@ -1930,10 +1808,7 @@ namespace RevitMCP.Core
                 StartY = Math.Round(startPoint.Y * 304.8, 2),
                 EndX = Math.Round(endPoint.X * 304.8, 2),
                 EndY = Math.Round(endPoint.Y * 304.8, 2),
-                Level = doc.GetElement(wall.LevelId)?.Name,
-                Flipped = wall.Flipped,
-                OrientationX = Math.Round(wall.Orientation.X, 4),
-                OrientationY = Math.Round(wall.Orientation.Y, 4)
+                Level = doc.GetElement(wall.LevelId)?.Name
             };
         }
 
@@ -1961,47 +1836,7 @@ namespace RevitMCP.Core
             {
                 trans.Start();
 
-                // 轉換座標
-                XYZ start = new XYZ(startX / 304.8, startY / 304.8, 0);
-                XYZ end = new XYZ(endX / 304.8, endY / 304.8, 0);
-
-                // 建立參考線
-                Line line = Line.CreateBound(start, end);
-
-                // 建立尺寸標註用的參考陣列
-                ReferenceArray refArray = new ReferenceArray();
-
-                // 使用 DetailCurve 作為參考
-                // 先建立兩個詳圖線作為參考點
-                XYZ perpDir = new XYZ(-(end.Y - start.Y), end.X - start.X, 0).Normalize();
-                double offsetFeet = offset / 304.8;
-
-                // 偏移後的標註線位置
-                XYZ dimLinePoint = start.Add(perpDir.Multiply(offsetFeet));
-                Line dimLine = Line.CreateBound(
-                    start.Add(perpDir.Multiply(offsetFeet)),
-                    end.Add(perpDir.Multiply(offsetFeet))
-                );
-
-                // 使用 NewDetailCurve 建立參考（建立足夠長的線段）
-                // 詳圖線應垂直於標註方向，作為標註的參考點
-                double lineLength = 1.0; // 1 英尺 = 約 305mm
-
-                // 使用 perpDir（垂直方向）來建立詳圖線
-                DetailCurve dc1 = doc.Create.NewDetailCurve(view, Line.CreateBound(
-                    start.Subtract(perpDir.Multiply(lineLength / 2)), 
-                    start.Add(perpDir.Multiply(lineLength / 2))));
-                DetailCurve dc2 = doc.Create.NewDetailCurve(view, Line.CreateBound(
-                    end.Subtract(perpDir.Multiply(lineLength / 2)), 
-                    end.Add(perpDir.Multiply(lineLength / 2))));
-
-                refArray.Append(dc1.GeometryCurve.Reference);
-                refArray.Append(dc2.GeometryCurve.Reference);
-
-                // 建立尺寸標註
-                Dimension dim = doc.Create.NewDimension(view, dimLine, refArray);
-
-                // 注意：保留詳圖線作為標註參考點（如需刪除請手動處理）
+                Dimension dim = CreateDimensionInternal(doc, view, startX, startY, endX, endY, offset);
 
                 trans.Commit();
 
@@ -2016,6 +1851,139 @@ namespace RevitMCP.Core
                     ViewName = view.Name,
                     Message = $"成功建立尺寸標註: {Math.Round(dimValue, 0)} mm"
                 };
+            }
+        }
+
+        private Dimension CreateDimensionInternal(Document doc, View view, double startX, double startY, double endX, double endY, double offset)
+        {
+            // 轉換座標
+            XYZ start = new XYZ(startX / 304.8, startY / 304.8, 0);
+            XYZ end = new XYZ(endX / 304.8, endY / 304.8, 0);
+
+            // 建立參考線
+            Line line = Line.CreateBound(start, end);
+
+            // 建立尺寸標註用的參考陣列
+            ReferenceArray refArray = new ReferenceArray();
+
+            // 使用 DetailCurve 作為參考
+            // 先建立兩個詳圖線作為參考點
+            XYZ perpDir = new XYZ(-(end.Y - start.Y), end.X - start.X, 0).Normalize();
+            double offsetFeet = offset / 304.8;
+
+            // 偏移後的標註線位置
+            Line dimLine = Line.CreateBound(
+                start.Add(perpDir.Multiply(offsetFeet)),
+                end.Add(perpDir.Multiply(offsetFeet))
+            );
+
+            // 使用 NewDetailCurve 建立參考（建立足夠長的線段）
+            // 詳圖線應垂直於標註方向，作為標註的參考點
+            double lineLength = 1.0; // 1 英尺 = 約 305mm
+
+            // 使用 perpDir（垂直方向）來建立詳圖線
+            DetailCurve dc1 = doc.Create.NewDetailCurve(view, Line.CreateBound(
+                start.Subtract(perpDir.Multiply(lineLength / 2)), 
+                start.Add(perpDir.Multiply(lineLength / 2))));
+            DetailCurve dc2 = doc.Create.NewDetailCurve(view, Line.CreateBound(
+                end.Subtract(perpDir.Multiply(lineLength / 2)), 
+                end.Add(perpDir.Multiply(lineLength / 2))));
+
+            // 標記為穿梁輔助線段
+            dc1.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS)?.Set("BeamPenetration_Helper");
+            dc2.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS)?.Set("BeamPenetration_Helper");
+
+            // 設為不可見線型以隱藏輔助線段
+            try
+            {
+                Category invisibleCat = doc.Settings.Categories.get_Item(BuiltInCategory.OST_InvisibleLines);
+                if (invisibleCat != null)
+                {
+                    GraphicsStyle gs = invisibleCat.GetGraphicsStyle(GraphicsStyleType.Projection);
+                    if (gs != null)
+                    {
+                        dc1.LineStyle = gs;
+                        dc2.LineStyle = gs;
+                    }
+                }
+            }
+            catch { /* 靜默失敗以防止有些專案無此線型 */ }
+
+            refArray.Append(dc1.GeometryCurve.Reference);
+            refArray.Append(dc2.GeometryCurve.Reference);
+
+            // 建立尺寸標註
+            Dimension dim = doc.Create.NewDimension(view, dimLine, refArray);
+            
+            // 標記為穿梁輔助尺寸標註
+            dim.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS)?.Set("BeamPenetration_Helper");
+
+            return dim;
+        }
+
+        private object ClearPreviousAnnotations(JObject parameters)
+        {
+            Document doc = _uiApp.ActiveUIDocument.Document;
+            View activeView = doc.ActiveView;
+
+            using (Transaction trans = new Transaction(doc, "清除舊有穿梁標註"))
+            {
+                trans.Start();
+
+                // 1. 蒐集當前視圖中的所有 Dimension
+                var dimensions = new FilteredElementCollector(doc, activeView.Id)
+                    .OfClass(typeof(Dimension))
+                    .Cast<Dimension>()
+                    .ToList();
+
+                // 2. 蒐集當前視圖中的所有 DetailCurve
+                var detailCurves = new FilteredElementCollector(doc, activeView.Id)
+                    .OfClass(typeof(CurveElement))
+                    .Cast<CurveElement>()
+                    .Where(c => c is DetailArc || c is DetailLine || c.GetType().Name.Contains("Detail"))
+                    .ToList();
+
+                // 3. 蒐集當前視圖中的所有 TextNote
+                var textNotes = new FilteredElementCollector(doc, activeView.Id)
+                    .OfClass(typeof(TextNote))
+                    .Cast<TextNote>()
+                    .ToList();
+
+                List<ElementId> toDelete = new List<ElementId>();
+
+                // 檢查 Dimension
+                foreach (var d in dimensions) {
+                    Parameter p = d.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
+                    if (p != null && p.HasValue && p.AsString() == "BeamPenetration_Helper") {
+                        toDelete.Add(d.Id);
+                    }
+                }
+
+                // 檢查 DetailCurve
+                foreach (var dc in detailCurves) {
+                    Parameter p = dc.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
+                    if (p != null && p.HasValue && p.AsString() == "BeamPenetration_Helper") {
+                        toDelete.Add(dc.Id);
+                    }
+                }
+
+                // 檢查 TextNote
+                foreach (var tn in textNotes) {
+                    Parameter p = tn.get_Parameter(BuiltInParameter.ALL_MODEL_INSTANCE_COMMENTS);
+                    if (p != null && p.HasValue && p.AsString() == "BeamPenetration_Helper") {
+                        toDelete.Add(tn.Id);
+                    } else if (tn.Text.StartsWith("● PASS") || tn.Text.StartsWith("● FAIL:")) {
+                        toDelete.Add(tn.Id);
+                    }
+                }
+
+                int deletedCount = toDelete.Count;
+                if (deletedCount > 0) {
+                    doc.Delete(toDelete);
+                }
+
+                trans.Commit();
+                return new { Success = true, DeletedCount = deletedCount };
             }
         }
 
@@ -2200,189 +2168,6 @@ namespace RevitMCP.Core
                 AllPass_1600 = widthValues.All(w => w >= 1600),
                 AllPass_1200 = widthValues.All(w => w >= 1200),
                 Segments = measurements
-            };
-        }
-
-        /// <summary>
-        /// 走廊寬度分析 — 使用房間邊界線段找平行牆對，回傳寬度與各區段檢討結果
-        /// </summary>
-        private object AnalyzeCorridorWidth(JObject parameters)
-        {
-            Document doc = _uiApp.ActiveUIDocument.Document;
-            IdType? roomId = parameters["roomId"]?.Value<IdType>();
-            string roomName = parameters["roomName"]?.Value<string>();
-            double minWidth = parameters["minWidth"]?.Value<double>() ?? 1200;
-
-            Room room = null;
-
-            if (roomId.HasValue && roomId.Value > 0)
-            {
-                room = doc.GetElement(new ElementId(roomId.Value)) as Room;
-            }
-            else if (!string.IsNullOrEmpty(roomName))
-            {
-                room = new FilteredElementCollector(doc)
-                    .OfCategory(BuiltInCategory.OST_Rooms)
-                    .WhereElementIsNotElementType()
-                    .Cast<Room>()
-                    .FirstOrDefault(r => r.Name.Contains(roomName) ||
-                                         r.get_Parameter(BuiltInParameter.ROOM_NAME)?.AsString()?.Contains(roomName) == true);
-            }
-
-            if (room == null)
-            {
-                throw new Exception(roomId.HasValue
-                    ? $"找不到房間 ID: {roomId}"
-                    : $"找不到房間名稱包含: {roomName}");
-            }
-
-            var bOptions = new SpatialElementBoundaryOptions();
-            bOptions.SpatialElementBoundaryLocation = SpatialElementBoundaryLocation.Finish;
-            var segmentLoops = room.GetBoundarySegments(bOptions);
-
-            if (segmentLoops == null || segmentLoops.Count == 0)
-                throw new Exception("房間無邊界線段");
-
-            var lines = new List<Line>();
-            foreach (var seg in segmentLoops[0])
-            {
-                var curve = seg.GetCurve();
-                if (curve is Line line && line.Length > 0.3)
-                    lines.Add(line);
-            }
-
-            if (lines.Count < 2)
-                throw new Exception($"邊界線段不足（僅 {lines.Count} 條直線）");
-
-            var pairs = new List<int[]>();
-            var pairWidths = new List<double>();
-            var pairAvgLens = new List<double>();
-
-            for (int i = 0; i < lines.Count; i++)
-            {
-                XYZ dir1 = lines[i].Direction.Normalize();
-                double len1 = lines[i].Length;
-
-                for (int j = i + 1; j < lines.Count; j++)
-                {
-                    XYZ dir2 = lines[j].Direction.Normalize();
-                    double len2 = lines[j].Length;
-
-                    double dot = Math.Abs(dir1.DotProduct(dir2));
-                    if (dot < 0.996) continue;
-
-                    XYZ perp = new XYZ(-dir1.Y, dir1.X, 0).Normalize();
-                    XYZ diff = lines[j].GetEndPoint(0).Subtract(lines[i].GetEndPoint(0));
-                    double dist = Math.Abs(diff.DotProduct(perp));
-
-                    if (dist < 100.0 / 304.8) continue;
-
-                    double avgLen = (len1 + len2) / 2;
-                    if (avgLen < dist) continue;
-
-                    double s1a = lines[i].GetEndPoint(0).DotProduct(dir1);
-                    double s1b = lines[i].GetEndPoint(1).DotProduct(dir1);
-                    double s2a = lines[j].GetEndPoint(0).DotProduct(dir1);
-                    double s2b = lines[j].GetEndPoint(1).DotProduct(dir1);
-
-                    double min1 = Math.Min(s1a, s1b), max1 = Math.Max(s1a, s1b);
-                    double min2 = Math.Min(s2a, s2b), max2 = Math.Max(s2a, s2b);
-                    double oStart = Math.Max(min1, min2);
-                    double oEnd = Math.Min(max1, max2);
-                    if (oEnd <= oStart + 0.01) continue;
-
-                    pairs.Add(new[] { i, j });
-                    pairWidths.Add(dist);
-                    pairAvgLens.Add(avgLen);
-                }
-            }
-
-            if (pairs.Count == 0)
-                throw new Exception("找不到平行牆面對（可能不是走廊形狀）");
-
-            var sorted = Enumerable.Range(0, pairs.Count)
-                .OrderByDescending(k => pairAvgLens[k])
-                .ToList();
-
-            var segments = new List<object>();
-            var widthValues = new List<double>();
-
-            foreach (int k in sorted)
-            {
-                var line1 = lines[pairs[k][0]];
-                var line2 = lines[pairs[k][1]];
-                XYZ dir = line1.Direction.Normalize();
-
-                double s1a = line1.GetEndPoint(0).DotProduct(dir);
-                double s1b = line1.GetEndPoint(1).DotProduct(dir);
-                double s2a = line2.GetEndPoint(0).DotProduct(dir);
-                double s2b = line2.GetEndPoint(1).DotProduct(dir);
-
-                double min1 = Math.Min(s1a, s1b), max1 = Math.Max(s1a, s1b);
-                double min2 = Math.Min(s2a, s2b), max2 = Math.Max(s2a, s2b);
-                double oMid = (Math.Max(min1, min2) + Math.Min(max1, max2)) / 2;
-
-                double t1 = (s1b != s1a) ? (oMid - s1a) / (s1b - s1a) : 0.5;
-                double t2 = (s2b != s2a) ? (oMid - s2a) / (s2b - s2a) : 0.5;
-                t1 = Math.Max(0.01, Math.Min(0.99, t1));
-                t2 = Math.Max(0.01, Math.Min(0.99, t2));
-
-                XYZ p1 = line1.Evaluate(t1, true);
-                XYZ p2 = line2.Evaluate(t2, true);
-
-                double widthMm = Math.Round(pairWidths[k] * 304.8, 1);
-                double lengthMm = Math.Round(pairAvgLens[k] * 304.8, 1);
-                widthValues.Add(widthMm);
-
-                segments.Add(new
-                {
-                    SegmentIndex = segments.Count + 1,
-                    Width = widthMm,
-                    Length = lengthMm,
-                    Method = "boundary_accurate",
-                    Status = widthMm >= minWidth ? "PASS" : "FAIL",
-                    CenterPoint = new
-                    {
-                        X = Math.Round((p1.X + p2.X) * 304.8 / 2, 1),
-                        Y = Math.Round((p1.Y + p2.Y) * 304.8 / 2, 1)
-                    },
-                    Point1 = new
-                    {
-                        X = Math.Round(p1.X * 304.8, 1),
-                        Y = Math.Round(p1.Y * 304.8, 1)
-                    },
-                    Point2 = new
-                    {
-                        X = Math.Round(p2.X * 304.8, 1),
-                        Y = Math.Round(p2.Y * 304.8, 1)
-                    }
-                });
-            }
-
-            string resolvedRoomName = room.get_Parameter(BuiltInParameter.ROOM_NAME)?.AsString() ?? room.Name;
-            string roomNumber = room.Number ?? "";
-
-            return new
-            {
-                Room = new
-                {
-                    ElementId = room.Id.GetIdValue(),
-                    Name = resolvedRoomName,
-                    Number = roomNumber,
-                    Level = doc.GetElement(room.LevelId)?.Name
-                },
-                Input = new
-                {
-                    MinWidth = minWidth,
-                    BoundarySegmentCount = lines.Count
-                },
-                Summary = new
-                {
-                    TotalSegments = segments.Count,
-                    MinWidth = widthValues.Count > 0 ? widthValues.Min() : 0,
-                    AllPass = widthValues.All(w => w >= minWidth)
-                },
-                Segments = segments
             };
         }
 
@@ -3276,48 +3061,6 @@ namespace RevitMCP.Core
                 TotalPairs = storedCount,
                 Message = $"已恢復 {rejoinedCount} 個接合關係"
             };
-        }
-
-        /// <summary>
-        /// 取得房間邊界線段 (用於精確計算走廊寬度)
-        /// </summary>
-        private List<object> GetRoomBoundarySegments(Room room)
-        {
-            var segments = new List<object>();
-            var options = new SpatialElementBoundaryOptions();
-
-            try
-            {
-                var boundarySegments = room.GetBoundarySegments(options);
-                if (boundarySegments == null || boundarySegments.Count == 0)
-                    return segments;
-
-                foreach (var loop in boundarySegments)
-                {
-                    foreach (BoundarySegment seg in loop)
-                    {
-                        var curve = seg.GetCurve();
-                        var start = curve.GetEndPoint(0);
-                        var end = curve.GetEndPoint(1);
-
-                        segments.Add(new
-                        {
-                            StartX = Math.Round(start.X * 304.8, 2),
-                            StartY = Math.Round(start.Y * 304.8, 2),
-                            EndX = Math.Round(end.X * 304.8, 2),
-                            EndY = Math.Round(end.Y * 304.8, 2),
-                            Length = Math.Round(curve.Length * 304.8, 2)
-                        });
-                    }
-                }
-            }
-            catch (Exception)
-            {
-                // 某些房間可能無法取得邊界 (未封閉、未放置等)
-                // 回傳空陣列,讓 JS 端使用 BoundingBox fallback
-            }
-
-            return segments;
         }
 
         #endregion

--- a/MCP/Core/Commands/CommandExecutor.BeamPenetration.cs
+++ b/MCP/Core/Commands/CommandExecutor.BeamPenetration.cs
@@ -1,0 +1,611 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.Structure;
+using Autodesk.Revit.UI;
+using Newtonsoft.Json.Linq;
+using RevitMCP.Models;
+
+#if REVIT2025_OR_GREATER
+using IdType = System.Int64;
+#else
+using IdType = System.Int32;
+#endif
+
+namespace RevitMCP.Core
+{
+    public partial class CommandExecutor
+    {
+        /// <summary>
+        /// 1. 掃描目前視圖中所有被套管穿過的梁 (V3.0)
+        /// </summary>
+        private object ScanPenetratedBeamsInView(JObject parameters)
+        {
+            Document mainDoc = _uiApp.ActiveUIDocument.Document;
+            View activeView = mainDoc.ActiveView;
+            
+            // 獲取視圖中所有套管
+            var sleeves = new FilteredElementCollector(mainDoc, activeView.Id)
+                .WhereElementIsNotElementType()
+                .WherePasses(new ElementMulticategoryFilter(new List<BuiltInCategory> { 
+                    BuiltInCategory.OST_PipeAccessory, 
+                    BuiltInCategory.OST_GenericModel 
+                })).ToList();
+
+            var results = new Dictionary<string, dynamic>();
+
+            // 獲取視圖中所有連結模型
+            var linkInstances = new FilteredElementCollector(mainDoc, activeView.Id)
+                .OfClass(typeof(RevitLinkInstance))
+                .Cast<RevitLinkInstance>()
+                .ToList();
+
+            foreach (var sleeve in sleeves)
+            {
+                BoundingBoxXYZ sleeveBBox = sleeve.get_BoundingBox(null);
+                if (sleeveBBox == null) continue;
+
+                // 幾何碰撞第一層篩選已移至內部 linkBeams 迴圈：
+                // 不在此處直接 continue 排除碰牆/碰板的套管，以免誤判梁側貼牆的合法套管。
+
+                foreach (var li in linkInstances)
+                {
+                    Document linkDoc = li.GetLinkDocument();
+                    if (linkDoc == null) continue;
+
+                    Transform tr = li.GetTotalTransform();
+                    Outline sleeveOutline = new Outline(tr.Inverse.OfPoint(sleeveBBox.Min), tr.Inverse.OfPoint(sleeveBBox.Max));
+
+                    // 只針對視圖中「看得到」的梁進行幾何碰撞
+                    var linkBeams = new FilteredElementCollector(linkDoc)
+                        .OfCategory(BuiltInCategory.OST_StructuralFraming)
+                        .WherePasses(new BoundingBoxIntersectsFilter(sleeveOutline))
+                        .WhereElementIsNotElementType();
+
+                    foreach (var b in linkBeams)
+                    {
+                        // 判定貼梁牆/貼梁板之過濾排除：
+                        // 如果套管同時與牆或板相交，且套管長度與該相交梁的寬度不匹配 (誤差 > 10mm)，則排除。
+                        bool intersectsWall = CheckIsIntersectsWithWall(mainDoc, sleeve);
+                        bool intersectsFloor = CheckIsIntersectsWithFloor(mainDoc, sleeve);
+                        if (intersectsWall || intersectsFloor)
+                        {
+                            double sleeveLen = GetSleeveLength(sleeve) * 304.8;
+                            double beamWidthMM = GetBeamWidth(b) * 304.8;
+                            
+                            double perpDistXY = 0;
+                            LocationCurve beamLoc = b.Location as LocationCurve;
+                            if (beamLoc != null)
+                            {
+                                XYZ sleeveCenter = (sleeveBBox.Min + sleeveBBox.Max) * 0.5;
+                                XYZ localSleeveCenter = tr.Inverse.OfPoint(sleeveCenter);
+                                IntersectionResult ir = beamLoc.Curve.Project(localSleeveCenter);
+                                if (ir != null)
+                                {
+                                    perpDistXY = new XYZ(localSleeveCenter.X - ir.XYZPoint.X, localSleeveCenter.Y - ir.XYZPoint.Y, 0).GetLength() * 304.8;
+                                }
+                            }
+
+                            if (sleeveLen < beamWidthMM - 10.0 || perpDistXY > (beamWidthMM / 2.0) + 100.0)
+                            {
+                                continue; // 長度小於梁寬或偏離過遠，跳過
+                            }
+                        }
+
+                        string key = $"{li.Id.GetIdValue()}_{b.Id.GetIdValue()}";
+                        if (!results.ContainsKey(key))
+                        {
+                            results[key] = new { 
+                                BeamId = b.Id.GetIdValue(), 
+                                LinkId = li.Id.GetIdValue(), 
+                                Name = b.Name, 
+                                Level = GetReferenceLevelName(b), 
+                                SleeveIds = new List<IdType>() 
+                            };
+                        }
+                        results[key].SleeveIds.Add(sleeve.Id.GetIdValue());
+                    }
+                }
+            }
+            return new { Count = results.Count, Beams = results.Values.ToList() };
+        }
+
+        /// <summary>
+        /// 2. 深度分析穿梁幾何
+        /// </summary>
+        private object AnalyzeBeamPenetration(JObject parameters)
+        {
+            try {
+                IdType beamId = parameters["beamId"]?.Value<IdType>() ?? 0;
+                IdType linkId = parameters["linkInstanceId"]?.Value<IdType>() ?? 0;
+
+                // 接收外部傳遞的動態參數名稱 (若無則由方法內部給定預設值)
+                string[] diamParams = parameters["diameterParamNames"]?.ToObject<string[]>();
+                string[] lenParams = parameters["lengthParamNames"]?.ToObject<string[]>();
+                string[] widthParams = parameters["widthParamNames"]?.ToObject<string[]>();
+
+                Document mainDoc = _uiApp.ActiveUIDocument.Document;
+                Document doc = mainDoc;
+                Transform tr = Transform.Identity;
+                
+                if (linkId != 0) {
+                    var link = mainDoc.GetElement(new ElementId(linkId)) as RevitLinkInstance;
+                    if (link == null) throw new Exception($"找不到連結模型實體 (ID: {linkId})");
+                    doc = link.GetLinkDocument();
+                    if (doc == null) throw new Exception("無法取得連結模型的文件 (Document 為 null)");
+                    tr = link.GetTotalTransform();
+                }
+
+                Element beamElem = doc.GetElement(new ElementId(beamId));
+                if (beamElem == null) throw new Exception($"在目標文件中找不到梁 (ID: {beamId})");
+                
+                FamilyInstance beam = beamElem as FamilyInstance;
+                if (beam == null) throw new Exception($"元素 (ID: {beamId}) 不是 FamilyInstance (目前為 {beamElem.GetType().Name})");
+
+                string beamLevel = GetReferenceLevelName(beam);
+                double beamDepth = GetBeamDepth(beam);
+                double beamWidth = GetBeamWidth(beam, widthParams);
+
+                BoundingBoxXYZ beamBox = beam.get_BoundingBox(null);
+                if (beamBox == null) throw new Exception($"無法取得梁 (ID: {beamId}) 的 BoundingBox");
+
+                // 將梁的 BoundingBox 轉換為世界座標中的 Outline
+                XYZ worldMin = tr.OfPoint(beamBox.Min);
+                XYZ worldMax = tr.OfPoint(beamBox.Max);
+                Outline beamOutline = new Outline(
+                    new XYZ(Math.Min(worldMin.X, worldMax.X), Math.Min(worldMin.Y, worldMax.Y), Math.Min(worldMin.Z, worldMax.Z)),
+                    new XYZ(Math.Max(worldMin.X, worldMax.X), Math.Max(worldMin.Y, worldMax.Y), Math.Max(worldMin.Z, worldMax.Z))
+                );
+
+                List<Element> sleeves = new List<Element>();
+                IdType[] targetSleeveIds = parameters["sleeveIds"]?.ToObject<IdType[]>();
+
+                if (targetSleeveIds != null && targetSleeveIds.Length > 0) {
+                    // 如果外部已經明確指定了套管清單 (精確名單模式)，直接讀取實體
+                    foreach (IdType sId in targetSleeveIds) {
+                        Element sl = mainDoc.GetElement(new ElementId(sId));
+                        if (sl != null) sleeves.Add(sl);
+                    }
+                } else {
+                    // 退回舊有邏輯：在主模型的當前視圖中，尋找與梁相交的套管
+                    View activeView = mainDoc.ActiveView;
+                    sleeves = new FilteredElementCollector(mainDoc, activeView.Id)
+                        .WhereElementIsNotElementType()
+                        .WherePasses(new BoundingBoxIntersectsFilter(beamOutline))
+                        .WherePasses(new ElementMulticategoryFilter(new List<BuiltInCategory> { 
+                            BuiltInCategory.OST_PipeAccessory, 
+                            BuiltInCategory.OST_GenericModel 
+                        })).ToList();
+                }
+
+                Outline localBeamOutline = new Outline(beamBox.Min, beamBox.Max);
+                List<FamilyInstance> orthogonalBeams = new List<FamilyInstance>();
+                LocationCurve beamLocForOrthogonal = beam.Location as LocationCurve;
+                if (beamLocForOrthogonal != null) {
+                    XYZ beamDir = (beamLocForOrthogonal.Curve.GetEndPoint(1) - beamLocForOrthogonal.Curve.GetEndPoint(0)).Normalize();
+                    var intersectingBeams = new FilteredElementCollector(doc)
+                        .OfCategory(BuiltInCategory.OST_StructuralFraming)
+                        .WherePasses(new BoundingBoxIntersectsFilter(localBeamOutline))
+                        .WhereElementIsNotElementType()
+                        .Cast<FamilyInstance>()
+                        .Where(b => b.Id != beam.Id)
+                        .ToList();
+
+                    foreach (var ib in intersectingBeams) {
+                        LocationCurve ibLoc = ib.Location as LocationCurve;
+                        if (ibLoc != null) {
+                            XYZ ibDir = (ibLoc.Curve.GetEndPoint(1) - ibLoc.Curve.GetEndPoint(0)).Normalize();
+                            if (Math.Abs(beamDir.DotProduct(ibDir)) < 0.5) { // 正交或大於 60 度
+                                orthogonalBeams.Add(ib);
+                            }
+                        }
+                    }
+                }
+
+                var checkResults = new List<object>();
+
+                foreach (var sleeve in sleeves)
+                {
+                    BoundingBoxXYZ sleeveBBox = sleeve.get_BoundingBox(null);
+                    if (sleeveBBox == null) continue;
+
+                    // 幾何碰撞第一層篩選已移至內部：不在此處直接 continue 排除碰牆/碰板的套管，
+                    // 以免誤判「梁側貼牆/貼板」的合法穿梁套管。改由後續長度匹配度判定。
+
+                    string comments = sleeve.LookupParameter("備註")?.AsString() ?? "";
+                    string familyName = (sleeve as FamilyInstance)?.Symbol?.FamilyName ?? "";
+                    string typeName = sleeve.Name;
+
+                    bool hasSleeveKeyword = familyName.IndexOf("Sleeve", StringComparison.OrdinalIgnoreCase) >= 0 || 
+                                           typeName.IndexOf("Sleeve", StringComparison.OrdinalIgnoreCase) >= 0;
+                    bool isSleeve = comments.Contains("穿梁") || familyName.Contains("穿梁") || familyName.Contains("套管") || hasSleeveKeyword;
+
+                    if (!isSleeve) continue;
+
+                    XYZ sleeveCenter = (sleeveBBox.Min + sleeveBBox.Max) * 0.5;
+                    double sleeveD = GetSleeveDiameter(sleeve, sleeveBBox, diamParams);
+                    string sleeveLevel = GetReferenceLevelName(sleeve);
+
+                    double distToStart = -1;
+                    double distToEnd = -1;
+                    double minDist = -1;
+                    double perpDistXY = 0;
+                    double connDepthStart = -1;
+                    double connDepthEnd = -1;
+                    double distToStartFace = -1;
+                    double distToEndFace = -1;
+
+                    LocationCurve beamLoc = beam.Location as LocationCurve;
+                    if (beamLoc != null)
+                    {
+                        Curve bc = beamLoc.Curve;
+                        XYZ localSleeveCenter = tr.Inverse.OfPoint(sleeveCenter);
+                        IntersectionResult ir = bc.Project(localSleeveCenter);
+                        if (ir != null)
+                        {
+                            distToStart = ir.XYZPoint.DistanceTo(bc.GetEndPoint(0));
+                            distToEnd = ir.XYZPoint.DistanceTo(bc.GetEndPoint(1));
+                            minDist = Math.Min(distToStart, distToEnd);
+                            perpDistXY = new XYZ(localSleeveCenter.X - ir.XYZPoint.X, localSleeveCenter.Y - ir.XYZPoint.Y, 0).GetLength() * 304.8;
+                        }
+                        
+                        distToStartFace = distToStart;
+                        distToEndFace = distToEnd;
+
+                        XYZ beamDirTemp = (bc.GetEndPoint(1) - bc.GetEndPoint(0)).Normalize();
+                        XYZ worldP0Temp = tr.OfPoint(bc.GetEndPoint(0));
+                        XYZ worldP1Temp = tr.OfPoint(bc.GetEndPoint(1));
+                        XYZ worldBeamDirTemp = tr.OfVector(beamDirTemp).Normalize();
+
+                        double offsetStart = GetCollisionWidthAtPoint(mainDoc, worldP0Temp, worldBeamDirTemp, beam.Id);
+                        double offsetEnd = GetCollisionWidthAtPoint(mainDoc, worldP1Temp, worldBeamDirTemp, beam.Id);
+
+                        distToStartFace = distToStart - offsetStart / 2.0;
+                        distToEndFace = distToEnd - offsetEnd / 2.0;
+
+                        // 偵測起點(0)相連結構取得大梁深度
+                        var conn0 = beamLoc.get_ElementsAtJoin(0);
+                        if (conn0 != null)
+                        {
+                            foreach (ElementId id in conn0)
+                            {
+                                Element elem = doc.GetElement(id);
+                                if (elem == null || elem.Id == beam.Id) continue;
+                                if (elem.Category != null)
+                                {
+                                    if (elem.Category.Id.GetIdValue() == (IdType)(int)BuiltInCategory.OST_StructuralFraming) {
+                                        connDepthStart = GetBeamDepth(elem) * 304.8;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+
+                        // 偵測終點(1)相連結構取得大梁深度
+                        var conn1 = beamLoc.get_ElementsAtJoin(1);
+                        if (conn1 != null)
+                        {
+                            foreach (ElementId id in conn1)
+                            {
+                                Element elem = doc.GetElement(id);
+                                if (elem == null || elem.Id == beam.Id) continue;
+                                if (elem.Category != null)
+                                {
+                                    if (elem.Category.Id.GetIdValue() == (IdType)(int)BuiltInCategory.OST_StructuralFraming) {
+                                        connDepthEnd = GetBeamDepth(elem) * 304.8;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    double beamBottomZ = worldMin.Z;
+                    double beamTopZ = beamBottomZ + beamDepth; // 扣除梁頂增築：以梁底標高加上型號梁深作為結構梁原本頂標高
+
+                    XYZ worldP0 = XYZ.Zero;
+                    XYZ worldP1 = XYZ.Zero;
+                    if (beamLoc != null)
+                    {
+                        worldP0 = tr.OfPoint(beamLoc.Curve.GetEndPoint(0));
+                        worldP1 = tr.OfPoint(beamLoc.Curve.GetEndPoint(1));
+                    }
+
+                    FamilyInstance nearestSideBeam = null;
+                    double minSideBeamDist = double.MaxValue;
+                    double nearestSideBeamDepth = 0;
+                    double nearestSideBeamWidth = 0;
+
+                    if (beamLoc != null)
+                    {
+                        XYZ sleeveLocalProj = tr.Inverse.OfPoint(sleeveCenter);
+                        IntersectionResult irSleeve = beamLoc.Curve.Project(sleeveLocalProj);
+                        if (irSleeve != null)
+                        {
+                            foreach (var ob in orthogonalBeams) {
+                                LocationCurve obLoc = ob.Location as LocationCurve;
+                                if (obLoc == null) continue;
+                                IntersectionResult p0 = beamLoc.Curve.Project(obLoc.Curve.GetEndPoint(0));
+                                IntersectionResult p1 = beamLoc.Curve.Project(obLoc.Curve.GetEndPoint(1));
+                                
+                                double d0 = p0 != null ? p0.XYZPoint.DistanceTo(irSleeve.XYZPoint) : double.MaxValue;
+                                double d1 = p1 != null ? p1.XYZPoint.DistanceTo(irSleeve.XYZPoint) : double.MaxValue;
+                                
+                                double distToSideBeamCenter = Math.Min(d0, d1);
+                                
+                                if (distToSideBeamCenter < minSideBeamDist && distToSideBeamCenter < (3000.0 / 304.8)) {
+                                    minSideBeamDist = distToSideBeamCenter;
+                                    nearestSideBeam = ob;
+                                    nearestSideBeamDepth = GetBeamDepth(ob) * 304.8;
+                                    nearestSideBeamWidth = GetBeamWidth(ob) * 304.8;
+                                }
+                            }
+                        }
+                    }
+
+                    checkResults.Add(new {
+                        SleeveId = sleeve.Id.GetIdValue(),
+                        SleeveLevel = sleeveLevel,
+                        BeamId = beamId,
+                        BeamName = beam.Name,
+                        BeamLevel = beamLevel,
+                        BeamUsage = DetermineBeamUsage(beam),
+                        IsNearWall = CheckIsIntersectsWithWall(mainDoc, sleeve),
+                        BeamDepth = beamDepth * 304.8, // mm
+                        BeamWidth = beamWidth * 304.8, // mm
+                        SleeveDiameter = sleeveD * 304.8, // mm
+                        SleeveLength = GetSleeveLength(sleeve, lenParams) * 304.8, // mm
+                        IsExcluded = GetSleeveLength(sleeve, lenParams) * 304.8 < beamWidth * 304.8 - 10.0 || perpDistXY > (beamWidth * 304.8 / 2.0) + 100.0,
+                        ExclusionReason = GetSleeveLength(sleeve, lenParams) * 304.8 < beamWidth * 304.8 - 10.0 ? "套管長度小於梁寬，無法穿梁" : (perpDistXY > (beamWidth * 304.8 / 2.0) + 100.0 ? "套管偏離梁中心線過遠，疑似平行穿牆套管" : ""),
+                        DistanceToStart = distToStart * 304.8,
+                        DistanceToEnd = distToEnd * 304.8,
+                        MinDistance = minDist * 304.8,
+                        MinDistanceFace = Math.Min(distToStartFace, distToEndFace) * 304.8,
+                        PerpDistXY = perpDistXY,
+                        ConnectedBeamDepthStart = connDepthStart,
+                        ConnectedBeamDepthEnd = connDepthEnd,
+                        SleeveZ = sleeveCenter.Z * 304.8,
+                        BeamTopZ = beamTopZ * 304.8,
+                        BeamBottomZ = beamBottomZ * 304.8,
+                        BeamStartX = worldP0.X * 304.8,
+                        BeamStartY = worldP0.Y * 304.8,
+                        BeamEndX = worldP1.X * 304.8,
+                        BeamEndY = worldP1.Y * 304.8,
+                        NearestSideBeamId = nearestSideBeam?.Id.GetIdValue() ?? 0,
+                        NearestSideBeamName = nearestSideBeam?.Name ?? "",
+                        NearestSideBeamDepth = nearestSideBeamDepth,
+                        NearestSideBeamWidth = nearestSideBeamWidth,
+                        DistToNearestSideBeamCenter = minSideBeamDist == double.MaxValue ? -1 : minSideBeamDist * 304.8,
+                        SleeveX = sleeveCenter.X * 304.8,
+                        SleeveY = sleeveCenter.Y * 304.8
+                    });
+                }
+
+                return new { 
+                    Success = true, 
+                    Results = checkResults 
+                };
+            } catch (Exception ex) {
+                return new { Success = false, Error = "分析失敗: " + ex.Message + "\n" + ex.StackTrace };
+            }
+        }
+
+        private bool IsPointNearColumn(Document doc, XYZ point)
+        {
+            // 建立一個約 15cm (0.5 英尺) 大小的 Bounding Box 包圍該端點，作為拓撲未連接時的備用幾何防線
+            double size = 0.5; 
+            Outline outline = new Outline(
+                new XYZ(point.X - size / 2, point.Y - size / 2, point.Z - size / 2),
+                new XYZ(point.X + size / 2, point.Y + size / 2, point.Z + size / 2)
+            );
+
+            // 1. 搜尋主模型中的結構柱
+            var columns = new FilteredElementCollector(doc)
+                .OfCategory(BuiltInCategory.OST_StructuralColumns)
+                .WherePasses(new BoundingBoxIntersectsFilter(outline))
+                .WhereElementIsNotElementType()
+                .ToList();
+
+            if (columns.Count > 0) return true;
+
+            // 2. 搜尋連結模型中的結構柱
+            var linkInstances = new FilteredElementCollector(doc)
+                .OfClass(typeof(RevitLinkInstance))
+                .Cast<RevitLinkInstance>()
+                .ToList();
+
+            foreach (var li in linkInstances)
+            {
+                Document linkDoc = li.GetLinkDocument();
+                if (linkDoc == null) continue;
+
+                Transform tr = li.GetTotalTransform();
+                XYZ localPoint = tr.Inverse.OfPoint(point);
+                Outline localOutline = new Outline(
+                    new XYZ(localPoint.X - size / 2, localPoint.Y - size / 2, localPoint.Z - size / 2),
+                    new XYZ(localPoint.X + size / 2, localPoint.Y + size / 2, localPoint.Z + size / 2)
+                );
+
+                var linkColumns = new FilteredElementCollector(linkDoc)
+                    .OfCategory(BuiltInCategory.OST_StructuralColumns)
+                    .WherePasses(new BoundingBoxIntersectsFilter(localOutline))
+                    .WhereElementIsNotElementType()
+                    .ToList();
+
+                if (linkColumns.Count > 0) return true;
+            }
+
+            return false;
+        }
+
+        private bool IsBeamEndConnectedToColumn(FamilyInstance beam, int end)
+        {
+            try
+            {
+                LocationCurve beamLoc = beam.Location as LocationCurve;
+                if (beamLoc == null) return false;
+
+                Document doc = beam.Document;
+                var connectedIds = beamLoc.get_ElementsAtJoin(end);
+                if (connectedIds == null) return false;
+
+                foreach (ElementId id in connectedIds)
+                {
+                    Element elem = doc.GetElement(id);
+                    if (elem == null) continue;
+
+                    // 檢查相連元素的品類是否為結構柱
+                    if (elem.Category != null && elem.Category.Id.GetIdValue() == (IdType)(int)BuiltInCategory.OST_StructuralColumns)
+                    {
+                        return true;
+                    }
+                }
+            }
+            catch
+            {
+                // 忽略異常，退回幾何判定
+            }
+            return false;
+        }
+
+        private string DetermineBeamUsage(FamilyInstance beam)
+        {
+            // 1. 先使用內建參數判斷，若是 Joist 則直接判定為 Minor
+            var usage = beam.StructuralUsage;
+            if (usage == StructuralInstanceUsage.Joist) return "Minor";
+
+            try
+            {
+                LocationCurve beamLoc = beam.Location as LocationCurve;
+                if (beamLoc != null)
+                {
+                    // 2. 優先使用方案 A：拓撲相連檢查 (get_ElementsAtJoin)
+                    bool p0Connected = IsBeamEndConnectedToColumn(beam, 0);
+                    bool p1Connected = IsBeamEndConnectedToColumn(beam, 1);
+                    if (p0Connected || p1Connected) return "Major";
+
+                    // 3. 備用防禦方案 B：幾何微距碰撞檢查 (15cm 穩健公差範圍)
+                    XYZ p0 = beamLoc.Curve.GetEndPoint(0);
+                    XYZ p1 = beamLoc.Curve.GetEndPoint(1);
+
+                    bool p0NearCol = IsPointNearColumn(beam.Document, p0);
+                    bool p1NearCol = IsPointNearColumn(beam.Document, p1);
+
+                    if (p0NearCol || p1NearCol)
+                    {
+                        return "Major";
+                    }
+                    else
+                    {
+                        return "Minor";
+                    }
+                }
+            }
+            catch
+            {
+                // 發生異常時退回 Major
+            }
+
+            return "Major";
+        }
+
+        private bool CheckIsIntersectsWithWall(Document mainDoc, Element sleeve)
+        {
+            BoundingBoxXYZ bbox = sleeve.get_BoundingBox(null);
+            if (bbox == null) return false;
+            
+            Outline outline = new Outline(bbox.Min, bbox.Max);
+            
+            // 1. 檢查主模型中的牆
+            var walls = new FilteredElementCollector(mainDoc)
+                .OfCategory(BuiltInCategory.OST_Walls)
+                .WherePasses(new BoundingBoxIntersectsFilter(outline))
+                .WhereElementIsNotElementType()
+                .ToList();
+                
+            if (walls.Count > 0) return true;
+            
+            // 2. 檢查連結模型中的牆
+            var linkInstances = new FilteredElementCollector(mainDoc)
+                .OfClass(typeof(RevitLinkInstance))
+                .Cast<RevitLinkInstance>()
+                .ToList();
+                
+            foreach (var li in linkInstances)
+            {
+                Document linkDoc = li.GetLinkDocument();
+                if (linkDoc == null) continue;
+                
+                Transform tr = li.GetTotalTransform();
+                
+                // 將套管的 BoundingBox 轉換至連結模型坐標系
+                XYZ localMin = tr.Inverse.OfPoint(bbox.Min);
+                XYZ localMax = tr.Inverse.OfPoint(bbox.Max);
+                Outline localOutline = new Outline(
+                    new XYZ(Math.Min(localMin.X, localMax.X), Math.Min(localMin.Y, localMax.Y), Math.Min(localMin.Z, localMax.Z)),
+                    new XYZ(Math.Max(localMin.X, localMax.X), Math.Max(localMin.Y, localMax.Y), Math.Max(localMin.Z, localMax.Z))
+                );
+                
+                var linkWalls = new FilteredElementCollector(linkDoc)
+                    .OfCategory(BuiltInCategory.OST_Walls)
+                    .WherePasses(new BoundingBoxIntersectsFilter(localOutline))
+                    .WhereElementIsNotElementType()
+                    .ToList();
+                    
+                if (linkWalls.Count > 0) return true;
+            }
+            
+            return false;
+        }
+
+        private bool CheckIsIntersectsWithFloor(Document mainDoc, Element sleeve)
+        {
+            BoundingBoxXYZ bbox = sleeve.get_BoundingBox(null);
+            if (bbox == null) return false;
+            
+            Outline outline = new Outline(bbox.Min, bbox.Max);
+            
+            // 1. 檢查主模型中的樓板
+            var floors = new FilteredElementCollector(mainDoc)
+                .OfCategory(BuiltInCategory.OST_Floors)
+                .WherePasses(new BoundingBoxIntersectsFilter(outline))
+                .WhereElementIsNotElementType()
+                .ToList();
+                
+            if (floors.Count > 0) return true;
+            
+            // 2. 檢查連結模型中的樓板
+            var linkInstances = new FilteredElementCollector(mainDoc)
+                .OfClass(typeof(RevitLinkInstance))
+                .Cast<RevitLinkInstance>()
+                .ToList();
+                
+            foreach (var li in linkInstances)
+            {
+                Document linkDoc = li.GetLinkDocument();
+                if (linkDoc == null) continue;
+                
+                Transform tr = li.GetTotalTransform();
+                
+                XYZ localMin = tr.Inverse.OfPoint(bbox.Min);
+                XYZ localMax = tr.Inverse.OfPoint(bbox.Max);
+                Outline localOutline = new Outline(
+                    new XYZ(Math.Min(localMin.X, localMax.X), Math.Min(localMin.Y, localMax.Y), Math.Min(localMin.Z, localMax.Z)),
+                    new XYZ(Math.Max(localMin.X, localMax.X), Math.Max(localMin.Y, localMax.Y), Math.Max(localMin.Z, localMax.Z))
+                );
+                
+                var linkFloors = new FilteredElementCollector(linkDoc)
+                    .OfCategory(BuiltInCategory.OST_Floors)
+                    .WherePasses(new BoundingBoxIntersectsFilter(localOutline))
+                    .WhereElementIsNotElementType()
+                    .ToList();
+                    
+                if (linkFloors.Count > 0) return true;
+            }
+            
+            return false;
+        }
+
+    }
+}


### PR DESCRIPTION
這是依照上游建議，將原 #59 PR 拆分後的**第一階段 (PR 1)** 提交。

### 階段一內容 (C# 幾何萃取與套管分類)
- 新增 CommandExecutor.BeamPenetration.cs (僅保留 ScanPenetratedBeamsInView 與 AnalyzeBeamPenetration 核心，移除自動標註與視覺化程式碼以降低耦合)
- 更新 CommandExecutor.cs 以註冊前述路由
- 新增 structure-tools.ts 以定義對應的 MCP Tool Schema
- 更新 index.ts 將 structureTools 註冊至 full 與 structural profiles

此 PR 專注於底層 Revit 幾何資料提取，為下一階段 (JS 端的法規與 RC Zone 邏輯判斷) 提供乾淨的資料來源。