### PR TITLE
功能：Toposolid 樓板投影整地工具（grade_toposolid_to_floors）與三方案實測驗證

### DIFF
--- a/MCP-Server/src/tools/grading-tools.ts
+++ b/MCP-Server/src/tools/grading-tools.ts
@@ -1,0 +1,49 @@
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+/** Toposolid 依樓板底面投影範圍進行整地。 */
+export const gradingTools: Tool[] = [
+    {
+        name: "grade_toposolid_to_floors",
+        description: "依指定樓板底面的水平投影範圍整平 Toposolid；本次僅支援 footprint_only 模式。",
+        inputSchema: {
+            type: "object",
+            properties: {
+                toposolidId: {
+                    type: "integer",
+                    description: "要整地的 Toposolid 元素 ID",
+                },
+                floorIds: {
+                    type: "array",
+                    minItems: 1,
+                    items: { type: "integer" },
+                    description: "作為整地範圍來源的樓板元素 ID；至少提供一筆",
+                },
+                mode: {
+                    type: "string",
+                    enum: ["footprint_only"],
+                    default: "footprint_only",
+                    description: "整地模式；本次只接受 footprint_only",
+                },
+                targetFace: {
+                    type: "string",
+                    enum: ["bottom"],
+                    default: "bottom",
+                    description: "樓板目標面；本次只接受 bottom",
+                },
+                allowPhaseSetup: {
+                    type: "boolean",
+                    default: true,
+                    description:
+                        "是否自動設定整地所需階段（預設 true）：原地形會改為較早階段建立、於目前階段拆除，設計副本建立於目前階段——與 Revit 原生整地行為一致。設為 false 時不修改階段，僅回報所需變更。",
+                },
+                updateExisting: {
+                    type: "boolean",
+                    enum: [false],
+                    default: false,
+                    description: "是否更新既有整地結果；本次只接受 false",
+                },
+            },
+            required: ["toposolidId", "floorIds"],
+        },
+    },
+];

--- a/MCP-Server/src/tools/revit-tools.ts
+++ b/MCP-Server/src/tools/revit-tools.ts
@@ -9,9 +9,24 @@
  */
 
 import { RevitSocketClient } from "../socket.js";
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { gradingTools } from "./grading-tools.js";
+import { registerRevitTools as registerProfileTools } from "./index.js";
 
-// Re-export from new module system
-export { registerRevitTools } from "./index.js";
+/**
+ * 依 Profile 註冊工具，並將 Toposolid 整地限制於建築與結構相關 Profile。
+ */
+export function registerRevitTools(): Tool[] {
+    const tools = registerProfileTools();
+    const requestedProfile = process.env.MCP_PROFILE || "full";
+    const profile = ["full", "architect", "mep", "structural", "fire-safety"].includes(requestedProfile)
+        ? requestedProfile
+        : "full";
+
+    return ["full", "architect", "structural"].includes(profile)
+        ? [...tools, ...gradingTools]
+        : tools;
+}
 
 /**
  * 執行 Revit 工具

--- a/MCP/Core/CommandExecutor.cs
+++ b/MCP/Core/CommandExecutor.cs
@@ -464,6 +464,12 @@ namespace RevitMCP.Core
                         result = ClearPreviousAnnotations(parameters);
                         break;
 
+#if REVIT2024_OR_GREATER
+                    case "grade_toposolid_to_floors":
+                        result = GradeToposolidToFloors(parameters);
+                        break;
+#endif
+
                     default:
                         throw new NotImplementedException($"未實作的命令: {request.CommandName}");
                 }

--- a/MCP/Core/Commands/CommandExecutor.ToposolidGrading.cs
+++ b/MCP/Core/Commands/CommandExecutor.ToposolidGrading.cs
@@ -1,0 +1,227 @@
+#if REVIT2024_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Autodesk.Revit.DB;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using RevitMCP.Core.Grading;
+
+namespace RevitMCP.Core
+{
+    public partial class CommandExecutor
+    {
+        /// <summary>
+        /// 將樓板底面投影套用至 Toposolid 設計副本，並計算挖填方。
+        /// </summary>
+        private object GradeToposolidToFloors(JObject parameters)
+        {
+            var stopwatch = Stopwatch.StartNew();
+            var timeline = new GradingTimeline();
+            var request = new GradingRequest
+            {
+                ToposolidId = parameters["toposolidId"]?.Value<long>() ?? 0,
+                FloorIds = parameters["floorIds"]?.Values<long>().ToArray() ?? new long[0],
+                Mode = parameters["mode"]?.Value<string>() ?? "footprint_only",
+                TargetFace = parameters["targetFace"]?.Value<string>() ?? "bottom",
+                // 預設自動設定階段：一般使用者的地形建立於「新建」階段，
+                // 整地需要它成為既有地貌；除非明確傳入 false，工具自動調整。
+                AllowPhaseSetup = parameters["allowPhaseSetup"]?.Value<bool>() ?? true,
+                UpdateExisting = parameters["updateExisting"]?.Value<bool>() ?? false
+            };
+            request.Validate();
+
+            var doc = _uiApp.ActiveUIDocument.Document;
+            IToposolidGradingAdapter adapter = new RevitToposolidGradingAdapter(timeline);
+            Toposolid original;
+            IReadOnlyList<Floor> floors;
+            IReadOnlyList<FloorFootprint> footprints;
+            using (timeline.Measure("元素驗證"))
+            {
+                original = adapter.ValidateToposolid(doc, request.ToposolidId);
+                floors = adapter.ValidateFloors(doc, request.FloorIds);
+            }
+
+            using (timeline.Measure("樓板底面擷取"))
+            {
+                footprints = adapter.ExtractBottomFootprints(floors);
+            }
+
+            Toposolid design = null!;
+            string associationId = null!;
+            var modifiedPointCount = 0;
+            var cutCubicMeters = 0.0;
+            var fillCubicMeters = 0.0;
+
+            using (var group = new TransactionGroup(doc, "樓板投影整地"))
+            {
+                try
+                {
+                    if (group.Start() != TransactionStatus.Started)
+                    {
+                        throw new InvalidOperationException("無法啟動樓板投影整地交易群組。");
+                    }
+
+                    using (var setupTransaction = new Transaction(doc, "建立整地設計副本"))
+                    {
+                        if (setupTransaction.Start() != TransactionStatus.Started)
+                        {
+                            throw new InvalidOperationException("無法啟動建立整地設計副本交易。");
+                        }
+
+                        using (timeline.Measure("設計副本與階段設定"))
+                        {
+                            design = adapter.CreateDesignCopy(doc, original, request.AllowPhaseSetup);
+                            associationId = adapter.WriteAssociation(
+                                doc,
+                                design,
+                                request.ToposolidId,
+                                request.FloorIds);
+                        }
+
+                        using (timeline.Measure("交易一提交"))
+                        {
+                            if (setupTransaction.Commit() != TransactionStatus.Committed)
+                            {
+                                throw new InvalidOperationException("建立整地設計副本交易未能提交。");
+                            }
+                        }
+                    }
+
+                    using (var gradingTransaction = new Transaction(doc, "套用樓板投影並計算挖填方"))
+                    {
+                        if (gradingTransaction.Start() != TransactionStatus.Started)
+                        {
+                            throw new InvalidOperationException("無法啟動套用樓板投影交易。");
+                        }
+
+                        modifiedPointCount = adapter.ApplyFootprintOnly(doc, design, footprints);
+                        using (timeline.Measure("整地後重生"))
+                        {
+                            doc.Regenerate();
+                        }
+
+                        using (timeline.Measure("CUT/FILL 讀取"))
+                        {
+                            (cutCubicMeters, fillCubicMeters) = adapter.ReadCutFill(design);
+                        }
+
+                        using (timeline.Measure("交易二提交"))
+                        {
+                            if (gradingTransaction.Commit() != TransactionStatus.Committed)
+                            {
+                                throw new InvalidOperationException("套用樓板投影交易未能提交。");
+                            }
+                        }
+                    }
+
+                    using (timeline.Measure("交易群組彙整"))
+                    {
+                        if (group.Assimilate() != TransactionStatus.Committed)
+                        {
+                            throw new InvalidOperationException("樓板投影整地交易群組未能完整提交。");
+                        }
+                    }
+                }
+                catch (Exception exception)
+                {
+                    if (group.GetStatus() == TransactionStatus.Started)
+                    {
+                        group.RollBack();
+                    }
+
+                    // 失敗也要留下效能與原因記錄，供逐次修正。
+                    WriteGradingPerformanceRecord(new
+                    {
+                        Timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"),
+                        Document = doc.Title,
+                        Success = false,
+                        Error = exception.Message,
+                        request.ToposolidId,
+                        FloorIds = request.FloorIds,
+                        TotalMilliseconds = stopwatch.ElapsedMilliseconds,
+                        Stages = timeline.Stages
+                            .Select(stage => new { stage.Name, stage.ElapsedMilliseconds })
+                            .ToArray()
+                    });
+
+                    throw;
+                }
+            }
+
+            var result = new GradingResult
+            {
+                OriginalToposolidId = request.ToposolidId,
+                DesignToposolidId = design.Id.GetIdValue(),
+                FloorIds = request.FloorIds,
+                CutCubicMeters = cutCubicMeters,
+                FillCubicMeters = fillCubicMeters,
+                ModifiedPointCount = modifiedPointCount,
+                AssociationId = associationId,
+                Warnings = new string[0]
+            };
+
+            var timing = new
+            {
+                TotalMilliseconds = stopwatch.ElapsedMilliseconds,
+                Stages = timeline.Stages
+                    .Select(stage => new { stage.Name, stage.ElapsedMilliseconds })
+                    .ToArray()
+            };
+
+            WriteGradingPerformanceRecord(new
+            {
+                Timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss"),
+                Document = doc.Title,
+                Success = true,
+                Error = (string)null,
+                request.ToposolidId,
+                FloorIds = request.FloorIds,
+                DesignToposolidId = result.DesignToposolidId,
+                result.ModifiedPointCount,
+                result.CutCubicMeters,
+                result.FillCubicMeters,
+                Timing = timing
+            });
+
+            return new
+            {
+                result.OriginalToposolidId,
+                result.DesignToposolidId,
+                result.FloorIds,
+                result.CutCubicMeters,
+                result.FillCubicMeters,
+                result.NetCubicMeters,
+                result.ModifiedPointCount,
+                result.AssociationId,
+                result.Warnings,
+                Timing = timing,
+                Message = "樓板投影整地完成。"
+            };
+        }
+
+        /// <summary>
+        /// 附加一筆整地效能記錄至 %APPDATA%\RevitMCP\grading-performance.jsonl。
+        /// 記錄僅供優化參考，寫入失敗不得影響整地流程。
+        /// </summary>
+        private static void WriteGradingPerformanceRecord(object record)
+        {
+            try
+            {
+                var directory = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                    "RevitMCP");
+                Directory.CreateDirectory(directory);
+                File.AppendAllText(
+                    Path.Combine(directory, "grading-performance.jsonl"),
+                    JsonConvert.SerializeObject(record) + Environment.NewLine);
+            }
+            catch
+            {
+            }
+        }
+    }
+}
+#endif

--- a/MCP/Core/Grading/GradingModels.cs
+++ b/MCP/Core/Grading/GradingModels.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace RevitMCP.Core.Grading
+{
+    public struct Point2D
+    {
+        public Point2D(double x, double y) { X = x; Y = y; }
+        public double X { get; }
+        public double Y { get; }
+    }
+
+    public sealed class GradingRequest
+    {
+        public long ToposolidId { get; set; }
+        public IReadOnlyList<long> FloorIds { get; set; }
+        public string Mode { get; set; }
+        public string TargetFace { get; set; }
+        public bool AllowPhaseSetup { get; set; }
+        public bool UpdateExisting { get; set; }
+
+        public void Validate()
+        {
+            if (ToposolidId <= 0) throw new ArgumentException("地形 ID 必須大於 0。");
+            if (FloorIds == null || FloorIds.Count == 0) throw new ArgumentException("至少一片樓板才能執行整地。");
+            if (FloorIds.Any(id => id <= 0)) throw new ArgumentException("樓板 ID 必須大於 0。");
+            if (!string.Equals(Mode, "footprint_only", StringComparison.OrdinalIgnoreCase))
+                throw new ArgumentException("本次試跑僅支援 footprint_only。");
+            if (!string.Equals(TargetFace, "bottom", StringComparison.OrdinalIgnoreCase))
+                throw new ArgumentException("本次試跑僅支援樓板底面 bottom。");
+            if (UpdateExisting)
+                throw new ArgumentException("本次試跑尚未支援 updateExisting=true。");
+        }
+    }
+
+    public sealed class FloorFootprint
+    {
+        public long FloorId { get; set; }
+        public IReadOnlyList<Point2D> OuterLoop { get; set; }
+        public Func<double, double, double> BottomElevationAt { get; set; }
+    }
+
+    /// <summary>整地執行的單一階段耗時。</summary>
+    public sealed class GradingStage
+    {
+        public GradingStage(string name, long elapsedMilliseconds)
+        {
+            Name = name;
+            ElapsedMilliseconds = elapsedMilliseconds;
+        }
+
+        public string Name { get; }
+        public long ElapsedMilliseconds { get; }
+    }
+
+    /// <summary>整地執行的分段計時，供效能記錄與逐步優化使用。</summary>
+    public sealed class GradingTimeline
+    {
+        private readonly List<GradingStage> _stages = new List<GradingStage>();
+
+        public IReadOnlyList<GradingStage> Stages => _stages;
+
+        public IDisposable Measure(string name)
+        {
+            return new StageScope(this, name);
+        }
+
+        public void Record(string name, long elapsedMilliseconds)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("階段名稱不可空白。", nameof(name));
+            }
+
+            _stages.Add(new GradingStage(name, elapsedMilliseconds < 0 ? 0 : elapsedMilliseconds));
+        }
+
+        private sealed class StageScope : IDisposable
+        {
+            private readonly GradingTimeline _timeline;
+            private readonly string _name;
+            private readonly Stopwatch _stopwatch = Stopwatch.StartNew();
+            private bool _disposed;
+
+            public StageScope(GradingTimeline timeline, string name)
+            {
+                _timeline = timeline;
+                _name = name;
+            }
+
+            public void Dispose()
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                _timeline.Record(_name, _stopwatch.ElapsedMilliseconds);
+            }
+        }
+    }
+
+    public sealed class GradingResult
+    {
+        public long OriginalToposolidId { get; set; }
+        public long DesignToposolidId { get; set; }
+        public IReadOnlyList<long> FloorIds { get; set; }
+        public double CutCubicMeters { get; set; }
+        public double FillCubicMeters { get; set; }
+        public double NetCubicMeters => FillCubicMeters - CutCubicMeters;
+        public int ModifiedPointCount { get; set; }
+        public string AssociationId { get; set; }
+        public IReadOnlyList<string> Warnings { get; set; }
+    }
+}

--- a/MCP/Core/Grading/Polygon2D.cs
+++ b/MCP/Core/Grading/Polygon2D.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections.Generic;
+
+namespace RevitMCP.Core.Grading
+{
+    public static class Polygon2D
+    {
+        public static bool Contains(
+            IReadOnlyList<Point2D> polygon,
+            Point2D point,
+            double tolerance)
+        {
+            if (polygon == null || polygon.Count < 3)
+            {
+                return false;
+            }
+
+            tolerance = Math.Abs(tolerance);
+            if (IsOnBoundary(polygon, point, tolerance))
+            {
+                return true;
+            }
+
+            var inside = false;
+            for (var i = 0; i < polygon.Count; i++)
+            {
+                var start = polygon[i];
+                var end = polygon[(i + 1) % polygon.Count];
+                var crossesRay = (start.Y > point.Y) != (end.Y > point.Y);
+                if (!crossesRay)
+                {
+                    continue;
+                }
+
+                var intersectionX = start.X
+                    + ((point.Y - start.Y) * (end.X - start.X) / (end.Y - start.Y));
+                if (point.X < intersectionX)
+                {
+                    inside = !inside;
+                }
+            }
+
+            return inside;
+        }
+
+        public static bool Overlaps(
+            IReadOnlyList<Point2D> first,
+            IReadOnlyList<Point2D> second,
+            double tolerance)
+        {
+            if (first == null || second == null || first.Count < 3 || second.Count < 3)
+            {
+                return false;
+            }
+
+            tolerance = Math.Abs(tolerance);
+            var firstWinding = Math.Sign(SignedArea(first));
+            var secondWinding = Math.Sign(SignedArea(second));
+            for (var firstIndex = 0; firstIndex < first.Count; firstIndex++)
+            {
+                var firstStart = first[firstIndex];
+                var firstEnd = first[(firstIndex + 1) % first.Count];
+
+                for (var secondIndex = 0; secondIndex < second.Count; secondIndex++)
+                {
+                    var secondStart = second[secondIndex];
+                    var secondEnd = second[(secondIndex + 1) % second.Count];
+                    if (StrictlyIntersects(
+                        firstStart,
+                        firstEnd,
+                        secondStart,
+                        secondEnd,
+                        tolerance))
+                    {
+                        return true;
+                    }
+
+                    if (HasCollinearOverlapOnSameInteriorSide(
+                        firstStart,
+                        firstEnd,
+                        secondStart,
+                        secondEnd,
+                        firstWinding,
+                        secondWinding,
+                        tolerance))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return HasStrictlyContainedVertex(first, second, tolerance)
+                || HasStrictlyContainedVertex(second, first, tolerance);
+        }
+
+        private static bool HasStrictlyContainedVertex(
+            IReadOnlyList<Point2D> candidateVertices,
+            IReadOnlyList<Point2D> polygon,
+            double tolerance)
+        {
+            for (var i = 0; i < candidateVertices.Count; i++)
+            {
+                var candidate = candidateVertices[i];
+                if (!IsOnBoundary(polygon, candidate, tolerance)
+                    && Contains(polygon, candidate, tolerance))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool HasCollinearOverlapOnSameInteriorSide(
+            Point2D firstStart,
+            Point2D firstEnd,
+            Point2D secondStart,
+            Point2D secondEnd,
+            int firstWinding,
+            int secondWinding,
+            double tolerance)
+        {
+            var firstLength = Distance(firstStart, firstEnd);
+            var secondLength = Distance(secondStart, secondEnd);
+            if (firstLength == 0 || secondLength == 0 || firstWinding == 0 || secondWinding == 0)
+            {
+                return false;
+            }
+
+            if (Math.Abs(Cross(firstStart, firstEnd, secondStart)) > tolerance * firstLength
+                || Math.Abs(Cross(firstStart, firstEnd, secondEnd)) > tolerance * firstLength)
+            {
+                return false;
+            }
+
+            var firstDirectionX = (firstEnd.X - firstStart.X) / firstLength;
+            var firstDirectionY = (firstEnd.Y - firstStart.Y) / firstLength;
+            var secondStartProjection = ((secondStart.X - firstStart.X) * firstDirectionX)
+                + ((secondStart.Y - firstStart.Y) * firstDirectionY);
+            var secondEndProjection = ((secondEnd.X - firstStart.X) * firstDirectionX)
+                + ((secondEnd.Y - firstStart.Y) * firstDirectionY);
+            var overlapLength = Math.Min(firstLength, Math.Max(secondStartProjection, secondEndProjection))
+                - Math.Max(0, Math.Min(secondStartProjection, secondEndProjection));
+            if (overlapLength <= tolerance)
+            {
+                return false;
+            }
+
+            var secondDirectionX = (secondEnd.X - secondStart.X) / secondLength;
+            var secondDirectionY = (secondEnd.Y - secondStart.Y) / secondLength;
+            var interiorNormalDot = firstWinding * secondWinding
+                * ((firstDirectionX * secondDirectionX) + (firstDirectionY * secondDirectionY));
+            return interiorNormalDot > 0;
+        }
+
+        private static bool IsOnBoundary(
+            IReadOnlyList<Point2D> polygon,
+            Point2D point,
+            double tolerance)
+        {
+            for (var i = 0; i < polygon.Count; i++)
+            {
+                if (IsOnSegment(
+                    polygon[i],
+                    polygon[(i + 1) % polygon.Count],
+                    point,
+                    tolerance))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsOnSegment(
+            Point2D start,
+            Point2D end,
+            Point2D point,
+            double tolerance)
+        {
+            var deltaX = end.X - start.X;
+            var deltaY = end.Y - start.Y;
+            var lengthSquared = (deltaX * deltaX) + (deltaY * deltaY);
+            if (lengthSquared == 0)
+            {
+                return DistanceSquared(start, point) <= tolerance * tolerance;
+            }
+
+            var projection = ((point.X - start.X) * deltaX + (point.Y - start.Y) * deltaY)
+                / lengthSquared;
+            var projectionTolerance = tolerance / Math.Sqrt(lengthSquared);
+            if (projection < -projectionTolerance || projection > 1 + projectionTolerance)
+            {
+                return false;
+            }
+
+            var cross = Cross(start, end, point);
+            return Math.Abs(cross) <= tolerance * Math.Sqrt(lengthSquared);
+        }
+
+        private static bool StrictlyIntersects(
+            Point2D firstStart,
+            Point2D firstEnd,
+            Point2D secondStart,
+            Point2D secondEnd,
+            double tolerance)
+        {
+            var firstLength = Distance(firstStart, firstEnd);
+            var secondLength = Distance(secondStart, secondEnd);
+            if (firstLength == 0 || secondLength == 0)
+            {
+                return false;
+            }
+
+            var secondStartSide = Cross(firstStart, firstEnd, secondStart);
+            var secondEndSide = Cross(firstStart, firstEnd, secondEnd);
+            var firstStartSide = Cross(secondStart, secondEnd, firstStart);
+            var firstEndSide = Cross(secondStart, secondEnd, firstEnd);
+
+            return AreOnStrictOppositeSides(secondStartSide, secondEndSide, tolerance * firstLength)
+                && AreOnStrictOppositeSides(firstStartSide, firstEndSide, tolerance * secondLength);
+        }
+
+        private static bool AreOnStrictOppositeSides(double first, double second, double threshold)
+        {
+            return (first > threshold && second < -threshold)
+                || (first < -threshold && second > threshold);
+        }
+
+        private static double Cross(Point2D start, Point2D end, Point2D point)
+        {
+            return ((end.X - start.X) * (point.Y - start.Y))
+                - ((end.Y - start.Y) * (point.X - start.X));
+        }
+
+        private static double Distance(Point2D first, Point2D second)
+        {
+            return Math.Sqrt(DistanceSquared(first, second));
+        }
+
+        private static double DistanceSquared(Point2D first, Point2D second)
+        {
+            var deltaX = second.X - first.X;
+            var deltaY = second.Y - first.Y;
+            return (deltaX * deltaX) + (deltaY * deltaY);
+        }
+
+        private static double SignedArea(IReadOnlyList<Point2D> polygon)
+        {
+            var doubledArea = 0.0;
+            for (var i = 0; i < polygon.Count; i++)
+            {
+                var current = polygon[i];
+                var next = polygon[(i + 1) % polygon.Count];
+                doubledArea += (current.X * next.Y) - (next.X * current.Y);
+            }
+
+            return doubledArea / 2.0;
+        }
+    }
+}

--- a/MCP/Core/Grading/RevitToposolidGradingAdapter.cs
+++ b/MCP/Core/Grading/RevitToposolidGradingAdapter.cs
@@ -1,0 +1,1186 @@
+#if REVIT2024_OR_GREATER
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.DB.ExtensibleStorage;
+
+namespace RevitMCP.Core.Grading
+{
+    internal interface IToposolidGradingAdapter
+    {
+        Toposolid ValidateToposolid(Document doc, long id);
+        IReadOnlyList<Floor> ValidateFloors(Document doc, IReadOnlyList<long> ids);
+        IReadOnlyList<FloorFootprint> ExtractBottomFootprints(IReadOnlyList<Floor> floors);
+        Toposolid CreateDesignCopy(Document doc, Toposolid original, bool allowPhaseSetup);
+        string WriteAssociation(Document doc, Toposolid design, long originalId, IReadOnlyList<long> floorIds);
+        int ApplyFootprintOnly(Document doc, Toposolid design, IReadOnlyList<FloorFootprint> footprints);
+        (double cutCubicMeters, double fillCubicMeters) ReadCutFill(Toposolid design);
+    }
+
+    internal sealed class RevitToposolidGradingAdapter : IToposolidGradingAdapter
+    {
+        private const string AbsoluteFinishUnavailableMessage =
+            "Revit 2024 公開 API 無法可靠設定此 Toposolid 的絕對完成面";
+        private const int MaximumCurveSubdivisionDepth = 32;
+        private const int MaximumDiscretizedPointCount = 100000;
+        private const double ChordLengthToleranceFactor = 1e-9;
+
+        // 底面法向量 Z 分量上限：-cos(15°)。允許至約 15 度（約 1:3.7）的斜板底面，仍排除側面與頂面。
+        private const double BottomFaceNormalZMaximum = -0.965925826289068;
+
+        private static readonly Guid AssociationSchemaGuid =
+            new Guid("9B4B16C7-4C9C-4B73-9D13-B44F88650D29");
+
+        private readonly GradingTimeline _timeline;
+
+        public RevitToposolidGradingAdapter()
+            : this(null)
+        {
+        }
+
+        public RevitToposolidGradingAdapter(GradingTimeline timeline)
+        {
+            _timeline = timeline ?? new GradingTimeline();
+        }
+
+        public Toposolid ValidateToposolid(Document doc, long id)
+        {
+            if (doc == null)
+            {
+                throw new ArgumentNullException(nameof(doc));
+            }
+
+            var element = doc.GetElement(new ElementId(CheckedElementId(id)));
+            if (!(element is Toposolid toposolid))
+            {
+                throw new InvalidOperationException($"元素 ID {id} 不是 Toposolid。");
+            }
+
+            return toposolid;
+        }
+
+        public IReadOnlyList<Floor> ValidateFloors(Document doc, IReadOnlyList<long> ids)
+        {
+            if (doc == null)
+            {
+                throw new ArgumentNullException(nameof(doc));
+            }
+
+            if (ids == null || ids.Count == 0)
+            {
+                throw new ArgumentException("至少需要一個樓板 ID。", nameof(ids));
+            }
+
+            var floors = new List<Floor>(ids.Count);
+            foreach (var id in ids)
+            {
+                var element = doc.GetElement(new ElementId(CheckedElementId(id)));
+                if (!(element is Floor floor))
+                {
+                    throw new InvalidOperationException($"元素 ID {id} 不是 Floor。");
+                }
+
+                floors.Add(floor);
+            }
+
+            return floors;
+        }
+
+        public IReadOnlyList<FloorFootprint> ExtractBottomFootprints(IReadOnlyList<Floor> floors)
+        {
+            if (floors == null)
+            {
+                throw new ArgumentNullException(nameof(floors));
+            }
+
+            var footprints = new List<FloorFootprint>(floors.Count);
+            foreach (var floor in floors)
+            {
+                if (floor == null)
+                {
+                    throw new ArgumentException("樓板集合不可包含 null。", nameof(floors));
+                }
+
+                footprints.Add(ExtractBottomFootprint(floor));
+            }
+
+            return footprints;
+        }
+
+        public Toposolid CreateDesignCopy(Document doc, Toposolid original, bool allowPhaseSetup)
+        {
+            EnsureModifiable(doc);
+            if (original == null || !doc.Equals(original.Document))
+            {
+                throw new ArgumentException("原始 Toposolid 必須屬於指定文件。", nameof(original));
+            }
+
+            var currentPhase = GetCurrentPhase(doc);
+            var phases = doc.Phases;
+            var currentPhaseIndex = FindPhaseIndex(phases, currentPhase.Id);
+            if (currentPhaseIndex < 0)
+            {
+                throw new InvalidOperationException("目前視圖階段不在文件的階段清單中。");
+            }
+
+            var originalCreated = RequirePhaseParameter(original, BuiltInParameter.PHASE_CREATED, "建立階段");
+            var originalDemolished = RequirePhaseParameter(original, BuiltInParameter.PHASE_DEMOLISHED, "拆除階段");
+            var originalCreatedIndex = FindPhaseIndex(phases, originalCreated.AsElementId());
+            var needsEarlierCreatedPhase = originalCreatedIndex < 0 || originalCreatedIndex >= currentPhaseIndex;
+            var needsCurrentDemolishedPhase = originalDemolished.AsElementId() != currentPhase.Id;
+
+            if ((needsEarlierCreatedPhase || needsCurrentDemolishedPhase) && !allowPhaseSetup)
+            {
+                throw new InvalidOperationException(
+                    "原始 Toposolid 必須在較早階段建立並於目前階段拆除；請允許階段設定後再執行。");
+            }
+
+            if (needsEarlierCreatedPhase)
+            {
+                if (currentPhaseIndex == 0)
+                {
+                    throw new InvalidOperationException("目前階段之前沒有可供原始 Toposolid 使用的較早階段。");
+                }
+
+                SetPhaseParameter(originalCreated, phases.get_Item(currentPhaseIndex - 1).Id, "原始 Toposolid 建立階段");
+            }
+
+            if (needsCurrentDemolishedPhase)
+            {
+                SetPhaseParameter(originalDemolished, currentPhase.Id, "原始 Toposolid 拆除階段");
+            }
+
+            var copiedIds = ElementTransformUtils.CopyElement(doc, original.Id, XYZ.Zero);
+            var copiedToposolids = copiedIds
+                .Select(id => doc.GetElement(id))
+                .OfType<Toposolid>()
+                .ToList();
+            if (copiedToposolids.Count != 1)
+            {
+                throw new InvalidOperationException("複製原始 Toposolid 後未取得唯一的設計 Toposolid。");
+            }
+
+            var design = copiedToposolids[0];
+            var designCreated = RequirePhaseParameter(design, BuiltInParameter.PHASE_CREATED, "建立階段");
+            var designDemolished = RequirePhaseParameter(design, BuiltInParameter.PHASE_DEMOLISHED, "拆除階段");
+            SetPhaseParameter(designDemolished, ElementId.InvalidElementId, "設計 Toposolid 拆除階段");
+            SetPhaseParameter(designCreated, currentPhase.Id, "設計 Toposolid 建立階段");
+
+            doc.Regenerate();
+            if (design.SketchId == ElementId.InvalidElementId)
+            {
+                throw new InvalidOperationException("設計 Toposolid 沒有有效的 SketchId。");
+            }
+
+            var editor = design.GetSlabShapeEditor();
+            if (editor == null || !editor.IsValidObject)
+            {
+                throw new InvalidOperationException("設計 Toposolid 沒有有效的 SlabShapeEditor。");
+            }
+
+            return design;
+        }
+
+        public string WriteAssociation(
+            Document doc,
+            Toposolid design,
+            long originalId,
+            IReadOnlyList<long> floorIds)
+        {
+            EnsureModifiable(doc);
+            if (design == null || !doc.Equals(design.Document))
+            {
+                throw new ArgumentException("設計 Toposolid 必須屬於指定文件。", nameof(design));
+            }
+
+            if (floorIds == null)
+            {
+                throw new ArgumentNullException(nameof(floorIds));
+            }
+
+            var schema = GetOrCreateAssociationSchema();
+            EnsureAssociationSchema(schema);
+            var associationId = Guid.NewGuid().ToString("D", CultureInfo.InvariantCulture);
+            var entity = new Entity(schema);
+            entity.Set("AssociationId", associationId);
+            entity.Set("OriginalToposolidId", originalId);
+            entity.Set(
+                "FloorIds",
+                string.Join(",", floorIds.Select(id => id.ToString(CultureInfo.InvariantCulture))));
+            design.SetEntity(entity);
+            return associationId;
+        }
+
+        public int ApplyFootprintOnly(
+            Document doc,
+            Toposolid design,
+            IReadOnlyList<FloorFootprint> footprints)
+        {
+            EnsureModifiable(doc);
+            if (design == null || !doc.Equals(design.Document))
+            {
+                throw new ArgumentException("設計 Toposolid 必須屬於指定文件。", nameof(design));
+            }
+
+            if (footprints == null || footprints.Count == 0)
+            {
+                throw new ArgumentException("至少需要一個樓板投影。", nameof(footprints));
+            }
+
+            var editor = design.GetSlabShapeEditor();
+            if (editor == null || !editor.IsValidObject)
+            {
+                throw new InvalidOperationException("設計 Toposolid 沒有有效的 SlabShapeEditor。");
+            }
+
+            var xyTolerance = UnitUtils.ConvertToInternalUnits(1.0, UnitTypeId.Millimeters);
+            var elevationTolerance = UnitUtils.ConvertToInternalUnits(2.0, UnitTypeId.Millimeters);
+            using (_timeline.Measure("重疊衝突檢查"))
+            {
+                EnsureNoConflictingOverlaps(footprints, xyTolerance, elevationTolerance);
+            }
+
+            if (!editor.IsEnabled)
+            {
+                using (_timeline.Measure("形狀編輯器啟用"))
+                {
+                    editor.Enable();
+                    doc.Regenerate();
+                }
+            }
+
+            // 現況地形頂面 Z 以垂直射線與設計副本實體求交；必須在任何形狀修改前取樣。
+            IReadOnlyList<Solid> solids;
+            BoundingBoxXYZ boundingBox;
+            List<XYZ> existingPositions;
+            using (_timeline.Measure("現況幾何擷取"))
+            {
+                solids = CollectSolids(design);
+                boundingBox = design.get_BoundingBox(null);
+                existingPositions = CollectVertexPositions(editor);
+            }
+
+            if (solids.Count == 0)
+            {
+                throw new InvalidOperationException("設計 Toposolid 沒有可用的實體幾何。");
+            }
+
+            if (boundingBox == null)
+            {
+                throw new InvalidOperationException("設計 Toposolid 沒有有效的範圍盒。");
+            }
+
+            var rayBottomZ = boundingBox.Min.Z - 10.0;
+            var rayTopZ = boundingBox.Max.Z + 10.0;
+            var pointsToAdd = new List<XYZ>();
+            var boundarySampleScope = _timeline.Measure("邊界射線取樣");
+            foreach (var footprint in footprints)
+            {
+                var terrainHitCount = 0;
+                foreach (var boundaryPoint in footprint.OuterLoop)
+                {
+                    var terrainZ = IntersectTerrainTopZ(solids, boundaryPoint, rayBottomZ, rayTopZ);
+                    if (!terrainZ.HasValue)
+                    {
+                        // 規格規則 7：投影超出地形的部分僅處理相交區域。
+                        continue;
+                    }
+
+                    terrainHitCount++;
+                    var candidate = new XYZ(boundaryPoint.X, boundaryPoint.Y, terrainZ.Value);
+                    if (HasNearbyXY(existingPositions, candidate, xyTolerance)
+                        || HasNearbyXY(pointsToAdd, candidate, xyTolerance))
+                    {
+                        continue;
+                    }
+
+                    pointsToAdd.Add(candidate);
+                }
+
+                if (terrainHitCount == 0
+                    && !existingPositions.Any(position => Polygon2D.Contains(
+                        footprint.OuterLoop,
+                        ToPoint2D(position),
+                        xyTolerance)))
+                {
+                    throw new InvalidOperationException(
+                        $"樓板 ID {footprint.FloorId} 的投影範圍完全不與地形相交。");
+                }
+            }
+
+            boundarySampleScope.Dispose();
+
+            if (pointsToAdd.Count > 0)
+            {
+                using (_timeline.Measure("邊界點加入與重生"))
+                {
+                    EnsurePointLimit(existingPositions.Count + pointsToAdd.Count);
+                    editor.AddPoints(pointsToAdd);
+                    doc.Regenerate();
+                }
+            }
+
+            // 邊界摺線：以分割線把樓板邊界刻成網格稜線，邊界內外的三角形都止於邊界，
+            // 杜絕外部高處地形的三角形跨越樓板上空。
+            using (_timeline.Measure("邊界摺線"))
+            {
+                DrawBoundarySplitLines(editor, footprints, xyTolerance);
+                doc.Regenerate();
+            }
+
+            // 分類全部頂點：XY 位於樓板投影內或邊界上者，目標高程為該處樓板底面。
+            var targets = new List<VertexTarget>();
+            var classifyScope = _timeline.Measure("頂點分類");
+            foreach (var position in CollectVertexPositions(editor))
+            {
+                double? targetZ = null;
+                foreach (var footprint in footprints)
+                {
+                    if (!Polygon2D.Contains(footprint.OuterLoop, ToPoint2D(position), xyTolerance))
+                    {
+                        continue;
+                    }
+
+                    var bottomZ = footprint.BottomElevationAt(position.X, position.Y);
+                    if (targetZ.HasValue && Math.Abs(targetZ.Value - bottomZ) > elevationTolerance)
+                    {
+                        throw new InvalidOperationException("樓板投影重疊且目標高程衝突，已中止整地。");
+                    }
+
+                    targetZ = targetZ ?? bottomZ;
+                }
+
+                if (targetZ.HasValue)
+                {
+                    targets.Add(new VertexTarget(position, targetZ.Value));
+                }
+            }
+
+            classifyScope.Dispose();
+
+            if (targets.Count == 0)
+            {
+                throw new InvalidOperationException("樓板投影範圍內沒有可修改的地形控制點。");
+            }
+
+            // 兩段式校準：先寫入 offset 0 讀回基準 Z，再寫入目標差值。
+            // 無論 ModifySubElement 的 offset 是絕對或增量語意，最終高程都收斂到目標值，
+            // 不猜測參考平面高程；偏差由下方 2 mm 驗收閘門把關。
+            using (_timeline.Measure("校準寫入第一輪"))
+            {
+                ApplyVertexOffsets(doc, editor, targets.Select(target => (target.Position, 0.0)).ToList());
+            }
+
+            double[] baselineZ;
+            using (_timeline.Measure("基準高程讀取"))
+            {
+                baselineZ = ReadVertexElevations(editor, targets);
+            }
+
+            using (_timeline.Measure("校準寫入第二輪"))
+            {
+                ApplyVertexOffsets(
+                    doc,
+                    editor,
+                    targets.Select((target, index) => (target.Position, target.TargetZ - baselineZ[index])).ToList());
+            }
+
+            using (_timeline.Measure("驗收檢查"))
+            {
+                var finalZ = ReadVertexElevations(editor, targets);
+                for (var index = 0; index < targets.Count; index++)
+                {
+                    if (Math.Abs(finalZ[index] - targets[index].TargetZ) > elevationTolerance)
+                    {
+                        throw new InvalidOperationException(AbsoluteFinishUnavailableMessage);
+                    }
+                }
+            }
+
+            // 表面抽樣驗收：控制點正確不代表點間表面正確，
+            // 以網格射線抽樣投影內實際表面，偏離板底超過 2 mm 即回滾。
+            using (_timeline.Measure("表面抽樣驗收"))
+            {
+                VerifySurfaceAgainstFootprints(
+                    design,
+                    footprints,
+                    elevationTolerance,
+                    xyTolerance,
+                    rayBottomZ,
+                    rayTopZ);
+            }
+
+            return targets.Count;
+        }
+
+        private readonly struct VertexTarget
+        {
+            public VertexTarget(XYZ position, double targetZ)
+            {
+                Position = position;
+                TargetZ = targetZ;
+            }
+
+            public XYZ Position { get; }
+            public double TargetZ { get; }
+        }
+
+        // 頂點在 AddPoints 或重新生成後可能有極小的 XY 位移，比對採 10 mm 容差。
+        private static double VertexMatchTolerance =>
+            UnitUtils.ConvertToInternalUnits(10.0, UnitTypeId.Millimeters);
+
+        private static void EnsureNoConflictingOverlaps(
+            IReadOnlyList<FloorFootprint> footprints,
+            double xyTolerance,
+            double elevationTolerance)
+        {
+            for (var firstIndex = 0; firstIndex < footprints.Count; firstIndex++)
+            {
+                for (var secondIndex = firstIndex + 1; secondIndex < footprints.Count; secondIndex++)
+                {
+                    var first = footprints[firstIndex];
+                    var second = footprints[secondIndex];
+                    if (!Polygon2D.Overlaps(first.OuterLoop, second.OuterLoop, xyTolerance))
+                    {
+                        continue;
+                    }
+
+                    if (HasConflictingElevation(first, second, xyTolerance, elevationTolerance)
+                        || HasConflictingElevation(second, first, xyTolerance, elevationTolerance))
+                    {
+                        throw new InvalidOperationException(
+                            $"樓板 ID {first.FloorId} 與 {second.FloorId} 的投影重疊且底面高程不同，請先處理衝突。");
+                    }
+                }
+            }
+        }
+
+        private static bool HasConflictingElevation(
+            FloorFootprint sampled,
+            FloorFootprint other,
+            double xyTolerance,
+            double elevationTolerance)
+        {
+            foreach (var point in sampled.OuterLoop)
+            {
+                if (!Polygon2D.Contains(other.OuterLoop, point, xyTolerance))
+                {
+                    continue;
+                }
+
+                var sampledZ = sampled.BottomElevationAt(point.X, point.Y);
+                var otherZ = other.BottomElevationAt(point.X, point.Y);
+                if (Math.Abs(sampledZ - otherZ) > elevationTolerance)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static IReadOnlyList<Solid> CollectSolids(Toposolid toposolid)
+        {
+            var solids = new List<Solid>();
+            var geometry = toposolid.get_Geometry(new Options());
+            if (geometry != null)
+            {
+                foreach (var geometryObject in geometry)
+                {
+                    if (geometryObject is Solid solid && solid.Volume > 0)
+                    {
+                        solids.Add(solid);
+                    }
+                }
+            }
+
+            return solids;
+        }
+
+        private static double? IntersectTerrainTopZ(
+            IReadOnlyList<Solid> solids,
+            Point2D point,
+            double rayBottomZ,
+            double rayTopZ)
+        {
+            var ray = Line.CreateBound(
+                new XYZ(point.X, point.Y, rayBottomZ),
+                new XYZ(point.X, point.Y, rayTopZ));
+            var options = new SolidCurveIntersectionOptions
+            {
+                ResultType = SolidCurveIntersectionMode.CurveSegmentsInside
+            };
+
+            double? topZ = null;
+            foreach (var solid in solids)
+            {
+                var intersection = solid.IntersectWithCurve(ray, options);
+                if (intersection == null)
+                {
+                    continue;
+                }
+
+                for (var index = 0; index < intersection.SegmentCount; index++)
+                {
+                    var segment = intersection.GetCurveSegment(index);
+                    var segmentTopZ = Math.Max(segment.GetEndPoint(0).Z, segment.GetEndPoint(1).Z);
+                    topZ = topZ.HasValue ? Math.Max(topZ.Value, segmentTopZ) : segmentTopZ;
+                }
+            }
+
+            return topZ;
+        }
+
+        private static List<XYZ> CollectVertexPositions(SlabShapeEditor editor)
+        {
+            var positions = new List<XYZ>();
+            foreach (SlabShapeVertex vertex in editor.SlabShapeVertices)
+            {
+                if (vertex != null && vertex.IsValidObject)
+                {
+                    positions.Add(vertex.Position);
+                }
+            }
+
+            return positions;
+        }
+
+        private static bool HasNearbyXY(IReadOnlyList<XYZ> points, XYZ candidate, double tolerance)
+        {
+            var toleranceSquared = tolerance * tolerance;
+            foreach (var point in points)
+            {
+                if (XYDistanceSquared(point, candidate) <= toleranceSquared)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static double XYDistanceSquared(XYZ first, XYZ second)
+        {
+            var deltaX = second.X - first.X;
+            var deltaY = second.Y - first.Y;
+            return deltaX * deltaX + deltaY * deltaY;
+        }
+
+        private static void ApplyVertexOffsets(
+            Document doc,
+            SlabShapeEditor editor,
+            IReadOnlyList<(XYZ Position, double Offset)> entries)
+        {
+            var vertices = new List<SlabShapeVertex>();
+            foreach (SlabShapeVertex vertex in editor.SlabShapeVertices)
+            {
+                if (vertex != null && vertex.IsValidObject)
+                {
+                    vertices.Add(vertex);
+                }
+            }
+
+            foreach (var entry in entries)
+            {
+                SlabShapeVertex nearest = null;
+                var nearestDistanceSquared = double.MaxValue;
+                foreach (var vertex in vertices)
+                {
+                    var distanceSquared = XYDistanceSquared(vertex.Position, entry.Position);
+                    if (distanceSquared < nearestDistanceSquared)
+                    {
+                        nearestDistanceSquared = distanceSquared;
+                        nearest = vertex;
+                    }
+                }
+
+                var matchTolerance = VertexMatchTolerance;
+                if (nearest == null || nearestDistanceSquared > matchTolerance * matchTolerance)
+                {
+                    throw new InvalidOperationException(AbsoluteFinishUnavailableMessage);
+                }
+
+                editor.ModifySubElement(nearest, entry.Offset);
+            }
+
+            doc.Regenerate();
+        }
+
+        private static double[] ReadVertexElevations(
+            SlabShapeEditor editor,
+            IReadOnlyList<VertexTarget> targets)
+        {
+            var positions = CollectVertexPositions(editor);
+            var matchTolerance = VertexMatchTolerance;
+            var matchToleranceSquared = matchTolerance * matchTolerance;
+            var elevations = new double[targets.Count];
+            for (var index = 0; index < targets.Count; index++)
+            {
+                XYZ nearest = null;
+                var nearestDistanceSquared = double.MaxValue;
+                foreach (var position in positions)
+                {
+                    var distanceSquared = XYDistanceSquared(position, targets[index].Position);
+                    if (distanceSquared < nearestDistanceSquared)
+                    {
+                        nearestDistanceSquared = distanceSquared;
+                        nearest = position;
+                    }
+                }
+
+                if (nearest == null || nearestDistanceSquared > matchToleranceSquared)
+                {
+                    throw new InvalidOperationException(AbsoluteFinishUnavailableMessage);
+                }
+
+                elevations[index] = nearest.Z;
+            }
+
+            return elevations;
+        }
+
+        private static void DrawBoundarySplitLines(
+            SlabShapeEditor editor,
+            IReadOnlyList<FloorFootprint> footprints,
+            double xyTolerance)
+        {
+            var vertices = new List<SlabShapeVertex>();
+            foreach (SlabShapeVertex vertex in editor.SlabShapeVertices)
+            {
+                if (vertex != null && vertex.IsValidObject)
+                {
+                    vertices.Add(vertex);
+                }
+            }
+
+            var matchTolerance = VertexMatchTolerance;
+            foreach (var footprint in footprints)
+            {
+                var loop = footprint.OuterLoop;
+                for (var index = 0; index < loop.Count; index++)
+                {
+                    var startVertex = FindNearestVertex(vertices, loop[index], matchTolerance);
+                    var endVertex = FindNearestVertex(vertices, loop[(index + 1) % loop.Count], matchTolerance);
+                    if (startVertex == null || endVertex == null)
+                    {
+                        // 邊界點可能因超出地形未建立（規則 7），跳過該段；完整性由表面抽樣驗收把關。
+                        continue;
+                    }
+
+                    if (XYDistanceSquared(startVertex.Position, endVertex.Position) <= xyTolerance * xyTolerance)
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        editor.DrawSplitLine(startVertex, endVertex);
+                    }
+                    catch (Autodesk.Revit.Exceptions.ApplicationException)
+                    {
+                        // 既有摺線或退化線段會被 Revit 拒絕；缺段風險由表面抽樣驗收把關。
+                        continue;
+                    }
+                }
+            }
+        }
+
+        private static SlabShapeVertex FindNearestVertex(
+            IReadOnlyList<SlabShapeVertex> vertices,
+            Point2D point,
+            double matchTolerance)
+        {
+            SlabShapeVertex nearest = null;
+            var nearestDistanceSquared = double.MaxValue;
+            foreach (var vertex in vertices)
+            {
+                var position = vertex.Position;
+                var deltaX = position.X - point.X;
+                var deltaY = position.Y - point.Y;
+                var distanceSquared = deltaX * deltaX + deltaY * deltaY;
+                if (distanceSquared < nearestDistanceSquared)
+                {
+                    nearestDistanceSquared = distanceSquared;
+                    nearest = vertex;
+                }
+            }
+
+            return nearestDistanceSquared <= matchTolerance * matchTolerance ? nearest : null;
+        }
+
+        private static void VerifySurfaceAgainstFootprints(
+            Toposolid design,
+            IReadOnlyList<FloorFootprint> footprints,
+            double elevationTolerance,
+            double xyTolerance,
+            double rayBottomZ,
+            double rayTopZ)
+        {
+            var solids = CollectSolids(design);
+            if (solids.Count == 0)
+            {
+                throw new InvalidOperationException("整地後設計 Toposolid 沒有可用的實體幾何。");
+            }
+
+            var boundaryMargin = UnitUtils.ConvertToInternalUnits(300, UnitTypeId.Millimeters);
+            var sampleStep = UnitUtils.ConvertToInternalUnits(2000, UnitTypeId.Millimeters);
+            foreach (var footprint in footprints)
+            {
+                var loop = footprint.OuterLoop;
+                var minX = double.MaxValue;
+                var minY = double.MaxValue;
+                var maxX = double.MinValue;
+                var maxY = double.MinValue;
+                foreach (var point in loop)
+                {
+                    minX = Math.Min(minX, point.X);
+                    minY = Math.Min(minY, point.Y);
+                    maxX = Math.Max(maxX, point.X);
+                    maxY = Math.Max(maxY, point.Y);
+                }
+
+                for (var x = minX + sampleStep / 2; x <= maxX; x += sampleStep)
+                {
+                    for (var y = minY + sampleStep / 2; y <= maxY; y += sampleStep)
+                    {
+                        var sample = new Point2D(x, y);
+                        if (!Polygon2D.Contains(loop, sample, xyTolerance))
+                        {
+                            continue;
+                        }
+
+                        if (DistanceToBoundary(loop, sample) < boundaryMargin)
+                        {
+                            continue;
+                        }
+
+                        var surfaceZ = IntersectTerrainTopZ(solids, sample, rayBottomZ, rayTopZ);
+                        if (!surfaceZ.HasValue)
+                        {
+                            // 超出地形的投影部分不檢查（規則 7）。
+                            continue;
+                        }
+
+                        var bottomZ = footprint.BottomElevationAt(x, y);
+                        if (Math.Abs(surfaceZ.Value - bottomZ) > elevationTolerance)
+                        {
+                            var deviationMillimeters = UnitUtils.ConvertFromInternalUnits(
+                                Math.Abs(surfaceZ.Value - bottomZ),
+                                UnitTypeId.Millimeters);
+                            throw new InvalidOperationException(
+                                $"樓板 ID {footprint.FloorId} 投影內表面抽樣偏離板底 "
+                                + $"{deviationMillimeters:F1} mm，超過 2 mm 容許，已回滾整地。");
+                        }
+                    }
+                }
+            }
+        }
+
+        private static double DistanceToBoundary(IReadOnlyList<Point2D> loop, Point2D point)
+        {
+            var minDistanceSquared = double.MaxValue;
+            for (var index = 0; index < loop.Count; index++)
+            {
+                var start = loop[index];
+                var end = loop[(index + 1) % loop.Count];
+                var edgeX = end.X - start.X;
+                var edgeY = end.Y - start.Y;
+                var lengthSquared = edgeX * edgeX + edgeY * edgeY;
+                double t = 0;
+                if (lengthSquared > 0)
+                {
+                    t = ((point.X - start.X) * edgeX + (point.Y - start.Y) * edgeY) / lengthSquared;
+                    t = Math.Max(0, Math.Min(1, t));
+                }
+
+                var deltaX = point.X - (start.X + t * edgeX);
+                var deltaY = point.Y - (start.Y + t * edgeY);
+                var distanceSquared = deltaX * deltaX + deltaY * deltaY;
+                if (distanceSquared < minDistanceSquared)
+                {
+                    minDistanceSquared = distanceSquared;
+                }
+            }
+
+            return Math.Sqrt(minDistanceSquared);
+        }
+
+        public (double cutCubicMeters, double fillCubicMeters) ReadCutFill(Toposolid design)
+        {
+            if (design == null)
+            {
+                throw new ArgumentNullException(nameof(design));
+            }
+
+            var cut = ReadVolumeParameter(
+                design,
+                BuiltInParameter.VOLUME_CUT,
+                "CUT");
+            var fill = ReadVolumeParameter(
+                design,
+                BuiltInParameter.VOLUME_FILL,
+                "FILL");
+
+            if (Math.Abs(cut) <= 1e-12 && Math.Abs(fill) <= 1e-12)
+            {
+                throw new InvalidOperationException("Toposolid 幾何變更後 CUT 與 FILL 皆為零，無法通過驗收。");
+            }
+
+            return (
+                UnitUtils.ConvertFromInternalUnits(cut, UnitTypeId.CubicMeters),
+                UnitUtils.ConvertFromInternalUnits(fill, UnitTypeId.CubicMeters));
+        }
+
+        private static FloorFootprint ExtractBottomFootprint(Floor floor)
+        {
+            var geometry = floor.get_Geometry(new Options());
+            var bottomFaces = new List<PlanarFace>();
+            if (geometry != null)
+            {
+                foreach (var geometryObject in geometry)
+                {
+                    if (!(geometryObject is Solid solid) || solid.Volume <= 0)
+                    {
+                        continue;
+                    }
+
+                    foreach (Face face in solid.Faces)
+                    {
+                        if (face is PlanarFace planarFace && planarFace.FaceNormal.Z < BottomFaceNormalZMaximum)
+                        {
+                            bottomFaces.Add(planarFace);
+                        }
+                    }
+                }
+            }
+
+            if (bottomFaces.Count != 1)
+            {
+                throw new InvalidOperationException(
+                    $"樓板 ID {floor.Id.Value} 沒有可用的單一平面底面");
+            }
+
+            var bottomFace = bottomFaces[0];
+            var loops = bottomFace.GetEdgesAsCurveLoops();
+            if (loops == null || loops.Count == 0)
+            {
+                throw new InvalidOperationException(
+                    $"樓板 ID {floor.Id.Value} 沒有可用的單一平面底面");
+            }
+
+            var outerLoop = loops
+                .Select(DiscretizeLoop)
+                .Where(points => points.Count >= 3)
+                .OrderByDescending(points => Math.Abs(SignedArea(points)))
+                .FirstOrDefault();
+            if (outerLoop == null)
+            {
+                throw new InvalidOperationException(
+                    $"樓板 ID {floor.Id.Value} 沒有可用的單一平面底面");
+            }
+
+            var origin = bottomFace.Origin;
+            var normal = bottomFace.FaceNormal;
+            return new FloorFootprint
+            {
+                FloorId = floor.Id.Value,
+                OuterLoop = outerLoop,
+                BottomElevationAt = (x, y) => origin.Z
+                    - ((normal.X * (x - origin.X) + normal.Y * (y - origin.Y)) / normal.Z)
+            };
+        }
+
+        private static IReadOnlyList<Point2D> DiscretizeLoop(CurveLoop loop)
+        {
+            var maximumChordLength = UnitUtils.ConvertToInternalUnits(300, UnitTypeId.Millimeters);
+            var points = new List<Point2D>();
+            foreach (var curve in loop)
+            {
+                if (curve is Line)
+                {
+                    AddDistinctPoint(points, ToPoint2D(curve.GetEndPoint(0)));
+                    AddDistinctPoint(points, ToPoint2D(curve.GetEndPoint(1)));
+                    EnsurePointLimit(points.Count);
+                    continue;
+                }
+
+                var curvePoints = new List<XYZ> { curve.Evaluate(0, true) };
+                AppendAdaptiveCurvePoints(
+                    curve,
+                    0,
+                    curvePoints[0],
+                    1,
+                    curve.Evaluate(1, true),
+                    0,
+                    maximumChordLength,
+                    curvePoints);
+                ValidateChordLengths(curvePoints, maximumChordLength);
+
+                foreach (var curvePoint in curvePoints)
+                {
+                    AddDistinctPoint(points, ToPoint2D(curvePoint));
+                    EnsurePointLimit(points.Count);
+                }
+            }
+
+            if (points.Count > 1 && DistanceSquared(points[0], points[points.Count - 1]) <= 1e-18)
+            {
+                points.RemoveAt(points.Count - 1);
+            }
+
+            return points;
+        }
+
+        private static void AppendAdaptiveCurvePoints(
+            Curve curve,
+            double startParameter,
+            XYZ startPoint,
+            double endParameter,
+            XYZ endPoint,
+            int depth,
+            double maximumChordLength,
+            ICollection<XYZ> points)
+        {
+            var tolerance = maximumChordLength * ChordLengthToleranceFactor;
+            var subcurveLength = GetSubcurveLength(curve, startParameter, endParameter);
+            var chordLength = startPoint.DistanceTo(endPoint);
+            if (subcurveLength <= maximumChordLength + tolerance
+                && chordLength <= maximumChordLength + tolerance)
+            {
+                EnsurePointLimit(points.Count + 1);
+                points.Add(endPoint);
+                return;
+            }
+
+            if (depth >= MaximumCurveSubdivisionDepth)
+            {
+                throw new InvalidOperationException(
+                    $"曲線離散化超過最大遞迴深度 {MaximumCurveSubdivisionDepth}，"
+                    + "無法保證 300 mm 最大弦長。");
+            }
+
+            var middleParameter = (startParameter + endParameter) / 2.0;
+            if (middleParameter <= startParameter || middleParameter >= endParameter)
+            {
+                throw new InvalidOperationException("曲線參數無法繼續細分，無法保證 300 mm 最大弦長。");
+            }
+
+            var middlePoint = curve.Evaluate(middleParameter, true);
+            AppendAdaptiveCurvePoints(
+                curve,
+                startParameter,
+                startPoint,
+                middleParameter,
+                middlePoint,
+                depth + 1,
+                maximumChordLength,
+                points);
+            AppendAdaptiveCurvePoints(
+                curve,
+                middleParameter,
+                middlePoint,
+                endParameter,
+                endPoint,
+                depth + 1,
+                maximumChordLength,
+                points);
+        }
+
+        private static double GetSubcurveLength(
+            Curve curve,
+            double startParameter,
+            double endParameter)
+        {
+            using (var subcurve = curve.Clone())
+            {
+                subcurve.MakeBound(
+                    curve.ComputeRawParameter(startParameter),
+                    curve.ComputeRawParameter(endParameter));
+                return subcurve.Length;
+            }
+        }
+
+        private static void ValidateChordLengths(
+            IReadOnlyList<XYZ> points,
+            double maximumChordLength)
+        {
+            var maximumWithTolerance = maximumChordLength
+                * (1 + ChordLengthToleranceFactor);
+            for (var index = 1; index < points.Count; index++)
+            {
+                if (points[index - 1].DistanceTo(points[index]) > maximumWithTolerance)
+                {
+                    throw new InvalidOperationException("曲線離散化產生超過 300 mm 的弦長。");
+                }
+            }
+        }
+
+        private static Point2D ToPoint2D(XYZ point)
+        {
+            return new Point2D(point.X, point.Y);
+        }
+
+        private static void EnsurePointLimit(int pointCount)
+        {
+            if (pointCount > MaximumDiscretizedPointCount)
+            {
+                throw new InvalidOperationException(
+                    $"曲線離散化超過最大點數 {MaximumDiscretizedPointCount}，已中止處理。");
+            }
+        }
+
+        private static void AddDistinctPoint(ICollection<Point2D> points, Point2D candidate)
+        {
+            var last = points.LastOrDefault();
+            if (points.Count == 0 || DistanceSquared(last, candidate) > 1e-18)
+            {
+                points.Add(candidate);
+            }
+        }
+
+        private static double SignedArea(IReadOnlyList<Point2D> polygon)
+        {
+            var doubledArea = 0.0;
+            for (var index = 0; index < polygon.Count; index++)
+            {
+                var current = polygon[index];
+                var next = polygon[(index + 1) % polygon.Count];
+                doubledArea += current.X * next.Y - next.X * current.Y;
+            }
+
+            return doubledArea / 2.0;
+        }
+
+        private static double DistanceSquared(Point2D first, Point2D second)
+        {
+            var deltaX = second.X - first.X;
+            var deltaY = second.Y - first.Y;
+            return deltaX * deltaX + deltaY * deltaY;
+        }
+
+        private static int CheckedElementId(long id)
+        {
+            if (id <= 0 || id > int.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(id), "元素 ID 必須介於 1 與 Int32.MaxValue 之間。");
+            }
+
+            return checked((int)id);
+        }
+
+        private static void EnsureModifiable(Document doc)
+        {
+            if (doc == null)
+            {
+                throw new ArgumentNullException(nameof(doc));
+            }
+
+            if (!doc.IsModifiable)
+            {
+                throw new InvalidOperationException("呼叫端必須先開啟 Revit 交易。");
+            }
+        }
+
+        private static Phase GetCurrentPhase(Document doc)
+        {
+            var activeView = doc.ActiveView;
+            var phaseParameter = activeView?.get_Parameter(BuiltInParameter.VIEW_PHASE);
+            var phase = phaseParameter == null ? null : doc.GetElement(phaseParameter.AsElementId()) as Phase;
+            if (phase == null)
+            {
+                throw new InvalidOperationException("目前視圖沒有有效的階段。");
+            }
+
+            return phase;
+        }
+
+        private static int FindPhaseIndex(PhaseArray phases, ElementId phaseId)
+        {
+            for (var index = 0; index < phases.Size; index++)
+            {
+                if (phases.get_Item(index).Id == phaseId)
+                {
+                    return index;
+                }
+            }
+
+            return -1;
+        }
+
+        private static Parameter RequirePhaseParameter(
+            Element element,
+            BuiltInParameter builtInParameter,
+            string displayName)
+        {
+            var parameter = element.get_Parameter(builtInParameter);
+            if (parameter == null || parameter.StorageType != StorageType.ElementId)
+            {
+                throw new InvalidOperationException($"元素 ID {element.Id.Value} 缺少有效的{displayName}參數。");
+            }
+
+            return parameter;
+        }
+
+        private static void SetPhaseParameter(Parameter parameter, ElementId value, string displayName)
+        {
+            if (parameter.IsReadOnly || !parameter.Set(value))
+            {
+                throw new InvalidOperationException($"無法設定{displayName}。");
+            }
+        }
+
+        private static Schema GetOrCreateAssociationSchema()
+        {
+            var schema = Schema.Lookup(AssociationSchemaGuid);
+            if (schema != null)
+            {
+                return schema;
+            }
+
+            var builder = new SchemaBuilder(AssociationSchemaGuid);
+            builder.SetSchemaName("RevitMCP_ToposolidGrading");
+            builder.SetReadAccessLevel(AccessLevel.Public);
+            builder.SetWriteAccessLevel(AccessLevel.Public);
+            builder.AddSimpleField("AssociationId", typeof(string));
+            builder.AddSimpleField("OriginalToposolidId", typeof(long));
+            builder.AddSimpleField("FloorIds", typeof(string));
+            return builder.Finish();
+        }
+
+        private static void EnsureAssociationSchema(Schema schema)
+        {
+            if (schema.GetField("AssociationId") == null
+                || schema.GetField("OriginalToposolidId") == null
+                || schema.GetField("FloorIds") == null)
+            {
+                throw new InvalidOperationException("既有 RevitMCP_ToposolidGrading schema 欄位不相容。");
+            }
+        }
+
+        private static double ReadVolumeParameter(
+            Toposolid design,
+            BuiltInParameter builtInParameter,
+            string displayName)
+        {
+            var parameter = design.get_Parameter(builtInParameter);
+            if (parameter == null
+                || !parameter.HasValue
+                || parameter.StorageType != StorageType.Double)
+            {
+                throw new InvalidOperationException(
+                    $"設計 Toposolid 缺少有值且可讀取的內建 {displayName} 體積參數。");
+            }
+
+            var value = parameter.AsDouble();
+            if (double.IsNaN(value) || double.IsInfinity(value))
+            {
+                throw new InvalidOperationException($"設計 Toposolid 的 {displayName} 體積不是有效數值。");
+            }
+
+            return value;
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## 摘要

新增 Revit 2024 Toposolid 樓板投影整地工具 `grade_toposolid_to_floors`：以選定樓板的底面水平投影範圍，將設計地形貼齊各樓板底面，並以 Revit 內建 CUT/FILL 參數回報挖方、填方與淨土方。已於 Revit 2024 實機完成三個整地方案的驗證。

本 PR 為**最小變更集**，僅含功能運行所需的 7 個檔案；單元測試、設計規格與實測紀錄保留於 fork（連結見文末），如需要可另行補入。

## 變更檔案（7 個）

| 檔案 | 角色 |
|---|---|
| `MCP/Core/Grading/GradingModels.cs` | 資料模型、輸入驗證、分段計時（純 .NET，無 Revit 相依） |
| `MCP/Core/Grading/Polygon2D.cs` | 點在多邊形內／投影重疊衝突判斷（純幾何） |
| `MCP/Core/Grading/RevitToposolidGradingAdapter.cs` | Revit 2024 配接層，全檔 `#if REVIT2024_OR_GREATER` 隔離 |
| `MCP/Core/Commands/CommandExecutor.ToposolidGrading.cs` | `TransactionGroup` 交易命令，失敗整組回滾 |
| `MCP/Core/CommandExecutor.cs` | 分派器插入 grading case（僅 +6 行） |
| `MCP-Server/src/tools/grading-tools.ts` | MCP 工具 schema |
| `MCP-Server/src/tools/revit-tools.ts` | 工具註冊（full／architect／structural profile） |

Revit 2022／2023 組態建置不受影響（新增 API 皆以條件編譯隔離）。

## 關鍵技術決策

- **兩段式校準**：Revit 2024 公開 API 讀不到 SlabShapeVertex 目前 offset，改以「寫入 offset 0 讀回基準 Z → 寫入目標差值 → 逐點 2mm 驗收」的序列，無論 `ModifySubElement` 為絕對或增量語意皆收斂到目標高程
- **邊界摺線（split line）**：僅下控制點不足以約束三角網格——外部高處地形的三角形會跨越樓板上空。以 `DrawSplitLine` 沿樓板邊界刻出封閉稜線，強制網格以邊界為硬邊
- **表面抽樣驗收**：完工後於投影內以 2m 網格垂直射線抽樣實際表面，偏離板底逾 2mm 即回滾——「控制點對、點間表面不對」不得靜默過關
- **階段自動化**：`allowPhaseSetup` 預設 `true`，自動將原地形設為較早階段建立、目前階段拆除（與 Revit 原生整地行為一致）；原地形永不刪除
- **效能記錄**：回應含 `Timing` 分段計時；每次執行（成敗皆記）附加 JSON Lines 至 `%APPDATA%\RevitMCP\grading-performance.jsonl`

## 支援範圍

- 模式：`footprint_only`（Offset 外延銜接與指定坡度銜接為後續方向）
- 樓板：直邊、曲線邊（300mm 弦長離散化）、斜板（底面傾斜至 15°，以平面方程式逐點計算高程）

## 實機驗證（Revit 2024）

| 方案 | CUT (m³) | FILL (m³) | 淨土方 (m³) | 耗時 |
|---|---|---|---|---|
| 方案一 | 2,159.84 | 1,868.35 | −291.49（餘土） | 4.2 s |
| 方案二 | 1,931.84 | 1,606.64 | −325.20（餘土） | 3.7 s |
| 方案三 | 4,257.55 | 2,733.40 | −1,524.16（大量餘土） | 127 s* |

*方案三的耗時異常為 Revit 元素重疊警告對話框阻塞交易提交所致（演算法各階段均在 50–120ms）。

### 整地前：原始地形與兩片控制樓板（平板＋約 1:15 斜板）

![整地前](https://raw.githubusercontent.com/7alexhuang-ux/REVIT_MCP_study/main/docs/superpowers/specs/images/2026-07-02-topo-before-grading.png)

### 整地後（方案一）：投影內貼齊板底、投影外垂直裙邊收邊、樓板上方無殘留土方

![方案一整地後](https://raw.githubusercontent.com/7alexhuang-ux/REVIT_MCP_study/main/docs/superpowers/specs/images/2026-07-03-scheme1-graded.png)

### 三方案挖填比較

![三方案比較](https://raw.githubusercontent.com/7alexhuang-ux/REVIT_MCP_study/main/docs/superpowers/specs/images/2026-07-03-three-scheme-comparison.png)

## 補充資料（保留於 fork，未納入本 PR）

- 單元測試（NUnit 16/16、schema 測試 4/4）：[MCP.Tests](https://github.com/7alexhuang-ux/REVIT_MCP_study/tree/main/MCP.Tests)、[grading-tools.test.ts](https://github.com/7alexhuang-ux/REVIT_MCP_study/blob/main/MCP-Server/src/tools/grading-tools.test.ts)
- 設計規格、Roadmap 與實測紀錄：[2026-07-02-toposolid-footprint-cut-fill-design.md](https://github.com/7alexhuang-ux/REVIT_MCP_study/blob/main/docs/superpowers/specs/2026-07-02-toposolid-footprint-cut-fill-design.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
