### PR TITLE
帷幕牆立面生成與尺寸標註

### DIFF
--- a/MCP-Server/src/tools/curtain-wall-tools.ts
+++ b/MCP-Server/src/tools/curtain-wall-tools.ts
@@ -52,6 +52,92 @@ export const curtainWallTools: Tool[] = [
         },
     },
     {
+        name: "create_curtain_wall_elevations",
+        description: "批次建立每一道帷幕牆的永久外立面視圖，建立/套用名為「帷幕立面」的視圖樣板，保留 crop box 與 far clip depth 可由各視圖自行控制，並回傳方向與 crop 診斷欄位。這個工具建立的是持久成果，不需要 cleanup；除非使用者明確要求清理，AI client 不得呼叫 delete_element 刪除這些 generated views。",
+        inputSchema: {
+            type: "object",
+            properties: {
+                placementViewId: { type: "number", description: "放置 ElevationMarker 的 ViewPlan ElementId；優先於 placementViewName。" },
+                placementViewName: { type: "string", description: "放置 ElevationMarker 的 ViewPlan 名稱。" },
+                scale: { type: "number", description: "立面視圖比例，預設 50。", default: 50 },
+                offsetMm: { type: "number", description: "marker 放在牆外側的距離，單位 mm，預設 1500。", default: 1500 },
+                horizontalMarginMm: { type: "number", description: "crop 左右餘裕，單位 mm，預設 0；剪裁範圍依 elevation view 內目標帷幕元素的 2D 可視範圍計算。", default: 0 },
+                verticalMarginMm: { type: "number", description: "crop 上下餘裕，單位 mm，預設 0；剪裁範圍依 elevation view 內目標帷幕元素的 2D 可視範圍計算。", default: 0 },
+                depthMm: { type: "number", description: "自動深度計算失敗時的 fallback 遠剪裁深度，單位 mm，預設 1200；正常情況會剛好包住帷幕牆所有相關元素，遠端剪裁模式固定為剪裁含線。", default: 1200 },
+                viewTemplateName: { type: "string", description: "視圖樣板名稱，預設「帷幕立面」。", default: "帷幕立面" },
+                elevationViewTypeName: { type: "string", description: "立面圖類型名稱，預設「帷幕立面」；不存在時會自動由既有 Elevation ViewFamilyType 複製建立。", default: "帷幕立面" },
+                applyViewTemplate: { type: "boolean", description: "是否建立/套用視圖樣板，預設 true。", default: true },
+                nameSeparator: { type: "string", description: "樓層與標記之間的分隔字串，預設「-」。", default: "-" },
+                addDimensions: { type: "boolean", description: "自動在帷幕立面加入總寬、總高、水平/垂直帷幕網格尺寸標註，預設 true。", default: true },
+                dimensionTypeSelectionMode: { type: "string", enum: ["auto", "prompt"], description: "標註類型選擇模式。auto 會用指定、最近一次、Revit 預設或第一個可用標註類型；prompt 會在沒有 dimensionTypeId/dimensionTypeName 時先要求呼叫 list_dimension_types。預設 auto。", default: "auto" },
+                dimensionTypeId: { type: "number", description: "可選 Revit DimensionType ElementId；未提供時使用最近一次成功標註類型、Revit 預設線性標註類型或第一個可用標註類型。" },
+                dimensionTypeName: { type: "string", description: "可選 Revit DimensionType 名稱；dimensionTypeId 未提供或無效時使用。" },
+                dimensionOffsetMm: { type: "number", description: "帷幕可視邊界到第一道尺寸線的距離，單位 mm，預設 300。", default: 300 },
+                dimensionStackOffsetMm: { type: "number", description: "總尺寸線與網格尺寸線之間的距離，單位 mm，預設 250。", default: 250 },
+                dryRun: { type: "boolean", description: "只回報將建立的視圖，不修改模型，預設 false。", default: false },
+            },
+        },
+    },
+    {
+        name: "diagnose_curtain_wall_elevation_direction",
+        description: "非破壞診斷指定帷幕牆的立面方向判定流程；以 rollback transaction 建立暫時 ElevationMarker/ViewSection，回傳 wall.Orientation、預期 marker 位置、暫時 view 方向與 dot 檢查，不留下視圖或 marker。",
+        inputSchema: {
+            type: "object",
+            properties: {
+                wallId: { type: "number", description: "要診斷的帷幕牆 Wall ElementId。" },
+                placementViewId: { type: "number", description: "放置暫時 ElevationMarker 的 ViewPlan ElementId；優先於 placementViewName。" },
+                placementViewName: { type: "string", description: "放置暫時 ElevationMarker 的 ViewPlan 名稱。" },
+                scale: { type: "number", description: "暫時立面視圖比例，預設 50。", default: 50 },
+                offsetMm: { type: "number", description: "暫時 marker 放在 wall.Orientation 側的距離，單位 mm，預設 1500。", default: 1500 },
+                includeCropDiagnostics: { type: "boolean", description: "Include non-mutating crop diagnostics for the temporary elevation view. Default: false", default: false },
+            },
+            required: ["wallId"],
+        },
+    },
+    {
+        name: "diagnose_curtain_wall_elevation_directions",
+        description: "Batch, non-destructive curtain wall elevation direction diagnostic. Compares wall.Orientation and -wall.Orientation candidate sides for selected or all curtain walls; temporary markers/views are created inside rollback transactions.",
+        inputSchema: {
+            type: "object",
+            properties: {
+                wallIds: {
+                    type: "array",
+                    description: "Optional curtain wall ElementIds. When omitted, all walls with CurtainGrid != null are diagnosed.",
+                    items: { type: "number" },
+                },
+                placementViewId: { type: "number", description: "Optional ViewPlan ElementId used for temporary ElevationMarker placement." },
+                placementViewName: { type: "string", description: "Optional ViewPlan name used for temporary ElevationMarker placement." },
+                scale: { type: "number", description: "Temporary elevation scale. Default: 50", default: 50 },
+                offsetMm: { type: "number", description: "Candidate marker offset from wall centerline in millimeters. Default: 1500", default: 1500 },
+                includeTemporaryMarker: { type: "boolean", description: "Create temporary ElevationMarker/ViewSection inside rollback transactions to read ViewDirection. Default: true", default: true },
+                includeCropDiagnostics: { type: "boolean", description: "Include non-mutating crop diagnostics for the auto-resolved temporary elevation view. Requires includeTemporaryMarker. Default: false", default: false },
+                knownExteriorSideByWallId: {
+                    type: "object",
+                    description: "Optional truth labels by wall id. Value must be 'api_orientation' or 'opposite_orientation'.",
+                    additionalProperties: {
+                        type: "string",
+                        enum: ["api_orientation", "opposite_orientation"],
+                    },
+                },
+            },
+        },
+    },
+    {
+        name: "diagnose_curtain_wall_elevation_dimensions",
+        description: "Non-destructive curtain elevation dimension diagnostic. Tests DimensionType resolution, geometry references, ReferencePlane fallback, NewDimension creation, and readback verification inside a rollback transaction by default.",
+        inputSchema: {
+            type: "object",
+            properties: {
+                viewId: { type: "number", description: "Optional existing curtain elevation ViewSection ElementId. When omitted, the active view is used if it is a ViewSection." },
+                wallId: { type: "number", description: "Optional curtain wall ElementId. When omitted, the first curtain wall is used." },
+                dimensionTypeId: { type: "number", description: "Optional DimensionType ElementId to test." },
+                dimensionTypeName: { type: "string", description: "Optional DimensionType name to test when dimensionTypeId is omitted or invalid." },
+                testMode: { type: "string", enum: ["geometry_reference", "reference_plane_fallback", "both"], description: "Dimension reference strategy to test. Default: both.", default: "both" },
+                rollback: { type: "boolean", description: "Rollback all diagnostic dimensions/reference planes so the model is not modified. Default: true.", default: true },
+            },
+        },
+    },
+    {
         name: "create_facade_panel",
         description: "建立單片立面面板（DirectShape）。支援 5 種幾何：curved_panel、beveled_opening、angled_panel、rounded_opening、flat_panel。",
         inputSchema: {

--- a/MCP/Core/CommandExecutor.cs
+++ b/MCP/Core/CommandExecutor.cs
@@ -315,6 +315,18 @@ namespace RevitMCP.Core
                     case "apply_panel_pattern":
                         result = ApplyPanelPattern(parameters);
                         break;
+                    case "create_curtain_wall_elevations":
+                        result = CreateCurtainWallElevations(parameters);
+                        break;
+                    case "diagnose_curtain_wall_elevation_direction":
+                        result = DiagnoseCurtainWallElevationDirection(parameters);
+                        break;
+                    case "diagnose_curtain_wall_elevation_directions":
+                        result = DiagnoseCurtainWallElevationDirections(parameters);
+                        break;
+                    case "diagnose_curtain_wall_elevation_dimensions":
+                        result = DiagnoseCurtainWallElevationDimensions(parameters);
+                        break;
                     case "create_facade_panel":
                         result = CreateFacadePanel(parameters);
                         break;

--- a/MCP/Core/Commands/CommandExecutor.CurtainWall.cs
+++ b/MCP/Core/Commands/CommandExecutor.CurtainWall.cs
@@ -5,7 +5,7 @@ using Autodesk.Revit.DB;
 using Autodesk.Revit.UI;
 using Newtonsoft.Json.Linq;
 
-// Revit 2025+ ElementId: int → long
+// Revit 2025+ ElementId: int ??long
 #if REVIT2025_OR_GREATER
 using IdType = System.Int64;
 #else
@@ -15,13 +15,15 @@ using IdType = System.Int32;
 namespace RevitMCP.Core
 {
     /// <summary>
-    /// 帷幕牆 + 立面面板命令
-    /// 來源：PR#11 (@7alexhuang-ux)，經跨版本修正後整合
+    /// 帷�???+ 立面?�板?�令
+    /// 來�?：PR#11 (@7alexhuang-ux)，�?跨�??�修�???��?
     /// </summary>
     public partial class CommandExecutor
     {
-        #region 帷幕牆工具
+        private const double CurtainElevationDirectionDotThreshold = 0.98;
+        private static IdType? LastCurtainElevationDimensionTypeId;
 
+        #region 帷�??�工??
         private object GetCurtainWallInfo(JObject parameters)
         {
             Document doc = _uiApp.ActiveUIDocument.Document;
@@ -30,7 +32,7 @@ namespace RevitMCP.Core
             IdType? elementId = parameters["elementId"]?.Value<IdType>();
             Wall wall = null;
 
-            // 如果沒有指定 elementId，使用目前選取的元素
+            // 如�?沒�??��? elementId，使?�目?�選?��??��?
             if (elementId.HasValue)
             {
                 Element elem = doc.GetElement(new ElementId(elementId.Value));
@@ -40,38 +42,38 @@ namespace RevitMCP.Core
             {
                 var selection = uidoc.Selection.GetElementIds();
                 if (selection.Count == 0)
-                    throw new Exception("請先選取一個帷幕牆，或指定 elementId");
+                    throw new Exception("請�??��?一?�帷幕�?，�??��? elementId");
 
                 Element elem = doc.GetElement(selection.First());
                 wall = elem as Wall;
             }
 
             if (wall == null)
-                throw new Exception("選取的元素不是牆");
+                throw new Exception("?��??��?素�??��?");
 
-            // 檢查是否為帷幕牆
+            // 檢查?�否?�帷幕�?
             CurtainGrid grid = wall.CurtainGrid;
             if (grid == null)
-                throw new Exception("此牆不是帷幕牆（沒有 CurtainGrid）");
+                throw new Exception("Selected wall is not a curtain wall (CurtainGrid is null).");
 
-            // 取得 Grid 資訊
+            // ?��? Grid 資�?
             var uGridIds = grid.GetUGridLineIds();
             var vGridIds = grid.GetVGridLineIds();
             var panelIds = grid.GetPanelIds();
 
-            // 計算 rows 和 columns
-            int rows = uGridIds.Count + 1;    // U Grid = 水平線 = 定義 Row
-            int columns = vGridIds.Count + 1; // V Grid = 垂直線 = 定義 Column
+            // 計�? rows ??columns
+            int rows = uGridIds.Count + 1;    // U Grid = 水平�?= 定義 Row
+            int columns = vGridIds.Count + 1; // V Grid = ?�直�?= 定義 Column
 
-            // 收集面板資訊
+            // ?��??�板資�?
             var panelTypeDict = new Dictionary<IdType, (string TypeName, string MaterialName, string MaterialColor, int Count)>();
             var panelMatrix = new List<List<int>>(); // [row][col] = typeId
 
-            // 取得牆的位置線來計算方向
+            // ?��??��?位置線�?計�??��?
             LocationCurve locCurve = wall.Location as LocationCurve;
             Curve curve = locCurve?.Curve;
 
-            // 收集面板並分析
+            // ?��??�板並�???
             foreach (ElementId panelId in panelIds)
             {
                 Element panel = doc.GetElement(panelId);
@@ -85,7 +87,7 @@ namespace RevitMCP.Core
                     ElementType panelType = doc.GetElement(typeId) as ElementType;
                     string typeName = panelType?.Name ?? "Unknown";
 
-                    // 嘗試取得材料資訊
+                    // ?�試?��??��?資�?
                     string materialName = "";
                     string materialColor = "#808080";
 
@@ -107,7 +109,7 @@ namespace RevitMCP.Core
                             }
                         }
                     }
-                    catch (Exception) { /* 忽略個別元素處理失敗 */ }
+                    catch (Exception) { /* 忽略?�別?��??��?失�? */ }
 
                     panelTypeDict[typeIdInt] = (typeName, materialName, materialColor, 0);
                 }
@@ -116,7 +118,7 @@ namespace RevitMCP.Core
                 panelTypeDict[typeIdInt] = (current.TypeName, current.MaterialName, current.MaterialColor, current.Count + 1);
             }
 
-            // 取得面板尺寸（從第一個面板估算）
+            // ?��??�板尺寸（�?第�??�面?�估算�?
             double panelWidth = 0;
             double panelHeight = 0;
 
@@ -131,7 +133,7 @@ namespace RevitMCP.Core
                 }
             }
 
-            // 組織回傳資料
+            // 組�??�傳資�?
             var panelTypes = panelTypeDict.Select(kvp => new
             {
                 TypeId = kvp.Key,
@@ -159,13 +161,13 @@ namespace RevitMCP.Core
         }
 
         /// <summary>
-        /// 取得專案中所有可用的帷幕面板類型
+        /// ?��?專�?中�??�可?��?帷�??�板類�?
         /// </summary>
         private object GetCurtainPanelTypes(JObject parameters)
         {
             Document doc = _uiApp.ActiveUIDocument.Document;
 
-            // 取得所有 Curtain Panel 類型
+            // ?��??�??Curtain Panel 類�?
             var panelTypes = new FilteredElementCollector(doc)
                 .OfCategory(BuiltInCategory.OST_CurtainWallPanels)
                 .WhereElementIsElementType()
@@ -195,7 +197,7 @@ namespace RevitMCP.Core
                             }
                         }
                     }
-                    catch (Exception) { /* 忽略個別元素處理失敗 */ }
+                    catch (Exception) { /* 忽略?�別?��??��?失�? */ }
 
                     return new
                     {
@@ -219,7 +221,4368 @@ namespace RevitMCP.Core
         }
 
         /// <summary>
-        /// 建立新的帷幕面板類型（含材料）
+        /// 建�?每�??�帷幕�??��?立面視�?，並套用?�帷幕�??�」�??�樣?��?
+        /// </summary>
+        private object CreateCurtainWallElevations(JObject parameters)
+        {
+            Document doc = _uiApp.ActiveUIDocument.Document;
+            UIDocument uidoc = _uiApp.ActiveUIDocument;
+
+            int scale = parameters["scale"]?.Value<int>() ?? 50;
+            double offsetFt = (parameters["offsetMm"]?.Value<double>() ?? 1500.0) / 304.8;
+            double horizontalMarginFt = (parameters["horizontalMarginMm"]?.Value<double>() ?? 0.0) / 304.8;
+            double verticalMarginFt = (parameters["verticalMarginMm"]?.Value<double>() ?? 0.0) / 304.8;
+            double fallbackDepthFt = (parameters["depthMm"]?.Value<double>() ?? 1200.0) / 304.8;
+            string viewTemplateName = parameters["viewTemplateName"]?.Value<string>() ?? "帷幕立面";
+            string elevationViewTypeName = parameters["elevationViewTypeName"]?.Value<string>() ?? "帷幕立面";
+            bool applyViewTemplate = parameters["applyViewTemplate"]?.Value<bool>() ?? true;
+            string nameSeparator = parameters["nameSeparator"]?.Value<string>() ?? "-";
+            bool dryRun = parameters["dryRun"]?.Value<bool>() ?? false;
+            bool addDimensions = parameters["addDimensions"]?.Value<bool>() ?? true;
+            string dimensionTypeSelectionMode = parameters["dimensionTypeSelectionMode"]?.Value<string>()?.Trim().ToLowerInvariant() ?? "auto";
+            double dimensionOffsetFt = (parameters["dimensionOffsetMm"]?.Value<double>() ?? 300.0) / 304.8;
+            double dimensionStackOffsetFt = (parameters["dimensionStackOffsetMm"]?.Value<double>() ?? 250.0) / 304.8;
+
+            ViewFamilyType sourceElevationType = GetFirstCurtainElevationViewFamilyType(doc);
+            ViewFamilyType elevationType = FindCurtainElevationViewFamilyType(doc, elevationViewTypeName) ?? sourceElevationType;
+
+            if (sourceElevationType == null)
+                throw new Exception("?��???Elevation ??ViewFamilyType");
+
+            ViewPlan explicitPlacementView = ResolveCurtainElevationPlacementView(doc, parameters);
+            Dictionary<ElementId, ViewPlan> floorPlansByLevel = GetCurtainElevationFloorPlansByLevel(doc);
+            ViewPlan activePlan = uidoc.ActiveView as ViewPlan;
+            if (activePlan != null && activePlan.IsTemplate)
+                activePlan = null;
+
+            var existingNames = new HashSet<string>(
+                new FilteredElementCollector(doc)
+                    .OfClass(typeof(View))
+                    .Cast<View>()
+                    .Select(v => v.Name));
+
+            List<Wall> curtainWalls = new FilteredElementCollector(doc)
+                .OfClass(typeof(Wall))
+                .WhereElementIsNotElementType()
+                .Cast<Wall>()
+                .Where(w =>
+                {
+                    try { return w.CurtainGrid != null; }
+                    catch { return false; }
+                })
+                .OrderBy(w => w.LevelId.GetIdValue())
+                .ThenBy(w => w.Id.GetIdValue())
+                .ToList();
+
+            var created = new List<object>();
+            var skipped = new List<object>();
+            var templateWarnings = new List<string>();
+            var dimensionWarnings = new List<string>();
+            View viewTemplate = null;
+            bool templateCreated = false;
+            bool templateUpdated = false;
+            bool elevationViewTypeCreated = false;
+            CurtainElevationDimensionTypeResolution dimensionTypeResolution =
+                ResolveCurtainElevationDimensionType(doc, parameters, dimensionWarnings);
+            DimensionType dimensionType = addDimensions ? dimensionTypeResolution.DimensionType : null;
+            int dimensionsCreatedCount = 0;
+            int dimensionsFailedCount = 0;
+            bool hasExplicitDimensionType =
+                parameters["dimensionTypeId"] != null ||
+                !string.IsNullOrWhiteSpace(parameters["dimensionTypeName"]?.Value<string>());
+
+            if (addDimensions && dimensionTypeSelectionMode == "prompt" && !hasExplicitDimensionType)
+            {
+                return new
+                {
+                    Success = false,
+                    WorkflowState = "awaiting_dimension_type_selection",
+                    NextAction = "call_list_dimension_types",
+                    RequiresUserInput = true,
+                    NoModelChanges = true,
+                    ElevationsCreated = false,
+                    MissingFields = new[] { "dimensionTypeId" },
+                    DimensionTypeSelectionMode = dimensionTypeSelectionMode,
+                    PromptToUser = "Call list_dimension_types and pass dimensionTypeId or dimensionTypeName, or set dimensionTypeSelectionMode to auto.",
+                    Message = "Dimension type selection is required; no curtain elevation views were created."
+                };
+            }
+
+            if (dryRun)
+            {
+                foreach (Wall wall in curtainWalls)
+                {
+                    Level level = doc.GetElement(wall.LevelId) as Level;
+                    string levelName = level?.Name ?? "Unknown Level";
+                    string mark = GetCurtainWallMark(wall);
+                    string viewName = MakeUniqueCurtainElevationViewName(existingNames, $"{levelName}{nameSeparator}{mark}");
+                    CurtainElevationExteriorResolution exterior = ResolveCurtainElevationExteriorSide(wall);
+
+                    created.Add(new
+                    {
+                        WallId = wall.Id.GetIdValue(),
+                        ViewId = (IdType)0,
+                        ViewName = viewName,
+                        ElevationViewTypeId = elevationType?.Id.GetIdValue() ?? 0,
+                        ElevationViewTypeName = elevationType?.Name ?? elevationViewTypeName,
+                        LevelName = levelName,
+                        Mark = mark,
+                        MarkerId = (IdType)0,
+                        WallFlipped = wall.Flipped,
+                        ResolvedExteriorSide = exterior?.SideName,
+                        ResolvedExteriorSource = exterior?.Source,
+                        ResolvedExteriorDirection = ToCurtainElevationXyz(exterior?.ExteriorDirection),
+                        AddDimensions = addDimensions,
+                        DimensionTypeSelectionMode = dimensionTypeSelectionMode,
+                        DimensionTypeId = dimensionType?.Id.GetIdValue(),
+                        DimensionTypeName = dimensionType?.Name,
+                        DimensionTypeSource = dimensionTypeResolution.Source,
+                        DimensionStatus = addDimensions ? "dry_run" : "disabled",
+                        IsPersistentOutput = true,
+                        DryRun = true
+                    });
+                }
+
+                return new
+                {
+                    Success = true,
+                    DryRun = true,
+                    PersistentViewsCreated = true,
+                    CleanupRequired = false,
+                    DeleteGeneratedViews = false,
+                    TotalCurtainWalls = curtainWalls.Count,
+                    CreatedCount = created.Count,
+                    SkippedCount = skipped.Count,
+                    ViewTemplateId = (IdType)0,
+                    ViewTemplateName = viewTemplateName,
+                    TemplateCreated = false,
+                    TemplateUpdated = false,
+                    ElevationViewTypeId = elevationType?.Id.GetIdValue() ?? 0,
+                    ElevationViewTypeName = elevationType?.Name ?? elevationViewTypeName,
+                    ElevationViewTypeCreated = false,
+                    ElevationViewTypeWillBeCreated = FindCurtainElevationViewFamilyType(doc, elevationViewTypeName) == null,
+                    AddDimensions = addDimensions,
+                    DimensionTypeSelectionMode = dimensionTypeSelectionMode,
+                    DimensionTypeId = dimensionType?.Id.GetIdValue(),
+                    DimensionTypeName = dimensionType?.Name,
+                    DimensionTypeSource = dimensionTypeResolution.Source,
+                    DimensionsCreatedCount = 0,
+                    DimensionsFailedCount = 0,
+                    DimensionWarnings = dimensionWarnings,
+                    Created = created,
+                    Skipped = skipped,
+                    TemplateWarnings = templateWarnings
+                };
+            }
+
+            using (Transaction trans = TransactionHelper.Begin(doc, "Create curtain wall elevations"))
+            {
+                trans.Start();
+                elevationType = GetOrCreateCurtainElevationViewFamilyType(
+                    doc,
+                    sourceElevationType,
+                    elevationViewTypeName,
+                    out elevationViewTypeCreated,
+                    templateWarnings);
+
+                
+                if (applyViewTemplate)
+                {
+                    viewTemplate = FindCurtainElevationViewTemplate(doc, viewTemplateName);
+                    if (viewTemplate != null)
+                    {
+                        ConfigureCurtainElevationViewTemplate(doc, viewTemplate, templateWarnings);
+                        templateUpdated = true;
+                    }
+                }
+
+                foreach (Wall wall in curtainWalls)
+                {
+                    Level level = doc.GetElement(wall.LevelId) as Level;
+                    string levelName = level?.Name ?? "Unknown Level";
+                    string mark = GetCurtainWallMark(wall);
+
+                    try
+                    {
+                        LocationCurve loc = wall.Location as LocationCurve;
+                        if (loc == null)
+                        {
+                            skipped.Add(new { WallId = wall.Id.GetIdValue(), LevelName = levelName, Mark = mark, Reason = "?��???LocationCurve" });
+                            continue;
+                        }
+
+                        BoundingBoxXYZ wallBox = wall.get_BoundingBox(null);
+                        if (wallBox == null)
+                        {
+                            skipped.Add(new { WallId = wall.Id.GetIdValue(), LevelName = levelName, Mark = mark, Reason = "?��??��???BoundingBox" });
+                            continue;
+                        }
+
+                        ViewPlan placementView = explicitPlacementView
+                            ?? ResolveCurtainElevationPlanForWall(wall, activePlan, floorPlansByLevel);
+                        if (placementView == null)
+                        {
+                            skipped.Add(new { WallId = wall.Id.GetIdValue(), LevelName = levelName, Mark = mark, Reason = "No placement ViewPlan available for ElevationMarker" });
+                            continue;
+                        }
+
+                        XYZ wallMid = loc.Curve.Evaluate(0.5, true);
+                        CurtainElevationExteriorResolution exterior = ResolveCurtainElevationExteriorSide(wall);
+                        XYZ outward = exterior?.ExteriorDirection;
+                        if (outward == null)
+                        {
+                            skipped.Add(new { WallId = wall.Id.GetIdValue(), LevelName = levelName, Mark = mark, Reason = "?��??�斷 wall.Orientation" });
+                            continue;
+                        }
+
+                        XYZ markerPoint = wallMid + outward * (wall.Width / 2.0 + offsetFt);
+                        string viewName = MakeUniqueCurtainElevationViewName(existingNames, $"{levelName}{nameSeparator}{mark}");
+
+                        ElevationMarker marker = ElevationMarker.CreateElevationMarker(doc, elevationType.Id, markerPoint, scale);
+                        ViewSection elevationView = marker.CreateElevation(doc, placementView.Id, 0);
+                        doc.Regenerate();
+
+                        XYZ desiredLookDirection = GetCurtainElevationDesiredLookDirection(wallMid, markerPoint);
+                        CurtainElevationDirectionResult directionResult = AlignCurtainElevationMarkerByVisualLook(
+                            doc, marker, markerPoint, elevationView, desiredLookDirection);
+                        if (directionResult.DirectionDot < CurtainElevationDirectionDotThreshold)
+                        {
+                            DeleteCurtainElevationMarkerAndView(doc, marker, elevationView);
+                            skipped.Add(new
+                            {
+                                WallId = wall.Id.GetIdValue(),
+                                LevelName = levelName,
+                                Mark = mark,
+                                Reason = $"立面?��?驗�?失�?，DirectionDot={directionResult.DirectionDot:F4}",
+                                DirectionDot = Math.Round(directionResult.DirectionDot, 4),
+                                DirectionFixApplied = directionResult.DirectionFixApplied,
+                                DesiredLookDirection = ToCurtainElevationXyz(directionResult.DesiredLookDirection),
+                                FinalVisualLookDirection = ToCurtainElevationXyz(directionResult.FinalVisualLookDirection),
+                                WallOrientation = ToCurtainElevationXyz(FlattenAndNormalize(wall.Orientation)),
+                                WallFlipped = wall.Flipped,
+                                ResolvedExteriorSide = exterior.SideName,
+                                ResolvedExteriorSource = exterior.Source,
+                                ResolvedExteriorDirection = ToCurtainElevationXyz(outward),
+                                MarkerPoint = ToCurtainElevationXyz(markerPoint),
+                                WallMidPoint = ToCurtainElevationXyz(wallMid)
+                            });
+                            continue;
+                        }
+
+                        elevationView.Name = viewName;
+                        elevationView.Scale = scale;
+                        if (applyViewTemplate)
+                        {
+                            if (viewTemplate == null)
+                            {
+                                viewTemplate = elevationView.CreateViewTemplate();
+                                viewTemplate.Name = viewTemplateName;
+                                templateCreated = true;
+                                ConfigureCurtainElevationViewTemplate(doc, viewTemplate, templateWarnings);
+                                templateUpdated = true;
+                            }
+
+                            elevationView.ViewTemplateId = viewTemplate.Id;
+                        }
+
+                        CurtainElevationCropResult cropResult = ConfigureCurtainElevationCrop(doc, elevationView, wall, wallMid, markerPoint, horizontalMarginFt, verticalMarginFt, fallbackDepthFt);
+                        ConfigureCurtainElevationFarClip(elevationView, cropResult, templateWarnings);
+                        CurtainElevationDimensionResult dimensionResult = CreateCurtainElevationDimensions(
+                            doc,
+                            elevationView,
+                            wall,
+                            cropResult,
+                            dimensionType,
+                            addDimensions,
+                            dimensionOffsetFt,
+                            dimensionStackOffsetFt);
+                        doc.Regenerate();
+                        VerifyCurtainElevationDimensionResult(doc, elevationView, dimensionResult);
+                        dimensionsCreatedCount += dimensionResult.CreatedCount;
+                        dimensionsFailedCount += dimensionResult.FailedCount;
+                        if (!string.IsNullOrWhiteSpace(dimensionResult.Warning))
+                            dimensionWarnings.Add($"Wall {wall.Id.GetIdValue()}: {dimensionResult.Warning}");
+                        created.Add(new
+                        {
+                            WallId = wall.Id.GetIdValue(),
+                            ViewId = elevationView.Id.GetIdValue(),
+                            ViewName = elevationView.Name,
+                            ElevationViewTypeId = elevationType.Id.GetIdValue(),
+                            ElevationViewTypeName = elevationType.Name,
+                            LevelName = levelName,
+                            Mark = mark,
+                            IsPersistentOutput = true,
+                            MarkerId = marker.Id.GetIdValue(),
+                            FarClipDepthMm = Math.Round(cropResult.FarClipDepthFt * 304.8, 1),
+                            FarClipMethod = cropResult.FarClipMethod,
+                            FarClipRequestedDepthMm = Math.Round(cropResult.FarClipRequestedDepthFt * 304.8, 1),
+                            FarClipActualOffsetMm = cropResult.FarClipActualOffsetFt.HasValue ? Math.Round(cropResult.FarClipActualOffsetFt.Value * 304.8, 1) : (double?)null,
+                            FarClipActualActive = cropResult.FarClipActualActive,
+                            FarClipActualMode = cropResult.FarClipActualMode,
+                            FarClipDepthOrigin = ToCurtainElevationPointMm(cropResult.FarClipDepthOrigin),
+                            FarClipLookDirection = ToCurtainElevationXyz(cropResult.FarClipLookDirection),
+                            FarClipMinCandidateDepthMm = Math.Round(cropResult.FarClipMinCandidateDepthFt * 304.8, 1),
+                            FarClipMaxCandidateDepthMm = Math.Round(cropResult.FarClipMaxCandidateDepthFt * 304.8, 1),
+                            FarClipPositivePointCount = cropResult.FarClipPositivePointCount,
+                            FarClipWarning = cropResult.FarClipWarning,
+                            FarClipMarginMm = Math.Round(cropResult.FarClipMarginFt * 304.8, 1),
+                            FarClipNearestTargetMm = Math.Round(cropResult.FarClipNearestTargetFt * 304.8, 1),
+                            FarClipFarthestTargetMm = Math.Round(cropResult.FarClipFarthestTargetFt * 304.8, 1),
+                            FarClipPointSource = cropResult.FarClipPointSource,
+                            FarClipExtremeContributor = cropResult.FarClipExtremeContributor,
+                            FarClipCropBoxDepthApplied = cropResult.FarClipCropBoxDepthApplied,
+                            FarClipCropBoxDepthMethod = cropResult.FarClipCropBoxDepthMethod,
+                            FarClipViewOriginLocalZMm = Math.Round(cropResult.FarClipViewOriginLocalZFt * 304.8, 1),
+                            FarClipLookDirectionLocalZ = Math.Round(cropResult.FarClipLookDirectionLocalZ, 6),
+                            FarClipCropBoxMinZBeforeMm = Math.Round(cropResult.FarClipCropBoxMinZBeforeFt * 304.8, 1),
+                            FarClipCropBoxMaxZBeforeMm = Math.Round(cropResult.FarClipCropBoxMaxZBeforeFt * 304.8, 1),
+                            FarClipCropBoxMinZAfterMm = Math.Round(cropResult.FarClipCropBoxMinZAfterFt * 304.8, 1),
+                            FarClipCropBoxMaxZAfterMm = Math.Round(cropResult.FarClipCropBoxMaxZAfterFt * 304.8, 1),
+                            FarClipCropBoxDepthAfterMm = Math.Round(cropResult.FarClipCropBoxDepthAfterFt * 304.8, 1),
+                            FarClipDepthDeltaMm = Math.Round(cropResult.FarClipDepthDeltaFt * 304.8, 1),
+                            FarClipPass = cropResult.FarClipPass,
+                            CropMethod = cropResult.Method,
+                            CropPointSource = cropResult.PointSource,
+                            CropPointCount = cropResult.PointCount,
+                            CropFallbackElementCount = cropResult.FallbackElementCount,
+                            CropFrameSource = cropResult.FrameSource,
+                            CropRightDirection = ToCurtainElevationXyz(cropResult.RightDirection),
+                            CropUpDirection = ToCurtainElevationXyz(cropResult.UpDirection),
+                            CropDepthDirection = ToCurtainElevationXyz(cropResult.DepthDirection),
+                            CropLocalMin = ToCurtainElevationXyz(cropResult.LocalMin),
+                            CropLocalMax = ToCurtainElevationXyz(cropResult.LocalMax),
+                            CropUsedRevitTransformFallback = cropResult.UsedRevitTransformFallback,
+                            CropUsedHostWallFallback = cropResult.UsedHostWallFallback,
+                            CropContributingElementIds = cropResult.ContributingElementIds,
+                            CropFallbackElementIds = cropResult.FallbackElementIds,
+                            CropExtremeContributors = cropResult.ExtremeContributors,
+                            Crop2DOrigin = ToCurtainElevationPointMm(cropResult.View2DOrigin),
+                            Crop2DRightDirection = ToCurtainElevationXyz(cropResult.View2DRightDirection),
+                            Crop2DUpDirection = ToCurtainElevationXyz(cropResult.View2DUpDirection),
+                            Crop2DMin = ToCurtainElevationXyz(cropResult.View2DMin),
+                            Crop2DMax = ToCurtainElevationXyz(cropResult.View2DMax),
+                            Crop2DPointCount = cropResult.View2DPointCount,
+                            Crop2DSource = cropResult.View2DSource,
+                            Crop2DExtremeContributors = cropResult.View2DExtremeContributors,
+                            CropRegionShapeApplied = cropResult.RegionShapeApplied,
+                            CropRegionShapeFallbackReason = cropResult.RegionShapeFallbackReason,
+                            DimensionAttemptCount = dimensionResult.AttemptCount,
+                            DimensionVerifiedCount = dimensionResult.VerifiedCount,
+                            DimensionCreationErrors = dimensionResult.CreationErrors,
+                            DimensionsCreatedCount = dimensionResult.CreatedCount,
+                            DimensionsFailedCount = dimensionResult.FailedCount,
+                            DimensionTypeSelectionMode = dimensionTypeSelectionMode,
+                            DimensionTypeId = dimensionType?.Id.GetIdValue(),
+                            DimensionTypeName = dimensionType?.Name,
+                            DimensionTypeSource = dimensionTypeResolution.Source,
+                            TotalWidthDimensionId = dimensionResult.TotalWidthDimensionId?.GetIdValue(),
+                            HorizontalGridDimensionId = dimensionResult.HorizontalGridDimensionId?.GetIdValue(),
+                            TotalHeightDimensionId = dimensionResult.TotalHeightDimensionId?.GetIdValue(),
+                            VerticalGridDimensionId = dimensionResult.VerticalGridDimensionId?.GetIdValue(),
+                            ReferenceCurveIds = dimensionResult.ReferenceCurveIds.Select(id => id.GetIdValue()).ToList(),
+                            TotalWidthDimensionReferenceSource = dimensionResult.TotalWidthDimensionReferenceSource,
+                            TotalHeightDimensionReferenceSource = dimensionResult.TotalHeightDimensionReferenceSource,
+                            HorizontalGridDimensionReferenceSource = dimensionResult.HorizontalGridDimensionReferenceSource,
+                            VerticalGridDimensionReferenceSource = dimensionResult.VerticalGridDimensionReferenceSource,
+                            GeometryReferenceCount = dimensionResult.GeometryReferenceCount,
+                            CurtainGridLineCount = dimensionResult.CurtainGridLineCount,
+                            CurtainGridLineReferenceCount = dimensionResult.CurtainGridLineReferenceCount,
+                            CurtainGridLineReferenceSamples = dimensionResult.CurtainGridLineReferenceSamples,
+                            CurtainGridLineReferenceFailures = dimensionResult.CurtainGridLineReferenceFailures,
+                            GeometryReferenceCategories = dimensionResult.GeometryReferenceCategories,
+                            DimensionFallbackReason = dimensionResult.DimensionFallbackReason,
+                            DimensionStatus = dimensionResult.Status,
+                            DimensionWarnings = dimensionResult.Warnings,
+                            DirectionDot = Math.Round(directionResult.DirectionDot, 4),
+                            DirectionFixApplied = directionResult.DirectionFixApplied,
+                            DesiredLookDirection = ToCurtainElevationXyz(directionResult.DesiredLookDirection),
+                            FinalVisualLookDirection = ToCurtainElevationXyz(directionResult.FinalVisualLookDirection),
+                            WallOrientation = ToCurtainElevationXyz(FlattenAndNormalize(wall.Orientation)),
+                            WallFlipped = wall.Flipped,
+                            ResolvedExteriorSide = exterior.SideName,
+                            ResolvedExteriorSource = exterior.Source,
+                            ResolvedExteriorDirection = ToCurtainElevationXyz(outward),
+                            MarkerPoint = ToCurtainElevationXyz(markerPoint),
+                            WallMidPoint = ToCurtainElevationXyz(wallMid)
+                        });
+                    }
+                    catch (Exception ex)
+                    {
+                        skipped.Add(new { WallId = wall.Id.GetIdValue(), LevelName = levelName, Mark = mark, Reason = ex.Message });
+                    }
+                }
+
+                trans.Commit();
+            }
+
+            return new
+            {
+                Success = true,
+                DryRun = false,
+                PersistentViewsCreated = true,
+                CleanupRequired = false,
+                DeleteGeneratedViews = false,
+                TotalCurtainWalls = curtainWalls.Count,
+                CreatedCount = created.Count,
+                SkippedCount = skipped.Count,
+                ViewTemplateId = viewTemplate?.Id.GetIdValue() ?? 0,
+                ViewTemplateName = viewTemplate?.Name ?? viewTemplateName,
+                TemplateCreated = templateCreated,
+                TemplateUpdated = templateUpdated,
+                ElevationViewTypeId = elevationType?.Id.GetIdValue() ?? 0,
+                ElevationViewTypeName = elevationType?.Name ?? elevationViewTypeName,
+                ElevationViewTypeCreated = elevationViewTypeCreated,
+                AddDimensions = addDimensions,
+                DimensionTypeSelectionMode = dimensionTypeSelectionMode,
+                DimensionTypeId = dimensionType?.Id.GetIdValue(),
+                DimensionTypeName = dimensionType?.Name,
+                DimensionTypeSource = dimensionTypeResolution.Source,
+                DimensionsCreatedCount = dimensionsCreatedCount,
+                DimensionsFailedCount = dimensionsFailedCount,
+                DimensionWarnings = dimensionWarnings,
+                Created = created,
+                Skipped = skipped,
+                TemplateWarnings = templateWarnings
+            };
+        }
+
+        private object DiagnoseCurtainWallElevationDimensions(JObject parameters)
+        {
+            Document doc = _uiApp.ActiveUIDocument.Document;
+            UIDocument uidoc = _uiApp.ActiveUIDocument;
+
+            string testMode = parameters["testMode"]?.Value<string>()?.Trim().ToLowerInvariant() ?? "both";
+            bool rollback = parameters["rollback"]?.Value<bool>() ?? true;
+            var failures = new List<string>();
+            var attempts = new List<CurtainElevationDimensionAttempt>();
+            var createdDimensionIds = new List<ElementId>();
+            var verifiedDimensionIds = new List<ElementId>();
+            var referencePlaneIds = new List<ElementId>();
+            var dimensionWarnings = new List<string>();
+
+            ViewSection view = null;
+            IdType? viewId = parameters["viewId"]?.Value<IdType>();
+            if (viewId.HasValue)
+                view = doc.GetElement(new ElementId(viewId.Value)) as ViewSection;
+            else
+                view = uidoc.ActiveView as ViewSection;
+
+            if (view == null || view.IsTemplate)
+                throw new Exception("Provide a valid elevation ViewSection viewId or make one active.");
+
+            Wall wall = null;
+            IdType? wallId = parameters["wallId"]?.Value<IdType>();
+            if (wallId.HasValue)
+                wall = doc.GetElement(new ElementId(wallId.Value)) as Wall;
+            else
+            {
+                wall = new FilteredElementCollector(doc)
+                    .OfClass(typeof(Wall))
+                    .WhereElementIsNotElementType()
+                    .Cast<Wall>()
+                    .FirstOrDefault(w =>
+                    {
+                        try { return w.CurtainGrid != null; }
+                        catch { return false; }
+                    });
+            }
+
+            if (wall == null || wall.CurtainGrid == null)
+                throw new Exception("Provide a valid curtain wall wallId (Wall with CurtainGrid).");
+
+            CurtainElevationDimensionTypeResolution dimensionTypeResolution =
+                ResolveCurtainElevationDimensionType(doc, parameters, dimensionWarnings);
+            DimensionType dimensionType = dimensionTypeResolution.DimensionType;
+            if (dimensionType == null)
+                failures.Add("No DimensionType could be resolved.");
+
+            int referencePlaneCreatedCount = 0;
+            int referencePlaneReferenceCount = 0;
+            List<CurtainElevationGeometryReference> geometryReferences = new List<CurtainElevationGeometryReference>();
+            List<CurtainElevationGeometryReference> gridLineReferences = new List<CurtainElevationGeometryReference>();
+            CurtainElevationCropResult cropResult = null;
+
+            using (Transaction trans = new Transaction(doc, rollback ? "Diagnose curtain elevation dimensions (Rollback)" : "Diagnose curtain elevation dimensions"))
+            {
+                trans.Start();
+
+                try
+                {
+                    LocationCurve loc = wall.Location as LocationCurve;
+                    XYZ wallMid = loc?.Curve?.Evaluate(0.5, true);
+                    cropResult = ConfigureCurtainElevationCrop(doc, view, wall, wallMid, view.Origin, 0, 0, 1200.0 / 304.8);
+                    doc.Regenerate();
+
+                    Transform sourceFrame = GetCurtainElevationView2DFrame(view, view.CropBox?.Transform);
+                    Transform frame = GetCurtainElevationDimensionFrame(view, sourceFrame);
+                    if (frame == null || sourceFrame == null || cropResult.View2DMin == null || cropResult.View2DMax == null)
+                    {
+                        failures.Add("Cannot resolve dimension frame or crop 2D bounds.");
+                    }
+                    else if (dimensionType != null)
+                    {
+                        XYZ sourceOriginDelta = sourceFrame.Origin - frame.Origin;
+                        double xShift = sourceOriginDelta.DotProduct(frame.BasisX);
+                        double yShift = sourceOriginDelta.DotProduct(frame.BasisY);
+                        double minX = cropResult.View2DMin.X + xShift;
+                        double maxX = cropResult.View2DMax.X + xShift;
+                        double minY = cropResult.View2DMin.Y + yShift;
+                        double maxY = cropResult.View2DMax.Y + yShift;
+                        double offsetFt = 300.0 / 304.8;
+
+                        geometryReferences = CollectCurtainElevationGeometryReferences(doc, wall, view, frame, minX, maxX, minY, maxY);
+                        gridLineReferences = CollectCurtainElevationGridLineReferences(doc, wall, view, frame, minX, maxX, minY, maxY);
+                        if (testMode == "geometry_reference" || testMode == "both")
+                        {
+                            List<CurtainElevationGeometryReference> totalWidthRefs = SelectCurtainElevationBoundaryReferences(geometryReferences, "horizontal", minX, maxX, minY, maxY);
+                            attempts.Add(TryDiagnoseCurtainGeometryDimension(doc, view, frame, dimensionType, "total_width", "horizontal", new List<double> { minX, maxX }, totalWidthRefs, maxY + offsetFt));
+
+                            List<CurtainElevationGeometryReference> totalHeightRefs = SelectCurtainElevationBoundaryReferences(geometryReferences, "vertical", minX, maxX, minY, maxY);
+                            attempts.Add(TryDiagnoseCurtainGeometryDimension(doc, view, frame, dimensionType, "total_height", "vertical", new List<double> { minY, maxY }, totalHeightRefs, maxX + offsetFt));
+
+                            List<double> verticalGridXs = GetCurtainElevationGridCoordinates(doc, wall, frame, "vertical", minX, maxX, minY, maxY);
+                            List<CurtainElevationGeometryReference> verticalGridRefs = SelectCurtainElevationGridDimensionReferences(geometryReferences, gridLineReferences, "horizontal", verticalGridXs);
+                            attempts.Add(TryDiagnoseCurtainGeometryDimension(doc, view, frame, dimensionType, "horizontal_grid", "horizontal", verticalGridXs, verticalGridRefs, maxY + offsetFt * 2));
+
+                            List<double> horizontalGridYs = GetCurtainElevationGridCoordinates(doc, wall, frame, "horizontal", minX, maxX, minY, maxY);
+                            List<CurtainElevationGeometryReference> horizontalGridRefs = SelectCurtainElevationGridDimensionReferences(geometryReferences, gridLineReferences, "vertical", horizontalGridYs);
+                            attempts.Add(TryDiagnoseCurtainGeometryDimension(doc, view, frame, dimensionType, "vertical_grid", "vertical", horizontalGridYs, horizontalGridRefs, maxX + offsetFt * 2));
+                        }
+
+                        if (testMode == "reference_plane_fallback" || testMode == "both")
+                        {
+                            attempts.Add(TryDiagnoseCurtainReferencePlaneDimension(doc, view, frame, dimensionType, "total_width", "horizontal", new List<double> { minX, maxX }, minY, maxY, maxY + offsetFt, referencePlaneIds, out int widthRefs));
+                            referencePlaneReferenceCount += widthRefs;
+
+                            attempts.Add(TryDiagnoseCurtainReferencePlaneDimension(doc, view, frame, dimensionType, "total_height", "vertical", new List<double> { minY, maxY }, minX, maxX, maxX + offsetFt, referencePlaneIds, out int heightRefs));
+                            referencePlaneReferenceCount += heightRefs;
+                        }
+                    }
+
+                    doc.Regenerate();
+
+                    foreach (CurtainElevationDimensionAttempt attempt in attempts)
+                    {
+                        if (attempt?.DimensionId == null || attempt.DimensionId == ElementId.InvalidElementId)
+                            continue;
+
+                        createdDimensionIds.Add(attempt.DimensionId);
+                        Dimension dimension = doc.GetElement(attempt.DimensionId) as Dimension;
+                        attempt.ExistsAfterCreate = dimension != null;
+                        attempt.OwnerViewId = dimension?.OwnerViewId;
+                        if (dimension != null && dimension.OwnerViewId == view.Id)
+                            verifiedDimensionIds.Add(attempt.DimensionId);
+                        else if (dimension != null)
+                            attempt.FailureMessage = AppendCurtainElevationWarning(attempt.FailureMessage, $"OwnerViewId readback mismatch: {dimension.OwnerViewId.GetIdValue()}.");
+                    }
+
+                    referencePlaneCreatedCount = referencePlaneIds.Count;
+
+                    if (rollback)
+                        trans.RollBack();
+                    else
+                        trans.Commit();
+                }
+                catch (Exception ex)
+                {
+                    failures.Add(ex.Message);
+                    if (trans.GetStatus() == TransactionStatus.Started)
+                        trans.RollBack();
+                }
+            }
+
+            return new
+            {
+                WallId = wall.Id.GetIdValue(),
+                ViewId = view.Id.GetIdValue(),
+                ViewName = view.Name,
+                DimensionTypeId = dimensionType?.Id.GetIdValue(),
+                DimensionTypeName = dimensionType?.Name,
+                DimensionTypeSource = dimensionTypeResolution.Source,
+                DimensionWarnings = dimensionWarnings,
+                GeometryReferenceCount = geometryReferences.Count,
+                GeometryReferenceSamples = geometryReferences
+                    .Take(20)
+                    .Select(r => new
+                    {
+                        ElementId = r.ElementId?.GetIdValue(),
+                        Category = r.CategoryName,
+                        IsVertical = r.IsVertical,
+                        IsHorizontal = r.IsHorizontal,
+                        CenterXmm = Math.Round(r.CenterX * 304.8, 1),
+                        CenterYmm = Math.Round(r.CenterY * 304.8, 1),
+                        LengthMm = Math.Round(r.Length * 304.8, 1)
+                    })
+                    .ToList(),
+                ReferencePlaneCreatedCount = referencePlaneCreatedCount,
+                ReferencePlaneReferenceCount = referencePlaneReferenceCount,
+                ReferencePlaneIds = referencePlaneIds.Select(id => id.GetIdValue()).ToList(),
+                AttemptedDimensions = attempts.Select(ToCurtainElevationDimensionAttemptResult).ToList(),
+                CreatedDimensionIds = createdDimensionIds.Select(id => id.GetIdValue()).ToList(),
+                VerifiedDimensionIds = verifiedDimensionIds.Select(id => id.GetIdValue()).ToList(),
+                Failures = failures,
+                Rollback = rollback
+            };
+        }
+
+        private object DiagnoseCurtainWallElevationDirection(JObject parameters)
+        {
+            Document doc = _uiApp.ActiveUIDocument.Document;
+            UIDocument uidoc = _uiApp.ActiveUIDocument;
+
+            IdType wallId = parameters["wallId"]?.Value<IdType>() ?? 0;
+            if (wallId == 0)
+                throw new Exception("必�??��? wallId");
+
+            int scale = parameters["scale"]?.Value<int>() ?? 50;
+            double offsetFt = (parameters["offsetMm"]?.Value<double>() ?? 1500.0) / 304.8;
+            bool includeCropDiagnostics = parameters["includeCropDiagnostics"]?.Value<bool>() ?? false;
+
+            Wall wall = doc.GetElement(new ElementId(wallId)) as Wall;
+            if (wall == null)
+                throw new Exception($"?��???Wall ID: {wallId}");
+            if (wall.CurtainGrid == null)
+                throw new Exception($"Wall ID {wallId} 不是 CurtainGrid != null ?�帷幕�?");
+
+            LocationCurve loc = wall.Location as LocationCurve;
+            if (loc == null || loc.Curve == null)
+                throw new Exception($"Wall ID {wallId} 沒�??�用 LocationCurve");
+
+            ViewFamilyType elevationType = new FilteredElementCollector(doc)
+                .OfClass(typeof(ViewFamilyType))
+                .Cast<ViewFamilyType>()
+                .FirstOrDefault(vft => vft.ViewFamily == ViewFamily.Elevation);
+            if (elevationType == null)
+                throw new Exception("?��???Elevation ??ViewFamilyType");
+
+            ViewPlan explicitPlacementView = ResolveCurtainElevationPlacementView(doc, parameters);
+            Dictionary<ElementId, ViewPlan> floorPlansByLevel = GetCurtainElevationFloorPlansByLevel(doc);
+            ViewPlan activePlan = uidoc.ActiveView as ViewPlan;
+            if (activePlan != null && activePlan.IsTemplate)
+                activePlan = null;
+
+            ViewPlan placementView = explicitPlacementView
+                ?? ResolveCurtainElevationPlanForWall(wall, activePlan, floorPlansByLevel);
+            if (placementView == null)
+                throw new Exception("?��??�可?��??�置 ElevationMarker ??ViewPlan");
+
+            Level level = doc.GetElement(wall.LevelId) as Level;
+            Curve curve = loc.Curve;
+            XYZ start = curve.GetEndPoint(0);
+            XYZ end = curve.GetEndPoint(1);
+            XYZ wallMid = curve.Evaluate(0.5, true);
+            XYZ wallDirection = FlattenAndNormalize(end - start);
+            XYZ wallOrientation = FlattenAndNormalize(wall.Orientation);
+            if (wallOrientation == null)
+                throw new Exception("?��??�斷 wall.Orientation");
+
+            XYZ apiExteriorMarkerPoint = wallMid + wallOrientation * (wall.Width / 2.0 + offsetFt);
+            XYZ apiExteriorLookDirection = GetCurtainElevationDesiredLookDirection(wallMid, apiExteriorMarkerPoint);
+            XYZ uiArrowSideCandidate = wallOrientation.Negate();
+            XYZ uiArrowMarkerPoint = wallMid + uiArrowSideCandidate * (wall.Width / 2.0 + offsetFt);
+            var notes = new List<string>
+            {
+                "Points are millimeters in model coordinates; vectors are unitless XYZ directions.",
+                "UiArrowSideCandidate is a diagnostic hypothesis only: opposite of wall.Orientation. It is not used by create_curtain_wall_elevations.",
+                "The temporary ElevationMarker/ViewSection are created inside a rollback transaction and should not remain in the model."
+            };
+
+            XYZ initialViewDirection = null;
+            XYZ initialVisualLookDirection = null;
+            XYZ temporaryViewDirection = null;
+            XYZ temporaryVisualLookDirection = null;
+            double directionDot = -1.0;
+            bool directionFixApplied = false;
+            bool wouldPassDirectionCheck = false;
+            object cropDiagnostics = null;
+
+            using (Transaction trans = new Transaction(doc, "Diagnose curtain wall elevation direction (Rollback)"))
+            {
+                trans.Start();
+
+                ElevationMarker marker = ElevationMarker.CreateElevationMarker(doc, elevationType.Id, apiExteriorMarkerPoint, scale);
+                ViewSection view = marker.CreateElevation(doc, placementView.Id, 0);
+                doc.Regenerate();
+
+                initialViewDirection = view.ViewDirection;
+                initialVisualLookDirection = GetCurtainElevationVisualLookDirection(view);
+
+                CurtainElevationDirectionResult directionResult = AlignCurtainElevationMarkerByVisualLook(
+                    doc, marker, apiExteriorMarkerPoint, view, apiExteriorLookDirection);
+
+                temporaryViewDirection = view.ViewDirection;
+                temporaryVisualLookDirection = directionResult.FinalVisualLookDirection;
+                directionDot = directionResult.DirectionDot;
+                directionFixApplied = directionResult.DirectionFixApplied;
+                wouldPassDirectionCheck = directionDot >= CurtainElevationDirectionDotThreshold;
+
+                if (includeCropDiagnostics)
+                    cropDiagnostics = BuildCurtainElevationCropDiagnostics(doc, wall, view, wallMid, apiExteriorMarkerPoint, directionResult);
+
+                trans.RollBack();
+            }
+
+            return new
+            {
+                WallId = wall.Id.GetIdValue(),
+                WallType = wall.WallType?.Name,
+                LevelName = level?.Name,
+                Flipped = wall.Flipped,
+                Units = "points=mm, vectors=unitless",
+                StartPoint = ToCurtainElevationPointMm(start),
+                EndPoint = ToCurtainElevationPointMm(end),
+                WallMidPoint = ToCurtainElevationPointMm(wallMid),
+                WallDirection = ToCurtainElevationXyz(wallDirection),
+                WallOrientation = ToCurtainElevationXyz(wallOrientation),
+                ApiExteriorMarkerPoint = ToCurtainElevationPointMm(apiExteriorMarkerPoint),
+                ApiExteriorLookDirection = ToCurtainElevationXyz(apiExteriorLookDirection),
+                UiArrowSideCandidate = ToCurtainElevationXyz(uiArrowSideCandidate),
+                UiArrowMarkerPoint = ToCurtainElevationPointMm(uiArrowMarkerPoint),
+                InitialViewDirection = ToCurtainElevationXyz(initialViewDirection),
+                InitialVisualLookDirection = ToCurtainElevationXyz(initialVisualLookDirection),
+                TemporaryViewDirection = ToCurtainElevationXyz(temporaryViewDirection),
+                TemporaryVisualLookDirection = ToCurtainElevationXyz(temporaryVisualLookDirection),
+                DirectionDot = Math.Round(directionDot, 4),
+                DirectionFixApplied = directionFixApplied,
+                WouldPassDirectionCheck = wouldPassDirectionCheck,
+                DirectionDotThreshold = CurtainElevationDirectionDotThreshold,
+                IncludeCropDiagnostics = includeCropDiagnostics,
+                CropDiagnostics = cropDiagnostics,
+                PlacementViewId = placementView.Id.GetIdValue(),
+                PlacementViewName = placementView.Name,
+                Notes = notes
+            };
+        }
+
+        private object DiagnoseCurtainWallElevationDirections(JObject parameters)
+        {
+            Document doc = _uiApp.ActiveUIDocument.Document;
+            UIDocument uidoc = _uiApp.ActiveUIDocument;
+
+            int scale = parameters["scale"]?.Value<int>() ?? 50;
+            double offsetFt = (parameters["offsetMm"]?.Value<double>() ?? 1500.0) / 304.8;
+            bool includeTemporaryMarker = parameters["includeTemporaryMarker"]?.Value<bool>() ?? true;
+            bool includeCropDiagnostics = parameters["includeCropDiagnostics"]?.Value<bool>() ?? false;
+            if (includeCropDiagnostics)
+                includeTemporaryMarker = true;
+            JObject knownExteriorSideByWallId = parameters["knownExteriorSideByWallId"] as JObject;
+
+            ViewFamilyType elevationType = null;
+            if (includeTemporaryMarker)
+            {
+                elevationType = new FilteredElementCollector(doc)
+                    .OfClass(typeof(ViewFamilyType))
+                    .Cast<ViewFamilyType>()
+                    .FirstOrDefault(vft => vft.ViewFamily == ViewFamily.Elevation);
+                if (elevationType == null)
+                    throw new Exception("No Elevation ViewFamilyType is available.");
+            }
+
+            ViewPlan explicitPlacementView = ResolveCurtainElevationPlacementView(doc, parameters);
+            Dictionary<ElementId, ViewPlan> floorPlansByLevel = GetCurtainElevationFloorPlansByLevel(doc);
+            ViewPlan activePlan = uidoc.ActiveView as ViewPlan;
+            if (activePlan != null && activePlan.IsTemplate)
+                activePlan = null;
+
+            JArray requestedWallIds = parameters["wallIds"] as JArray;
+            var walls = new List<Wall>();
+            var skipped = new List<object>();
+
+            if (requestedWallIds != null && requestedWallIds.Count > 0)
+            {
+                foreach (JToken token in requestedWallIds)
+                {
+                    IdType id = token.Value<IdType>();
+                    Wall wall = doc.GetElement(new ElementId(id)) as Wall;
+                    if (wall == null)
+                    {
+                        skipped.Add(new { WallId = id, Reason = "Element is not a Wall." });
+                        continue;
+                    }
+
+                    bool isCurtainWall = false;
+                    try { isCurtainWall = wall.CurtainGrid != null; }
+                    catch { isCurtainWall = false; }
+
+                    if (!isCurtainWall)
+                    {
+                        skipped.Add(new { WallId = id, Reason = "Wall.CurtainGrid is null." });
+                        continue;
+                    }
+
+                    walls.Add(wall);
+                }
+            }
+            else
+            {
+                walls = new FilteredElementCollector(doc)
+                    .OfClass(typeof(Wall))
+                    .WhereElementIsNotElementType()
+                    .Cast<Wall>()
+                    .Where(w =>
+                    {
+                        try { return w.CurtainGrid != null; }
+                        catch { return false; }
+                    })
+                    .OrderBy(w => w.LevelId.GetIdValue())
+                    .ThenBy(w => w.Id.GetIdValue())
+                    .ToList();
+            }
+
+            var results = new List<object>();
+
+            foreach (Wall wall in walls)
+            {
+                Level level = doc.GetElement(wall.LevelId) as Level;
+                string mark = GetCurtainWallMark(wall);
+
+                try
+                {
+                    LocationCurve loc = wall.Location as LocationCurve;
+                    if (loc == null || loc.Curve == null)
+                    {
+                        skipped.Add(new { WallId = wall.Id.GetIdValue(), LevelName = level?.Name, Mark = mark, Reason = "Wall has no usable LocationCurve." });
+                        continue;
+                    }
+
+                    XYZ wallOrientation = FlattenAndNormalize(wall.Orientation);
+                    if (wallOrientation == null)
+                    {
+                        skipped.Add(new { WallId = wall.Id.GetIdValue(), LevelName = level?.Name, Mark = mark, Reason = "Cannot resolve wall.Orientation." });
+                        continue;
+                    }
+
+                    ViewPlan placementView = null;
+                    if (includeTemporaryMarker)
+                    {
+                        placementView = explicitPlacementView
+                            ?? ResolveCurtainElevationPlanForWall(wall, activePlan, floorPlansByLevel);
+                        if (placementView == null)
+                        {
+                            skipped.Add(new { WallId = wall.Id.GetIdValue(), LevelName = level?.Name, Mark = mark, Reason = "No usable ViewPlan for temporary ElevationMarker placement." });
+                            continue;
+                        }
+                    }
+
+                    Curve curve = loc.Curve;
+                    XYZ start = curve.GetEndPoint(0);
+                    XYZ end = curve.GetEndPoint(1);
+                    XYZ wallMid = curve.Evaluate(0.5, true);
+                    XYZ wallDirection = FlattenAndNormalize(end - start);
+                    CurtainElevationExteriorResolution autoResolved = ResolveCurtainElevationExteriorSide(wall);
+
+                    CurtainElevationSideCandidate apiCandidate;
+                    CurtainElevationSideCandidate oppositeCandidate;
+                    object cropDiagnostics = null;
+
+                    if (includeTemporaryMarker)
+                    {
+                        using (Transaction trans = new Transaction(doc, "Diagnose curtain wall elevation sides (Rollback)"))
+                        {
+                            trans.Start();
+                            apiCandidate = BuildCurtainElevationSideCandidate(
+                                doc, elevationType, placementView, wall, wallMid, wallOrientation, offsetFt, scale, "api_orientation", true);
+                            oppositeCandidate = BuildCurtainElevationSideCandidate(
+                                doc, elevationType, placementView, wall, wallMid, wallOrientation.Negate(), offsetFt, scale, "opposite_orientation", true);
+                            if (includeCropDiagnostics)
+                            {
+                                cropDiagnostics = BuildCurtainElevationCropDiagnosticsForSide(
+                                    doc, elevationType, placementView, wall, wallMid, autoResolved?.ExteriorDirection, offsetFt, scale);
+                            }
+                            trans.RollBack();
+                        }
+                    }
+                    else
+                    {
+                        apiCandidate = BuildCurtainElevationSideCandidate(
+                            doc, elevationType, placementView, wall, wallMid, wallOrientation, offsetFt, scale, "api_orientation", false);
+                        oppositeCandidate = BuildCurtainElevationSideCandidate(
+                            doc, elevationType, placementView, wall, wallMid, wallOrientation.Negate(), offsetFt, scale, "opposite_orientation", false);
+                    }
+
+                    string wallIdKey = wall.Id.GetIdValue().ToString();
+                    string knownExteriorSide = knownExteriorSideByWallId?[wallIdKey]?.Value<string>();
+                    bool knownSideValid = knownExteriorSide == "api_orientation" || knownExteriorSide == "opposite_orientation";
+                    string matchedCandidate = knownSideValid ? knownExteriorSide : null;
+                    string autoResolvedCandidate = autoResolved?.SideName;
+                    bool? autoMatchesKnownExteriorSide = knownSideValid && autoResolvedCandidate != null
+                        ? autoResolvedCandidate == knownExteriorSide
+                        : (bool?)null;
+                    string recommendation = knownSideValid
+                        ? knownExteriorSide
+                        : "ambiguous_requires_user_label";
+
+                    results.Add(new
+                    {
+                        WallId = wall.Id.GetIdValue(),
+                        WallType = wall.WallType?.Name,
+                        LevelName = level?.Name,
+                        Mark = mark,
+                        Flipped = wall.Flipped,
+                        Units = "points=mm, vectors=unitless",
+                        StartPoint = ToCurtainElevationPointMm(start),
+                        EndPoint = ToCurtainElevationPointMm(end),
+                        WallMidPoint = ToCurtainElevationPointMm(wallMid),
+                        WallDirection = ToCurtainElevationXyz(wallDirection),
+                        WallOrientation = ToCurtainElevationXyz(wallOrientation),
+                        ApiCandidate = ToCurtainElevationSideCandidateResult(apiCandidate),
+                        OppositeCandidate = ToCurtainElevationSideCandidateResult(oppositeCandidate),
+                        KnownExteriorSide = knownExteriorSide,
+                        KnownExteriorSideValid = knownSideValid,
+                        MatchedCandidate = matchedCandidate,
+                        AutoResolvedCandidate = autoResolvedCandidate,
+                        AutoResolvedSource = autoResolved?.Source,
+                        AutoResolvedExteriorDirection = ToCurtainElevationXyz(autoResolved?.ExteriorDirection),
+                        AutoMatchesKnownExteriorSide = autoMatchesKnownExteriorSide,
+                        Recommendation = recommendation,
+                        IncludeCropDiagnostics = includeCropDiagnostics,
+                        CropDiagnostics = cropDiagnostics,
+                        PlacementViewId = placementView?.Id.GetIdValue() ?? 0,
+                        PlacementViewName = placementView?.Name,
+                        Notes = new[]
+                        {
+                            "Revit API does not expose the wall flip-control/double-arrow UI position as queryable model geometry.",
+                            "api_orientation uses wall.Orientation. opposite_orientation uses -wall.Orientation.",
+                            "Recommendation remains ambiguous unless knownExteriorSideByWallId supplies a user label."
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    skipped.Add(new { WallId = wall.Id.GetIdValue(), LevelName = level?.Name, Mark = mark, Reason = ex.Message });
+                }
+            }
+
+            return new
+            {
+                Success = true,
+                TotalCurtainWalls = requestedWallIds != null && requestedWallIds.Count > 0 ? requestedWallIds.Count : walls.Count,
+                DiagnosedCount = results.Count,
+                SkippedCount = skipped.Count,
+                IncludeTemporaryMarker = includeTemporaryMarker,
+                DirectionDotThreshold = CurtainElevationDirectionDotThreshold,
+                Results = results,
+                Skipped = skipped
+            };
+        }
+
+        private string GetCurtainWallMark(Wall wall)
+        {
+            string mark = wall.get_Parameter(BuiltInParameter.ALL_MODEL_MARK)?.AsString();
+            return string.IsNullOrWhiteSpace(mark) ? $"CW-{wall.Id.GetIdValue()}" : mark.Trim();
+        }
+
+        private ViewPlan ResolveCurtainElevationPlacementView(Document doc, JObject parameters)
+        {
+            IdType placementViewId = parameters["placementViewId"]?.Value<IdType>() ?? 0;
+            string placementViewName = parameters["placementViewName"]?.Value<string>();
+
+            if (placementViewId != 0)
+            {
+                ViewPlan view = doc.GetElement(new ElementId(placementViewId)) as ViewPlan;
+                if (view == null || view.IsTemplate)
+                    throw new Exception($"placementViewId {placementViewId} 不是?�用??ViewPlan");
+                return view;
+            }
+
+            if (!string.IsNullOrWhiteSpace(placementViewName))
+            {
+                ViewPlan view = new FilteredElementCollector(doc)
+                    .OfClass(typeof(ViewPlan))
+                    .Cast<ViewPlan>()
+                    .FirstOrDefault(v => !v.IsTemplate && v.Name == placementViewName);
+                if (view == null)
+                    throw new Exception($"?��???placementViewName ?��???ViewPlan: {placementViewName}");
+                return view;
+            }
+
+            return null;
+        }
+
+        private ViewFamilyType GetFirstCurtainElevationViewFamilyType(Document doc)
+        {
+            return new FilteredElementCollector(doc)
+                .OfClass(typeof(ViewFamilyType))
+                .Cast<ViewFamilyType>()
+                .FirstOrDefault(vft => vft.ViewFamily == ViewFamily.Elevation);
+        }
+
+        private ViewFamilyType FindCurtainElevationViewFamilyType(Document doc, string typeName)
+        {
+            if (string.IsNullOrWhiteSpace(typeName))
+                return null;
+
+            return new FilteredElementCollector(doc)
+                .OfClass(typeof(ViewFamilyType))
+                .Cast<ViewFamilyType>()
+                .FirstOrDefault(vft => vft.ViewFamily == ViewFamily.Elevation && vft.Name == typeName);
+        }
+
+        private ViewFamilyType GetOrCreateCurtainElevationViewFamilyType(
+            Document doc,
+            ViewFamilyType sourceElevationType,
+            string typeName,
+            out bool created,
+            List<string> warnings)
+        {
+            created = false;
+            string resolvedName = string.IsNullOrWhiteSpace(typeName) ? "帷幕立面" : typeName.Trim();
+            ViewFamilyType existing = FindCurtainElevationViewFamilyType(doc, resolvedName);
+            if (existing != null)
+                return existing;
+
+            if (sourceElevationType == null)
+                throw new Exception("?��???Elevation ??ViewFamilyType");
+
+            try
+            {
+                ElementType duplicated = sourceElevationType.Duplicate(resolvedName);
+                ViewFamilyType createdType = duplicated as ViewFamilyType;
+                if (createdType == null)
+                    throw new Exception("Duplicate did not return a ViewFamilyType.");
+
+                created = true;
+                return createdType;
+            }
+            catch (Exception ex)
+            {
+                warnings?.Add($"?��?建�?立面?��??�「{resolvedName}?��??�用?��?類�??�{sourceElevationType.Name}?? {ex.Message}");
+                return sourceElevationType;
+            }
+        }
+
+        private Dictionary<ElementId, ViewPlan> GetCurtainElevationFloorPlansByLevel(Document doc)
+        {
+            var result = new Dictionary<ElementId, ViewPlan>();
+            foreach (ViewPlan view in new FilteredElementCollector(doc).OfClass(typeof(ViewPlan)).Cast<ViewPlan>())
+            {
+                if (view.IsTemplate || view.ViewType != ViewType.FloorPlan || view.GenLevel == null)
+                    continue;
+                if (!result.ContainsKey(view.GenLevel.Id))
+                    result[view.GenLevel.Id] = view;
+            }
+            return result;
+        }
+
+        private ViewPlan ResolveCurtainElevationPlanForWall(Wall wall, ViewPlan activePlan, Dictionary<ElementId, ViewPlan> floorPlansByLevel)
+        {
+            if (activePlan != null && activePlan.ViewType == ViewType.FloorPlan)
+                return activePlan;
+            if (floorPlansByLevel.TryGetValue(wall.LevelId, out ViewPlan plan))
+                return plan;
+            return null;
+        }
+
+        private string MakeUniqueCurtainElevationViewName(HashSet<string> existingNames, string baseName)
+        {
+            baseName = string.IsNullOrWhiteSpace(baseName) ? "帷幕立面" : baseName.Trim();
+            if (existingNames.Add(baseName))
+                return baseName;
+
+            for (int i = 2; i < 10000; i++)
+            {
+                string candidate = $"{baseName}_{i}";
+                if (existingNames.Add(candidate))
+                    return candidate;
+            }
+
+            string fallback = $"{baseName}_{DateTime.Now:HHmmss}";
+            existingNames.Add(fallback);
+            return fallback;
+        }
+
+        private XYZ FlattenAndNormalize(XYZ vector)
+        {
+            if (vector == null)
+                return null;
+            XYZ flat = new XYZ(vector.X, vector.Y, 0);
+            return flat.GetLength() < 1e-9 ? null : flat.Normalize();
+        }
+
+        private class CurtainElevationDirectionResult
+        {
+            public double DirectionDot { get; set; } = -1.0;
+            public bool DirectionFixApplied { get; set; }
+            public XYZ DesiredLookDirection { get; set; }
+            public XYZ FinalVisualLookDirection { get; set; }
+        }
+
+        private class CurtainElevationExteriorResolution
+        {
+            public string SideName { get; set; }
+            public XYZ ExteriorDirection { get; set; }
+            public string Source { get; set; }
+        }
+
+        private CurtainElevationExteriorResolution ResolveCurtainElevationExteriorSide(Wall wall)
+        {
+            XYZ orientation = FlattenAndNormalize(wall?.Orientation);
+            if (orientation == null)
+            {
+                return new CurtainElevationExteriorResolution
+                {
+                    SideName = null,
+                    ExteriorDirection = null,
+                    Source = "wall.Flipped"
+                };
+            }
+
+            bool useApiOrientation = wall.Flipped;
+            return new CurtainElevationExteriorResolution
+            {
+                SideName = useApiOrientation ? "api_orientation" : "opposite_orientation",
+                ExteriorDirection = useApiOrientation ? orientation : orientation.Negate(),
+                Source = "wall.Flipped"
+            };
+        }
+
+        private class CurtainElevationSideCandidate
+        {
+            public string CandidateName { get; set; }
+            public XYZ ExteriorDirection { get; set; }
+            public XYZ MarkerPoint { get; set; }
+            public XYZ DesiredLookDirection { get; set; }
+            public XYZ InitialViewDirection { get; set; }
+            public XYZ InitialVisualLookDirection { get; set; }
+            public XYZ TemporaryViewDirection { get; set; }
+            public XYZ TemporaryVisualLookDirection { get; set; }
+            public double DirectionDot { get; set; } = -1.0;
+            public bool DirectionFixApplied { get; set; }
+            public bool WouldPassDirectionCheck { get; set; }
+            public string Error { get; set; }
+        }
+
+        private CurtainElevationSideCandidate BuildCurtainElevationSideCandidate(
+            Document doc,
+            ViewFamilyType elevationType,
+            ViewPlan placementView,
+            Wall wall,
+            XYZ wallMid,
+            XYZ exteriorDirection,
+            double offsetFt,
+            int scale,
+            string candidateName,
+            bool includeTemporaryMarker)
+        {
+            XYZ exterior = FlattenAndNormalize(exteriorDirection);
+            XYZ markerPoint = wallMid != null && exterior != null
+                ? wallMid + exterior * (wall.Width / 2.0 + offsetFt)
+                : null;
+            XYZ desiredLookDirection = GetCurtainElevationDesiredLookDirection(wallMid, markerPoint);
+
+            var candidate = new CurtainElevationSideCandidate
+            {
+                CandidateName = candidateName,
+                ExteriorDirection = exterior,
+                MarkerPoint = markerPoint,
+                DesiredLookDirection = desiredLookDirection
+            };
+
+            if (!includeTemporaryMarker)
+                return candidate;
+
+            if (doc == null || elevationType == null || placementView == null || markerPoint == null || desiredLookDirection == null)
+            {
+                candidate.Error = "Missing data required to create a temporary ElevationMarker.";
+                return candidate;
+            }
+
+            try
+            {
+                ElevationMarker marker = ElevationMarker.CreateElevationMarker(doc, elevationType.Id, markerPoint, scale);
+                ViewSection view = marker.CreateElevation(doc, placementView.Id, 0);
+                doc.Regenerate();
+
+                candidate.InitialViewDirection = view.ViewDirection;
+                candidate.InitialVisualLookDirection = GetCurtainElevationVisualLookDirection(view);
+
+                CurtainElevationDirectionResult directionResult = AlignCurtainElevationMarkerByVisualLook(
+                    doc, marker, markerPoint, view, desiredLookDirection);
+
+                candidate.TemporaryViewDirection = view.ViewDirection;
+                candidate.TemporaryVisualLookDirection = directionResult.FinalVisualLookDirection;
+                candidate.DirectionDot = directionResult.DirectionDot;
+                candidate.DirectionFixApplied = directionResult.DirectionFixApplied;
+                candidate.WouldPassDirectionCheck = directionResult.DirectionDot >= CurtainElevationDirectionDotThreshold;
+            }
+            catch (Exception ex)
+            {
+                candidate.Error = ex.Message;
+            }
+
+            return candidate;
+        }
+
+        private object ToCurtainElevationSideCandidateResult(CurtainElevationSideCandidate candidate)
+        {
+            if (candidate == null)
+                return null;
+
+            return new
+            {
+                CandidateName = candidate.CandidateName,
+                ExteriorDirection = ToCurtainElevationXyz(candidate.ExteriorDirection),
+                MarkerPoint = ToCurtainElevationPointMm(candidate.MarkerPoint),
+                DesiredLookDirection = ToCurtainElevationXyz(candidate.DesiredLookDirection),
+                InitialViewDirection = ToCurtainElevationXyz(candidate.InitialViewDirection),
+                InitialVisualLookDirection = ToCurtainElevationXyz(candidate.InitialVisualLookDirection),
+                TemporaryViewDirection = ToCurtainElevationXyz(candidate.TemporaryViewDirection),
+                TemporaryVisualLookDirection = ToCurtainElevationXyz(candidate.TemporaryVisualLookDirection),
+                DirectionDot = Math.Round(candidate.DirectionDot, 4),
+                DirectionFixApplied = candidate.DirectionFixApplied,
+                WouldPassDirectionCheck = candidate.WouldPassDirectionCheck,
+                Error = candidate.Error
+            };
+        }
+
+        private XYZ GetCurtainElevationDesiredLookDirection(XYZ wallMid, XYZ markerPoint)
+        {
+            if (wallMid == null || markerPoint == null)
+                return null;
+
+            return FlattenAndNormalize(wallMid - markerPoint);
+        }
+
+        private XYZ GetCurtainElevationVisualLookDirection(ViewSection view)
+        {
+            if (view == null)
+                return null;
+
+            // Elevation API ViewDirection is opposite to the visible marker look direction.
+            return FlattenAndNormalize(view.ViewDirection.Negate());
+        }
+
+        private CurtainElevationDirectionResult AlignCurtainElevationMarkerByVisualLook(
+            Document doc,
+            ElevationMarker marker,
+            XYZ origin,
+            ViewSection view,
+            XYZ desiredLookDirection)
+        {
+            XYZ desired = FlattenAndNormalize(desiredLookDirection);
+            var result = new CurtainElevationDirectionResult
+            {
+                DesiredLookDirection = desired,
+                FinalVisualLookDirection = GetCurtainElevationVisualLookDirection(view)
+            };
+
+            if (doc == null || marker == null || origin == null || view == null || desired == null)
+                return result;
+
+            RotateCurtainElevationMarkerByVisualLook(doc, marker, origin, view, desired);
+            doc.Regenerate();
+
+            result.FinalVisualLookDirection = GetCurtainElevationVisualLookDirection(view);
+            result.DirectionDot = GetCurtainElevationDirectionDot(result.FinalVisualLookDirection, desired);
+
+            if (result.DirectionDot < 0.0)
+            {
+                Line axis = Line.CreateBound(origin, origin + XYZ.BasisZ);
+                ElementTransformUtils.RotateElement(doc, marker.Id, axis, Math.PI);
+                result.DirectionFixApplied = true;
+                doc.Regenerate();
+
+                result.FinalVisualLookDirection = GetCurtainElevationVisualLookDirection(view);
+                result.DirectionDot = GetCurtainElevationDirectionDot(result.FinalVisualLookDirection, desired);
+            }
+
+            return result;
+        }
+
+        private void RotateCurtainElevationMarkerByVisualLook(
+            Document doc,
+            ElevationMarker marker,
+            XYZ origin,
+            ViewSection view,
+            XYZ desiredLookDirection)
+        {
+            XYZ current = GetCurtainElevationVisualLookDirection(view);
+            XYZ desired = FlattenAndNormalize(desiredLookDirection);
+            if (current == null || desired == null)
+                return;
+
+            double dot = Math.Max(-1.0, Math.Min(1.0, current.DotProduct(desired)));
+            double crossZ = current.CrossProduct(desired).Z;
+            double angle = Math.Atan2(crossZ, dot);
+            if (Math.Abs(angle) < 1e-9)
+                return;
+
+            Line axis = Line.CreateBound(origin, origin + XYZ.BasisZ);
+            ElementTransformUtils.RotateElement(doc, marker.Id, axis, angle);
+        }
+
+        private double GetCurtainElevationDirectionDot(XYZ visualLookDirection, XYZ desiredLookDirection)
+        {
+            XYZ visual = FlattenAndNormalize(visualLookDirection);
+            XYZ desired = FlattenAndNormalize(desiredLookDirection);
+            if (visual == null || desired == null)
+                return -1.0;
+
+            return Math.Max(-1.0, Math.Min(1.0, visual.DotProduct(desired)));
+        }
+
+        private void DeleteCurtainElevationMarkerAndView(Document doc, ElevationMarker marker, ViewSection view)
+        {
+            var ids = new List<ElementId>();
+            if (view != null && view.Id != ElementId.InvalidElementId)
+                ids.Add(view.Id);
+            if (marker != null && marker.Id != ElementId.InvalidElementId)
+                ids.Add(marker.Id);
+
+            foreach (ElementId id in ids.Distinct())
+            {
+                try
+                {
+                    if (doc.GetElement(id) != null)
+                        doc.Delete(id);
+                }
+                catch
+                {
+                    // Best effort cleanup; the skipped result still reports the direction failure.
+                }
+            }
+        }
+
+        private object ToCurtainElevationXyz(XYZ value)
+        {
+            if (value == null)
+                return null;
+
+            return new
+            {
+                X = Math.Round(value.X, 6),
+                Y = Math.Round(value.Y, 6),
+                Z = Math.Round(value.Z, 6)
+            };
+        }
+
+        private object ToCurtainElevationPointMm(XYZ value)
+        {
+            if (value == null)
+                return null;
+
+            return new
+            {
+                X = Math.Round(value.X * 304.8, 2),
+                Y = Math.Round(value.Y * 304.8, 2),
+                Z = Math.Round(value.Z * 304.8, 2)
+            };
+        }
+
+        private class CurtainElevationCropResult
+        {
+            public double FarClipDepthFt { get; set; }
+            public string FarClipMethod { get; set; } = "fallback_depth";
+            public double FarClipRequestedDepthFt { get; set; }
+            public double? FarClipActualOffsetFt { get; set; }
+            public int? FarClipActualActive { get; set; }
+            public int? FarClipActualMode { get; set; }
+            public XYZ FarClipDepthOrigin { get; set; }
+            public XYZ FarClipLookDirection { get; set; }
+            public double FarClipMinCandidateDepthFt { get; set; }
+            public double FarClipMaxCandidateDepthFt { get; set; }
+            public int FarClipPositivePointCount { get; set; }
+            public string FarClipWarning { get; set; }
+            public double FarClipMarginFt { get; set; }
+            public double FarClipNearestTargetFt { get; set; }
+            public double FarClipFarthestTargetFt { get; set; }
+            public string FarClipPointSource { get; set; }
+            public object FarClipExtremeContributor { get; set; }
+            public bool FarClipCropBoxDepthApplied { get; set; }
+            public string FarClipCropBoxDepthMethod { get; set; }
+            public double FarClipViewOriginLocalZFt { get; set; }
+            public double FarClipLookDirectionLocalZ { get; set; }
+            public double FarClipCropBoxMinZBeforeFt { get; set; }
+            public double FarClipCropBoxMaxZBeforeFt { get; set; }
+            public double FarClipCropBoxMinZAfterFt { get; set; }
+            public double FarClipCropBoxMaxZAfterFt { get; set; }
+            public double FarClipCropBoxDepthAfterFt { get; set; }
+            public double FarClipDepthDeltaFt { get; set; }
+            public bool FarClipPass { get; set; }
+            public string Method { get; set; } = "view_2d_visible_bounds";
+            public string PointSource { get; set; } = "bbox_fallback";
+            public int PointCount { get; set; }
+            public int FallbackElementCount { get; set; }
+            public string FrameSource { get; set; } = "unresolved";
+            public XYZ RightDirection { get; set; }
+            public XYZ UpDirection { get; set; }
+            public XYZ DepthDirection { get; set; }
+            public XYZ LocalMin { get; set; }
+            public XYZ LocalMax { get; set; }
+            public bool UsedRevitTransformFallback { get; set; }
+            public bool UsedHostWallFallback { get; set; }
+            public List<IdType> ContributingElementIds { get; set; } = new List<IdType>();
+            public List<IdType> FallbackElementIds { get; set; } = new List<IdType>();
+            public object ExtremeContributors { get; set; }
+            public XYZ View2DOrigin { get; set; }
+            public XYZ View2DRightDirection { get; set; }
+            public XYZ View2DUpDirection { get; set; }
+            public XYZ View2DMin { get; set; }
+            public XYZ View2DMax { get; set; }
+            public int View2DPointCount { get; set; }
+            public string View2DSource { get; set; }
+            public object View2DExtremeContributors { get; set; }
+            public bool RegionShapeApplied { get; set; }
+            public string RegionShapeFallbackReason { get; set; } = "disabled_for_diagnostics";
+        }
+
+        private class CurtainElevationDimensionTypeResolution
+        {
+            public DimensionType DimensionType { get; set; }
+            public string Source { get; set; } = "not_resolved";
+        }
+
+        private class CurtainElevationDimensionResult
+        {
+            public ElementId TotalWidthDimensionId { get; set; }
+            public ElementId HorizontalGridDimensionId { get; set; }
+            public ElementId TotalHeightDimensionId { get; set; }
+            public ElementId VerticalGridDimensionId { get; set; }
+            public List<ElementId> ReferenceCurveIds { get; } = new List<ElementId>();
+            public List<string> Warnings { get; } = new List<string>();
+            public int GeometryReferenceCount { get; set; }
+            public int CurtainGridLineCount { get; set; }
+            public int CurtainGridLineReferenceCount { get; set; }
+            public List<string> CurtainGridLineReferenceFailures { get; } = new List<string>();
+            public List<object> CurtainGridLineReferenceSamples { get; } = new List<object>();
+            public List<string> GeometryReferenceCategories { get; set; } = new List<string>();
+            public string TotalWidthDimensionReferenceSource { get; set; }
+            public string TotalHeightDimensionReferenceSource { get; set; }
+            public string HorizontalGridDimensionReferenceSource { get; set; }
+            public string VerticalGridDimensionReferenceSource { get; set; }
+            public string DimensionFallbackReason { get; set; }
+            public int AttemptCount { get; set; }
+            public int VerifiedCount { get; set; }
+            public List<string> CreationErrors { get; } = new List<string>();
+            public int CreatedCount { get; set; }
+            public int FailedCount { get; set; }
+            public string Status { get; set; } = "not_started";
+            public string Warning => string.Join(" ", Warnings.Where(w => !string.IsNullOrWhiteSpace(w)));
+        }
+
+        private class CurtainElevationGeometryReference
+        {
+            public Reference Reference { get; set; }
+            public ElementId ElementId { get; set; }
+            public string CategoryName { get; set; }
+            public XYZ Start { get; set; }
+            public XYZ End { get; set; }
+            public double MinX { get; set; }
+            public double MaxX { get; set; }
+            public double MinY { get; set; }
+            public double MaxY { get; set; }
+            public double CenterX => (MinX + MaxX) / 2.0;
+            public double CenterY => (MinY + MaxY) / 2.0;
+            public double Length { get; set; }
+            public bool IsVertical { get; set; }
+            public bool IsHorizontal { get; set; }
+            public ElementId CurtainGridLineId { get; set; }
+            public string StableRepresentation { get; set; }
+            public string GeometryObjectType { get; set; }
+            public bool SelectedForDimension { get; set; }
+            public string SelectionReason { get; set; }
+        }
+
+        private class CurtainElevationDimensionAttempt
+        {
+            public string Name { get; set; }
+            public string Method { get; set; }
+            public int ReferenceCount { get; set; }
+            public XYZ DimensionLineStart { get; set; }
+            public XYZ DimensionLineEnd { get; set; }
+            public bool Success { get; set; }
+            public ElementId DimensionId { get; set; }
+            public ElementId OwnerViewId { get; set; }
+            public bool ExistsAfterCreate { get; set; }
+            public string FailureMessage { get; set; }
+        }
+
+        private class CurtainElevationPointRecord
+        {
+            public XYZ Point { get; set; }
+            public ElementId ElementId { get; set; }
+            public string CategoryName { get; set; }
+            public string Source { get; set; }
+        }
+
+        private class CurtainElevationGeometryPointResult
+        {
+            public List<XYZ> Points { get; } = new List<XYZ>();
+            public List<CurtainElevationPointRecord> Records { get; } = new List<CurtainElevationPointRecord>();
+            public List<ElementId> FallbackElementIds { get; } = new List<ElementId>();
+            public HashSet<ElementId> ContributingElementIds { get; } = new HashSet<ElementId>();
+            public bool UsedHostWallFallback { get; set; }
+            public int GeometryPointCount { get; set; }
+            public int ViewSpecificBoundingBoxPointCount { get; set; }
+            public int FallbackElementCount { get; set; }
+            public int ElementCount { get; set; }
+
+            public string PointSource
+            {
+                get
+                {
+                    if (ViewSpecificBoundingBoxPointCount > 0 && (GeometryPointCount > 0 || FallbackElementCount > 0))
+                        return "view_bbox_with_fallback";
+                    if (ViewSpecificBoundingBoxPointCount > 0)
+                        return "view_bbox";
+                    if (GeometryPointCount > 0 && FallbackElementCount > 0)
+                        return "geometry_with_bbox_fallback";
+                    if (GeometryPointCount > 0)
+                        return "geometry";
+                    return "bbox_fallback";
+                }
+            }
+        }
+
+        private class CurtainElevationLocalExtents
+        {
+            public XYZ Min { get; set; }
+            public XYZ Max { get; set; }
+            public CurtainElevationPointRecord MinXRecord { get; set; }
+            public CurtainElevationPointRecord MaxXRecord { get; set; }
+            public CurtainElevationPointRecord MinYRecord { get; set; }
+            public CurtainElevationPointRecord MaxYRecord { get; set; }
+            public CurtainElevationPointRecord MinZRecord { get; set; }
+            public CurtainElevationPointRecord MaxZRecord { get; set; }
+        }
+
+        private class CurtainElevationFarClipResult
+        {
+            public double DepthFt { get; set; }
+            public double MarginFt { get; set; }
+            public double NearestTargetFt { get; set; }
+            public double FarthestTargetFt { get; set; }
+            public string Method { get; set; }
+            public string PointSource { get; set; }
+            public CurtainElevationPointRecord ExtremeContributor { get; set; }
+            public XYZ DepthOrigin { get; set; }
+            public XYZ LookDirection { get; set; }
+            public double MinCandidateDepthFt { get; set; }
+            public double MaxCandidateDepthFt { get; set; }
+            public int PositivePointCount { get; set; }
+            public string Warning { get; set; }
+            public bool CropBoxDepthApplied { get; set; }
+            public string CropBoxDepthMethod { get; set; }
+            public double ViewOriginLocalZFt { get; set; }
+            public double LookDirectionLocalZ { get; set; }
+            public double CropBoxMinZAfterFt { get; set; }
+            public double CropBoxMaxZAfterFt { get; set; }
+            public double CropBoxDepthAfterFt { get; set; }
+        }
+
+        private object BuildCurtainElevationCropDiagnosticsForSide(
+            Document doc,
+            ViewFamilyType elevationType,
+            ViewPlan placementView,
+            Wall wall,
+            XYZ wallMidPoint,
+            XYZ exteriorDirection,
+            double offsetFt,
+            int scale)
+        {
+            XYZ exterior = FlattenAndNormalize(exteriorDirection);
+            if (doc == null || elevationType == null || placementView == null || wall == null || wallMidPoint == null || exterior == null)
+                return new { Error = "Missing data required to create temporary crop diagnostic elevation." };
+
+            XYZ markerPoint = wallMidPoint + exterior * (wall.Width / 2.0 + offsetFt);
+            XYZ desiredLookDirection = GetCurtainElevationDesiredLookDirection(wallMidPoint, markerPoint);
+            if (desiredLookDirection == null)
+                return new { Error = "Cannot resolve desired look direction for crop diagnostics." };
+
+            try
+            {
+                ElevationMarker marker = ElevationMarker.CreateElevationMarker(doc, elevationType.Id, markerPoint, scale);
+                ViewSection view = marker.CreateElevation(doc, placementView.Id, 0);
+                doc.Regenerate();
+
+                CurtainElevationDirectionResult directionResult = AlignCurtainElevationMarkerByVisualLook(
+                    doc, marker, markerPoint, view, desiredLookDirection);
+                doc.Regenerate();
+
+                return BuildCurtainElevationCropDiagnostics(doc, wall, view, wallMidPoint, markerPoint, directionResult);
+            }
+            catch (Exception ex)
+            {
+                return new { Error = ex.Message };
+            }
+        }
+
+        private object BuildCurtainElevationCropDiagnostics(
+            Document doc,
+            Wall wall,
+            ViewSection view,
+            XYZ wallMidPoint,
+            XYZ markerPoint,
+            CurtainElevationDirectionResult directionResult)
+        {
+            if (doc == null || wall == null || view == null)
+                return new { Error = "Missing document, wall, or temporary view." };
+
+            BoundingBoxXYZ viewCrop = view.CropBox;
+            double? viewerBoundOffsetBefore = GetViewDoubleParameterByBuiltInName(view, "VIEWER_BOUND_OFFSET_FAR");
+            CurtainElevationGeometryPointResult pointResult = GetCurtainElevationGeometryPoints(doc, wall, view);
+            CurtainElevationGeometryPointResult view2DPointResult = GetCurtainElevationView2DPoints(doc, wall, view);
+            Transform viewCropFrame = viewCrop?.Transform;
+            Transform view2DFrame = GetCurtainElevationView2DFrame(view, viewCropFrame);
+            Transform wallAlignedFrame = GetCurtainElevationWallAlignedCropFrame(wall, wallMidPoint, markerPoint);
+            CurtainElevationLocalExtents viewExtents = GetCurtainElevationLocalExtents(pointResult.Records, viewCropFrame);
+            CurtainElevationLocalExtents view2DExtents = GetCurtainElevationLocalExtents(view2DPointResult.Records, view2DFrame);
+            CurtainElevationLocalExtents view2DCropFrameExtents = ConvertCurtainElevationView2DExtentsToCropFrameExtents(view2DFrame, view2DExtents, viewCropFrame, 0, 0);
+            CurtainElevationLocalExtents wallExtents = GetCurtainElevationLocalExtents(pointResult.Records, wallAlignedFrame);
+            CurtainElevationFarClipResult farClipResult = CalculateCurtainElevationFarClipDepth(view, viewCropFrame, view2DPointResult.Records, 0);
+
+            bool managerAvailable = false;
+            bool? loopValid = null;
+            string loopError = null;
+            List<XYZ> loopPoints = new List<XYZ>();
+
+            try
+            {
+                ViewCropRegionShapeManager manager = view.GetCropRegionShapeManager();
+                managerAvailable = manager != null;
+
+                if (manager != null && wallAlignedFrame != null && wallExtents?.Min != null && wallExtents?.Max != null)
+                {
+                    CurveLoop loop = BuildCurtainElevationCandidateCropLoop(view, wallAlignedFrame, wallExtents.Min, wallExtents.Max, loopPoints);
+                    loopValid = loop != null && manager.IsCropRegionShapeValid(loop);
+                }
+            }
+            catch (Exception ex)
+            {
+                loopError = ex.Message;
+            }
+
+            var diagnosticFarClipWarnings = new List<string>();
+            CurtainElevationCropResult appliedCropResult = ConfigureCurtainElevationCrop(doc, view, wall, wallMidPoint, markerPoint, 0, 0, 0);
+            ConfigureCurtainElevationFarClip(view, appliedCropResult, diagnosticFarClipWarnings);
+            BoundingBoxXYZ viewCropAfter = view.CropBox;
+            double? viewerBoundOffsetAfter = GetViewDoubleParameterByBuiltInName(view, "VIEWER_BOUND_OFFSET_FAR");
+
+            return new
+            {
+                DirectionDot = Math.Round(directionResult?.DirectionDot ?? -1.0, 4),
+                ViewRightDirection = ToCurtainElevationXyz(view.RightDirection),
+                ViewUpDirection = ToCurtainElevationXyz(view.UpDirection),
+                ViewDirection = ToCurtainElevationXyz(view.ViewDirection),
+                ViewCropTransform = ToCurtainElevationTransform(viewCropFrame),
+                CropBoxTransform = ToCurtainElevationTransform(viewCropFrame),
+                ViewCropMin = ToCurtainElevationXyz(viewCrop?.Min),
+                ViewCropMax = ToCurtainElevationXyz(viewCrop?.Max),
+                CropBoxMinZBeforeMm = viewCrop?.Min == null ? (double?)null : Math.Round(viewCrop.Min.Z * 304.8, 1),
+                CropBoxMaxZBeforeMm = viewCrop?.Max == null ? (double?)null : Math.Round(viewCrop.Max.Z * 304.8, 1),
+                CropBoxDepthBeforeMm = viewCrop?.Min == null || viewCrop.Max == null ? (double?)null : Math.Round(Math.Abs(viewCrop.Max.Z - viewCrop.Min.Z) * 304.8, 1),
+                CropBoxMinZAfterMm = viewCropAfter?.Min == null ? (double?)null : Math.Round(viewCropAfter.Min.Z * 304.8, 1),
+                CropBoxMaxZAfterMm = viewCropAfter?.Max == null ? (double?)null : Math.Round(viewCropAfter.Max.Z * 304.8, 1),
+                CropBoxDepthAfterMm = viewCropAfter?.Min == null || viewCropAfter.Max == null ? (double?)null : Math.Round(Math.Abs(viewCropAfter.Max.Z - viewCropAfter.Min.Z) * 304.8, 1),
+                ViewerBoundOffsetBeforeMm = viewerBoundOffsetBefore.HasValue ? Math.Round(viewerBoundOffsetBefore.Value * 304.8, 1) : (double?)null,
+                ViewerBoundOffsetAfterMm = viewerBoundOffsetAfter.HasValue ? Math.Round(viewerBoundOffsetAfter.Value * 304.8, 1) : (double?)null,
+                ExpectedDepthMm = Math.Round(appliedCropResult.FarClipRequestedDepthFt * 304.8, 1),
+                DepthDeltaMm = Math.Round(appliedCropResult.FarClipDepthDeltaFt * 304.8, 1),
+                FarClipPass = appliedCropResult.FarClipPass,
+                FarClipDiagnosticsWarnings = diagnosticFarClipWarnings,
+                WallAlignedFrame = ToCurtainElevationTransform(wallAlignedFrame),
+                GeometryPointSource = pointResult.PointSource,
+                GeometryPointCount = pointResult.Points.Count,
+                GeometryFallbackElementCount = pointResult.FallbackElementCount,
+                UsedHostWallFallback = pointResult.UsedHostWallFallback,
+                PointSourceCountsByCategory = GetCurtainElevationPointSourceCountsByCategory(pointResult.Records),
+                FallbackElementIds = pointResult.FallbackElementIds.Select(id => id.GetIdValue()).ToList(),
+                GeometryLocalExtentsInActualCropFrame = ToCurtainElevationLocalExtents(viewExtents),
+                GeometryLocalExtentsInViewCropFrame = ToCurtainElevationLocalExtents(viewExtents),
+                GeometryLocalExtentsInWallAlignedFrame = ToCurtainElevationLocalExtents(wallExtents),
+                ExtremeContributors = ToCurtainElevationExtremeContributors(viewExtents),
+                View2DCropMethod = "view_2d_visible_bounds",
+                View2DOrigin = ToCurtainElevationPointMm(view2DFrame?.Origin),
+                View2DRightDirection = ToCurtainElevationXyz(view2DFrame?.BasisX),
+                View2DUpDirection = ToCurtainElevationXyz(view2DFrame?.BasisY),
+                View2DPointSource = view2DPointResult.PointSource,
+                View2DPointCount = view2DPointResult.Points.Count,
+                View2DPointSourceCountsByCategory = GetCurtainElevationPointSourceCountsByCategory(view2DPointResult.Records),
+                View2DFallbackElementIds = view2DPointResult.FallbackElementIds.Select(id => id.GetIdValue()).ToList(),
+                View2DLocalExtents = ToCurtainElevationLocalExtents(view2DExtents),
+                View2DConvertedCropFrameExtents = ToCurtainElevationLocalExtents(view2DCropFrameExtents),
+                View2DExtremeContributors = ToCurtainElevationExtremeContributors(view2DExtents),
+                FarClipMethod = farClipResult?.Method,
+                FarClipDepthMm = farClipResult == null ? (double?)null : Math.Round(farClipResult.DepthFt * 304.8, 1),
+                FarClipRequestedDepthMm = farClipResult == null ? (double?)null : Math.Round(farClipResult.DepthFt * 304.8, 1),
+                FarClipDepthOrigin = ToCurtainElevationPointMm(farClipResult?.DepthOrigin),
+                FarClipLookDirection = ToCurtainElevationXyz(farClipResult?.LookDirection),
+                FarClipMinCandidateDepthMm = farClipResult == null ? (double?)null : Math.Round(farClipResult.MinCandidateDepthFt * 304.8, 1),
+                FarClipMaxCandidateDepthMm = farClipResult == null ? (double?)null : Math.Round(farClipResult.MaxCandidateDepthFt * 304.8, 1),
+                FarClipPositivePointCount = farClipResult?.PositivePointCount,
+                FarClipWarning = farClipResult?.Warning,
+                FarClipCropBoxDepthApplied = farClipResult?.CropBoxDepthApplied,
+                FarClipCropBoxDepthMethod = farClipResult?.CropBoxDepthMethod,
+                FarClipViewOriginLocalZMm = farClipResult == null ? (double?)null : Math.Round(farClipResult.ViewOriginLocalZFt * 304.8, 1),
+                FarClipLookDirectionLocalZ = farClipResult == null ? (double?)null : Math.Round(farClipResult.LookDirectionLocalZ, 6),
+                FarClipCropBoxMinZAfterMm = farClipResult == null ? (double?)null : Math.Round(farClipResult.CropBoxMinZAfterFt * 304.8, 1),
+                FarClipCropBoxMaxZAfterMm = farClipResult == null ? (double?)null : Math.Round(farClipResult.CropBoxMaxZAfterFt * 304.8, 1),
+                FarClipCropBoxDepthAfterMm = farClipResult == null ? (double?)null : Math.Round(farClipResult.CropBoxDepthAfterFt * 304.8, 1),
+                FarClipMarginMm = farClipResult == null ? (double?)null : Math.Round(farClipResult.MarginFt * 304.8, 1),
+                FarClipNearestTargetMm = farClipResult == null ? (double?)null : Math.Round(farClipResult.NearestTargetFt * 304.8, 1),
+                FarClipFarthestTargetMm = farClipResult == null ? (double?)null : Math.Round(farClipResult.FarthestTargetFt * 304.8, 1),
+                FarClipPointSource = farClipResult?.PointSource,
+                FarClipExtremeContributor = ToCurtainElevationPointContributor(farClipResult?.ExtremeContributor),
+                CandidateCropLoopPoints = loopPoints.Select(ToCurtainElevationPointMm).ToList(),
+                CandidateCropLoopIsValid = loopValid,
+                CandidateCropLoopError = loopError,
+                CropRegionShapeManagerAvailable = managerAvailable,
+                Note = "Diagnostic only; crop shape is not applied."
+            };
+        }
+
+        private CurtainElevationLocalExtents GetCurtainElevationLocalExtents(List<CurtainElevationPointRecord> records, Transform frame)
+        {
+            if (records == null || records.Count == 0 || frame == null)
+                return null;
+
+            Transform inverse = frame.Inverse;
+            double minX = double.MaxValue;
+            double minY = double.MaxValue;
+            double minZ = double.MaxValue;
+            double maxX = double.MinValue;
+            double maxY = double.MinValue;
+            double maxZ = double.MinValue;
+
+            CurtainElevationPointRecord minXRecord = null;
+            CurtainElevationPointRecord minYRecord = null;
+            CurtainElevationPointRecord minZRecord = null;
+            CurtainElevationPointRecord maxXRecord = null;
+            CurtainElevationPointRecord maxYRecord = null;
+            CurtainElevationPointRecord maxZRecord = null;
+
+            foreach (CurtainElevationPointRecord record in records)
+            {
+                XYZ point = record?.Point;
+                if (point == null)
+                    continue;
+
+                XYZ local = inverse.OfPoint(point);
+                if (local.X < minX) { minX = local.X; minXRecord = record; }
+                if (local.Y < minY) { minY = local.Y; minYRecord = record; }
+                if (local.Z < minZ) { minZ = local.Z; minZRecord = record; }
+                if (local.X > maxX) { maxX = local.X; maxXRecord = record; }
+                if (local.Y > maxY) { maxY = local.Y; maxYRecord = record; }
+                if (local.Z > maxZ) { maxZ = local.Z; maxZRecord = record; }
+            }
+
+            if (minX == double.MaxValue)
+                return null;
+
+            return new CurtainElevationLocalExtents
+            {
+                Min = new XYZ(minX, minY, minZ),
+                Max = new XYZ(maxX, maxY, maxZ),
+                MinXRecord = minXRecord,
+                MaxXRecord = maxXRecord,
+                MinYRecord = minYRecord,
+                MaxYRecord = maxYRecord,
+                MinZRecord = minZRecord,
+                MaxZRecord = maxZRecord
+            };
+        }
+
+        private object ToCurtainElevationLocalExtents(CurtainElevationLocalExtents extents)
+        {
+            if (extents == null)
+                return null;
+
+            return new
+            {
+                MinFt = ToCurtainElevationXyz(extents.Min),
+                MaxFt = ToCurtainElevationXyz(extents.Max),
+                MinMm = ToCurtainElevationPointMm(extents.Min),
+                MaxMm = ToCurtainElevationPointMm(extents.Max)
+            };
+        }
+
+        private object ToCurtainElevationExtremeContributors(CurtainElevationLocalExtents extents)
+        {
+            if (extents == null)
+                return null;
+
+            return new
+            {
+                MinX = ToCurtainElevationPointContributor(extents.MinXRecord),
+                MaxX = ToCurtainElevationPointContributor(extents.MaxXRecord),
+                MinY = ToCurtainElevationPointContributor(extents.MinYRecord),
+                MaxY = ToCurtainElevationPointContributor(extents.MaxYRecord),
+                MinZ = ToCurtainElevationPointContributor(extents.MinZRecord),
+                MaxZ = ToCurtainElevationPointContributor(extents.MaxZRecord)
+            };
+        }
+
+        private object ToCurtainElevationPointContributor(CurtainElevationPointRecord record)
+        {
+            if (record == null)
+                return null;
+
+            return new
+            {
+                ElementId = record.ElementId?.GetIdValue() ?? 0,
+                Category = record.CategoryName,
+                Source = record.Source,
+                Point = ToCurtainElevationPointMm(record.Point)
+            };
+        }
+
+        private object GetCurtainElevationPointSourceCountsByCategory(List<CurtainElevationPointRecord> records)
+        {
+            if (records == null)
+                return new List<object>();
+
+            return records
+                .GroupBy(r => new { Category = r.CategoryName ?? "(none)", Source = r.Source ?? "(unknown)" })
+                .Select(g => new
+                {
+                    g.Key.Category,
+                    g.Key.Source,
+                    Count = g.Count(),
+                    ElementCount = g.Select(r => r.ElementId).Where(id => id != null).Distinct().Count()
+                })
+                .OrderBy(x => x.Category)
+                .ThenBy(x => x.Source)
+                .ToList();
+        }
+
+        private object ToCurtainElevationTransform(Transform transform)
+        {
+            if (transform == null)
+                return null;
+
+            return new
+            {
+                Origin = ToCurtainElevationPointMm(transform.Origin),
+                BasisX = ToCurtainElevationXyz(transform.BasisX),
+                BasisY = ToCurtainElevationXyz(transform.BasisY),
+                BasisZ = ToCurtainElevationXyz(transform.BasisZ)
+            };
+        }
+
+        private CurtainElevationDimensionTypeResolution ResolveCurtainElevationDimensionType(Document doc, JObject parameters, List<string> warnings)
+        {
+            var result = new CurtainElevationDimensionTypeResolution();
+            if (doc == null)
+                return result;
+
+            IdType? explicitId = parameters?["dimensionTypeId"]?.Value<IdType?>();
+            if (explicitId.HasValue && explicitId.Value != 0)
+            {
+                DimensionType explicitType = doc.GetElement(new ElementId(explicitId.Value)) as DimensionType;
+                if (explicitType != null)
+                {
+                    result.DimensionType = explicitType;
+                    result.Source = "explicit_id";
+                    LastCurtainElevationDimensionTypeId = explicitType.Id.GetIdValue();
+                    return result;
+                }
+
+                warnings?.Add($"dimensionTypeId={explicitId.Value} is not a valid DimensionType; falling back to name/last/default.");
+            }
+
+            string explicitName = parameters?["dimensionTypeName"]?.Value<string>();
+            if (!string.IsNullOrWhiteSpace(explicitName))
+            {
+                DimensionType namedType = new FilteredElementCollector(doc)
+                    .OfClass(typeof(DimensionType))
+                    .Cast<DimensionType>()
+                    .FirstOrDefault(t => string.Equals(t.Name, explicitName, StringComparison.OrdinalIgnoreCase));
+                if (namedType != null)
+                {
+                    result.DimensionType = namedType;
+                    result.Source = "explicit_name";
+                    LastCurtainElevationDimensionTypeId = namedType.Id.GetIdValue();
+                    return result;
+                }
+
+                warnings?.Add($"dimensionTypeName='{explicitName}' not found; falling back to last/default.");
+            }
+
+            if (LastCurtainElevationDimensionTypeId.HasValue)
+            {
+                DimensionType lastType = doc.GetElement(new ElementId(LastCurtainElevationDimensionTypeId.Value)) as DimensionType;
+                if (lastType != null)
+                {
+                    result.DimensionType = lastType;
+                    result.Source = "last_used";
+                    return result;
+                }
+            }
+
+            try
+            {
+                ElementId defaultTypeId = doc.GetDefaultElementTypeId((ElementTypeGroup)10);
+                DimensionType defaultType = doc.GetElement(defaultTypeId) as DimensionType;
+                if (defaultType != null)
+                {
+                    result.DimensionType = defaultType;
+                    result.Source = "revit_default";
+                    LastCurtainElevationDimensionTypeId = defaultType.Id.GetIdValue();
+                    return result;
+                }
+            }
+            catch (Exception ex)
+            {
+                warnings?.Add($"Revit default dimension type lookup skipped: {ex.Message}");
+            }
+
+            DimensionType firstType = new FilteredElementCollector(doc)
+                .OfClass(typeof(DimensionType))
+                .WhereElementIsElementType()
+                .Cast<DimensionType>()
+                .FirstOrDefault();
+            if (firstType != null)
+            {
+                result.DimensionType = firstType;
+                result.Source = "first_available";
+                LastCurtainElevationDimensionTypeId = firstType.Id.GetIdValue();
+                return result;
+            }
+
+            warnings?.Add("No DimensionType found. Elevations will be created without dimensions.");
+            result.Source = "not_found";
+            return result;
+        }
+
+        private CurtainElevationDimensionResult CreateCurtainElevationDimensions(
+            Document doc,
+            ViewSection view,
+            Wall wall,
+            CurtainElevationCropResult cropResult,
+            DimensionType dimensionType,
+            bool addDimensions,
+            double offsetFt,
+            double stackOffsetFt)
+        {
+            var result = new CurtainElevationDimensionResult();
+            if (!addDimensions)
+            {
+                result.Status = "disabled";
+                return result;
+            }
+
+            if (doc == null || view == null || wall == null || cropResult == null)
+            {
+                result.Status = "failed";
+                result.Warnings.Add("dimension skipped: missing document/view/wall/crop result.");
+                result.FailedCount = 4;
+                return result;
+            }
+
+            if (dimensionType == null)
+            {
+                result.Status = "skipped_no_dimension_type";
+                result.Warnings.Add("dimension skipped: no DimensionType available.");
+                result.FailedCount = 4;
+                return result;
+            }
+
+            Transform sourceFrame = GetCurtainElevationView2DFrame(view, view.CropBox?.Transform);
+            Transform frame = GetCurtainElevationDimensionFrame(view, sourceFrame);
+            if (frame == null || sourceFrame == null || cropResult.View2DMin == null || cropResult.View2DMax == null)
+            {
+                result.Status = "failed";
+                result.Warnings.Add("dimension skipped: view 2D bounds unavailable.");
+                result.FailedCount = 4;
+                return result;
+            }
+
+            XYZ sourceOriginDelta = sourceFrame.Origin - frame.Origin;
+            double xShift = sourceOriginDelta.DotProduct(frame.BasisX);
+            double yShift = sourceOriginDelta.DotProduct(frame.BasisY);
+            double minX = cropResult.View2DMin.X + xShift;
+            double maxX = cropResult.View2DMax.X + xShift;
+            double minY = cropResult.View2DMin.Y + yShift;
+            double maxY = cropResult.View2DMax.Y + yShift;
+            if (maxX - minX <= 1e-6 || maxY - minY <= 1e-6)
+            {
+                result.Status = "failed";
+                result.Warnings.Add("dimension skipped: view 2D bounds are too small.");
+                result.FailedCount = 4;
+                return result;
+            }
+
+            double topTotalY = maxY + offsetFt;
+            double topGridY = topTotalY + stackOffsetFt;
+            double rightTotalX = maxX + offsetFt;
+            double rightGridX = rightTotalX + stackOffsetFt;
+            List<CurtainElevationGeometryReference> geometryReferences = CollectCurtainElevationGeometryReferences(doc, wall, view, frame, minX, maxX, minY, maxY);
+            List<CurtainElevationGeometryReference> gridLineReferences = CollectCurtainElevationGridLineReferences(doc, wall, view, frame, minX, maxX, minY, maxY);
+            result.GeometryReferenceCount = geometryReferences.Count + gridLineReferences.Count;
+            result.CurtainGridLineCount = wall.CurtainGrid.GetUGridLineIds().Count + wall.CurtainGrid.GetVGridLineIds().Count;
+            result.CurtainGridLineReferenceCount = gridLineReferences.Count;
+            if (result.CurtainGridLineReferenceCount < result.CurtainGridLineCount)
+                result.CurtainGridLineReferenceFailures.Add($"Only {result.CurtainGridLineReferenceCount} of {result.CurtainGridLineCount} CurtainGridLine elements exposed a usable aligned geometry reference.");
+            result.CurtainGridLineReferenceSamples.AddRange(gridLineReferences.Select(r => (object)new
+            {
+                GridLineId = r.CurtainGridLineId?.GetIdValue(),
+                GridLineOrientation = r.IsVertical ? "vertical" : (r.IsHorizontal ? "horizontal" : "other"),
+                GeometryObjectType = r.GeometryObjectType,
+                ReferenceAvailable = r.Reference != null,
+                StableRepresentation = r.StableRepresentation,
+                ProjectedCoordinate = Math.Round((r.IsVertical ? r.CenterX : r.CenterY) * 304.8, 1),
+                LengthMm = Math.Round(r.Length * 304.8, 1),
+                SelectedForDimension = r.SelectedForDimension,
+                SelectionReason = r.SelectionReason
+            }));
+            result.GeometryReferenceCategories = geometryReferences
+                .Select(r => r.CategoryName)
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .Distinct()
+                .OrderBy(s => s)
+                .ToList();
+
+            List<CurtainElevationGeometryReference> totalWidthRefs = SelectCurtainElevationBoundaryReferences(geometryReferences, "horizontal", minX, maxX, minY, maxY);
+            if (TryCreateCurtainElevationDimensionChain(doc, view, frame, dimensionType, "horizontal", new List<double> { minX, maxX }, totalWidthRefs, minY, maxY, topTotalY, result, false, out ElementId totalWidthId, out string totalWidthSource, out string totalWidthReason))
+            {
+                result.TotalWidthDimensionId = totalWidthId;
+                result.TotalWidthDimensionReferenceSource = totalWidthSource;
+                result.CreatedCount++;
+            }
+            else
+            {
+                result.FailedCount++;
+                result.TotalWidthDimensionReferenceSource = "failed";
+                result.Warnings.Add("total width dimension failed: " + totalWidthReason);
+            }
+
+            List<CurtainElevationGeometryReference> totalHeightRefs = SelectCurtainElevationBoundaryReferences(geometryReferences, "vertical", minX, maxX, minY, maxY);
+            if (TryCreateCurtainElevationDimensionChain(doc, view, frame, dimensionType, "vertical", new List<double> { minY, maxY }, totalHeightRefs, minX, maxX, rightTotalX, result, false, out ElementId totalHeightId, out string totalHeightSource, out string totalHeightReason))
+            {
+                result.TotalHeightDimensionId = totalHeightId;
+                result.TotalHeightDimensionReferenceSource = totalHeightSource;
+                result.CreatedCount++;
+            }
+            else
+            {
+                result.FailedCount++;
+                result.TotalHeightDimensionReferenceSource = "failed";
+                result.Warnings.Add("total height dimension failed: " + totalHeightReason);
+            }
+
+            List<double> verticalGridXs = GetCurtainElevationGridCoordinates(doc, wall, frame, "vertical", minX, maxX, minY, maxY);
+            if (verticalGridXs.Count >= 3)
+            {
+                List<CurtainElevationGeometryReference> verticalGridRefs = SelectCurtainElevationGridDimensionReferences(geometryReferences, gridLineReferences, "horizontal", verticalGridXs);
+                if (TryCreateCurtainElevationDimensionChain(doc, view, frame, dimensionType, "horizontal", verticalGridXs, verticalGridRefs, minY, maxY, topGridY, result, true, out ElementId horizontalGridId, out string horizontalGridSource, out string horizontalGridReason))
+                {
+                    result.HorizontalGridDimensionId = horizontalGridId;
+                    result.HorizontalGridDimensionReferenceSource = horizontalGridSource;
+                    result.CreatedCount++;
+                }
+                else
+                {
+                    result.FailedCount++;
+                    result.HorizontalGridDimensionReferenceSource = "failed";
+                    result.Warnings.Add("horizontal grid dimension failed: " + horizontalGridReason);
+                }
+            }
+            else
+            {
+                result.HorizontalGridDimensionReferenceSource = "skipped";
+                result.Warnings.Add("horizontal grid dimension skipped: fewer than 3 grid/boundary X coordinates.");
+            }
+
+            List<double> horizontalGridYs = GetCurtainElevationGridCoordinates(doc, wall, frame, "horizontal", minX, maxX, minY, maxY);
+            if (horizontalGridYs.Count >= 3)
+            {
+                List<CurtainElevationGeometryReference> horizontalGridRefs = SelectCurtainElevationGridDimensionReferences(geometryReferences, gridLineReferences, "vertical", horizontalGridYs);
+                if (TryCreateCurtainElevationDimensionChain(doc, view, frame, dimensionType, "vertical", horizontalGridYs, horizontalGridRefs, minX, maxX, rightGridX, result, true, out ElementId verticalGridId, out string verticalGridSource, out string verticalGridReason))
+                {
+                    result.VerticalGridDimensionId = verticalGridId;
+                    result.VerticalGridDimensionReferenceSource = verticalGridSource;
+                    result.CreatedCount++;
+                }
+                else
+                {
+                    result.FailedCount++;
+                    result.VerticalGridDimensionReferenceSource = "failed";
+                    result.Warnings.Add("vertical grid dimension failed: " + verticalGridReason);
+                }
+            }
+            else
+            {
+                result.VerticalGridDimensionReferenceSource = "skipped";
+                result.Warnings.Add("vertical grid dimension skipped: fewer than 3 grid/boundary Y coordinates.");
+            }
+
+            result.AttemptCount = result.CreatedCount + result.FailedCount;
+            result.Status = result.CreatedCount > 0
+                ? (result.FailedCount > 0 ? "partial" : "created")
+                : "failed";
+            return result;
+        }
+
+        private void VerifyCurtainElevationDimensionResult(Document doc, View view, CurtainElevationDimensionResult result)
+        {
+            if (doc == null || view == null || result == null)
+                return;
+
+            var ids = new[]
+            {
+                result.TotalWidthDimensionId,
+                result.HorizontalGridDimensionId,
+                result.TotalHeightDimensionId,
+                result.VerticalGridDimensionId
+            };
+
+            result.VerifiedCount = 0;
+            foreach (ElementId id in ids)
+            {
+                if (id == null || id == ElementId.InvalidElementId)
+                    continue;
+
+                Element element = doc.GetElement(id);
+                Dimension dimension = element as Dimension;
+                if (dimension == null)
+                {
+                    result.CreationErrors.Add($"Dimension id {id.GetIdValue()} was returned but cannot be read back as Dimension.");
+                    continue;
+                }
+
+                if (dimension.OwnerViewId != view.Id)
+                {
+                    result.CreationErrors.Add($"Dimension id {id.GetIdValue()} owner view is {dimension.OwnerViewId.GetIdValue()}, expected {view.Id.GetIdValue()}.");
+                    continue;
+                }
+
+                result.VerifiedCount++;
+            }
+
+            if (result.AttemptCount > 0 && result.VerifiedCount == 0)
+            {
+                result.Status = "failed_no_dimension_created";
+                if (result.CreationErrors.Count == 0)
+                result.CreationErrors.Add("No created dimension id could be verified in the target elevation view.");
+            }
+        }
+
+        private CurtainElevationDimensionAttempt TryDiagnoseCurtainGeometryDimension(
+            Document doc,
+            View view,
+            Transform frame,
+            DimensionType dimensionType,
+            string name,
+            string axis,
+            List<double> coordinates,
+            List<CurtainElevationGeometryReference> geometryReferences,
+            double dimensionLineOffset)
+        {
+            List<double> distinct = NormalizeCurtainElevationDimensionCoordinates(coordinates);
+            var attempt = new CurtainElevationDimensionAttempt
+            {
+                Name = name,
+                Method = "geometry_reference",
+                ReferenceCount = geometryReferences?.Count ?? 0
+            };
+
+            try
+            {
+                if (distinct.Count < 2)
+                {
+                    attempt.FailureMessage = "not enough coordinates.";
+                    return attempt;
+                }
+
+                if (axis == "horizontal")
+                {
+                    attempt.DimensionLineStart = CurtainElevationPointAt2D(frame, distinct.First(), dimensionLineOffset);
+                    attempt.DimensionLineEnd = CurtainElevationPointAt2D(frame, distinct.Last(), dimensionLineOffset);
+                }
+                else
+                {
+                    attempt.DimensionLineStart = CurtainElevationPointAt2D(frame, dimensionLineOffset, distinct.First());
+                    attempt.DimensionLineEnd = CurtainElevationPointAt2D(frame, dimensionLineOffset, distinct.Last());
+                }
+
+                if (geometryReferences == null || geometryReferences.Count < distinct.Count)
+                {
+                    attempt.FailureMessage = $"not enough geometry references. Need {distinct.Count}, got {geometryReferences?.Count ?? 0}.";
+                    return attempt;
+                }
+
+                var referenceArray = new ReferenceArray();
+                foreach (CurtainElevationGeometryReference geometryReference in geometryReferences)
+                {
+                    if (geometryReference?.Reference == null)
+                    {
+                        attempt.FailureMessage = "geometry reference contains null Reference.";
+                        return attempt;
+                    }
+
+                    referenceArray.Append(geometryReference.Reference);
+                }
+
+                Dimension dimension = doc.Create.NewDimension(
+                    view,
+                    Line.CreateBound(attempt.DimensionLineStart, attempt.DimensionLineEnd),
+                    referenceArray);
+                if (dimension == null)
+                {
+                    attempt.FailureMessage = "Revit returned null Dimension.";
+                    return attempt;
+                }
+
+                ApplyDimensionType(dimension, dimensionType);
+                attempt.DimensionId = dimension.Id;
+                attempt.OwnerViewId = dimension.OwnerViewId;
+                attempt.Success = true;
+                return attempt;
+            }
+            catch (Exception ex)
+            {
+                attempt.FailureMessage = ex.Message;
+                return attempt;
+            }
+        }
+
+        private CurtainElevationDimensionAttempt TryDiagnoseCurtainReferencePlaneDimension(
+            Document doc,
+            View view,
+            Transform frame,
+            DimensionType dimensionType,
+            string name,
+            string axis,
+            List<double> coordinates,
+            double minOther,
+            double maxOther,
+            double dimensionLineOffset,
+            List<ElementId> referencePlaneIds,
+            out int referenceCount)
+        {
+            referenceCount = 0;
+            List<double> distinct = NormalizeCurtainElevationDimensionCoordinates(coordinates);
+            var attempt = new CurtainElevationDimensionAttempt
+            {
+                Name = name,
+                Method = "reference_plane_fallback"
+            };
+
+            try
+            {
+                if (distinct.Count < 2)
+                {
+                    attempt.FailureMessage = "not enough coordinates.";
+                    return attempt;
+                }
+
+                double stubMin = minOther;
+                double stubMax = maxOther;
+                if (Math.Abs(stubMax - stubMin) < 1e-6)
+                    stubMax = stubMin + 100.0 / 304.8;
+
+                var referenceArray = new ReferenceArray();
+                foreach (double coordinate in distinct)
+                {
+                    XYZ bubbleEnd;
+                    XYZ freeEnd;
+                    if (axis == "horizontal")
+                    {
+                        bubbleEnd = CurtainElevationPointAt2D(frame, coordinate, stubMin);
+                        freeEnd = CurtainElevationPointAt2D(frame, coordinate, stubMax);
+                    }
+                    else
+                    {
+                        bubbleEnd = CurtainElevationPointAt2D(frame, stubMin, coordinate);
+                        freeEnd = CurtainElevationPointAt2D(frame, stubMax, coordinate);
+                    }
+
+                    ReferencePlane referencePlane = doc.Create.NewReferencePlane(bubbleEnd, freeEnd, frame.BasisZ, view);
+                    if (referencePlane == null)
+                    {
+                        attempt.FailureMessage = "failed to create ReferencePlane.";
+                        return attempt;
+                    }
+
+                    referencePlaneIds?.Add(referencePlane.Id);
+                    Reference reference = referencePlane.GetReference();
+                    if (reference == null)
+                    {
+                        attempt.FailureMessage = "ReferencePlane.GetReference() returned null.";
+                        return attempt;
+                    }
+
+                    referenceArray.Append(reference);
+                    referenceCount++;
+                }
+
+                attempt.ReferenceCount = referenceCount;
+                if (axis == "horizontal")
+                {
+                    attempt.DimensionLineStart = CurtainElevationPointAt2D(frame, distinct.First(), dimensionLineOffset);
+                    attempt.DimensionLineEnd = CurtainElevationPointAt2D(frame, distinct.Last(), dimensionLineOffset);
+                }
+                else
+                {
+                    attempt.DimensionLineStart = CurtainElevationPointAt2D(frame, dimensionLineOffset, distinct.First());
+                    attempt.DimensionLineEnd = CurtainElevationPointAt2D(frame, dimensionLineOffset, distinct.Last());
+                }
+
+                Dimension dimension = doc.Create.NewDimension(
+                    view,
+                    Line.CreateBound(attempt.DimensionLineStart, attempt.DimensionLineEnd),
+                    referenceArray);
+                if (dimension == null)
+                {
+                    attempt.FailureMessage = "Revit returned null Dimension.";
+                    return attempt;
+                }
+
+                ApplyDimensionType(dimension, dimensionType);
+                attempt.DimensionId = dimension.Id;
+                attempt.OwnerViewId = dimension.OwnerViewId;
+                attempt.Success = true;
+                return attempt;
+            }
+            catch (Exception ex)
+            {
+                attempt.ReferenceCount = referenceCount;
+                attempt.FailureMessage = ex.Message;
+                return attempt;
+            }
+        }
+
+        private object ToCurtainElevationDimensionAttemptResult(CurtainElevationDimensionAttempt attempt)
+        {
+            if (attempt == null)
+                return null;
+
+            return new
+            {
+                Name = attempt.Name,
+                Method = attempt.Method,
+                ReferenceCount = attempt.ReferenceCount,
+                DimensionLineStart = ToCurtainElevationPointMm(attempt.DimensionLineStart),
+                DimensionLineEnd = ToCurtainElevationPointMm(attempt.DimensionLineEnd),
+                Success = attempt.Success,
+                DimensionId = attempt.DimensionId?.GetIdValue(),
+                OwnerViewId = attempt.OwnerViewId?.GetIdValue(),
+                ExistsAfterCreate = attempt.ExistsAfterCreate,
+                FailureMessage = attempt.FailureMessage
+            };
+        }
+
+        private bool TryCreateCurtainElevationDimensionChain(
+            Document doc,
+            View view,
+            Transform frame,
+            DimensionType dimensionType,
+            string axis,
+            List<double> coordinates,
+            List<CurtainElevationGeometryReference> geometryReferences,
+            double minOther,
+            double maxOther,
+            double dimensionLineOffset,
+            CurtainElevationDimensionResult aggregate,
+            bool allowDetailCurveFallback,
+            out ElementId dimensionId,
+            out string referenceSource,
+            out string reason)
+        {
+            dimensionId = null;
+            referenceSource = null;
+            reason = null;
+
+            try
+            {
+                List<double> distinct = NormalizeCurtainElevationDimensionCoordinates(coordinates);
+                if (distinct.Count < 2)
+                {
+                    reason = "not enough coordinates.";
+                    referenceSource = "failed";
+                    return false;
+                }
+
+                if (TryCreateCurtainElevationGeometryReferenceDimension(
+                    doc,
+                    view,
+                    frame,
+                    dimensionType,
+                    axis,
+                    distinct,
+                    geometryReferences,
+                    dimensionLineOffset,
+                    out dimensionId,
+                    out string geometryReason))
+                {
+                    referenceSource = "geometry_reference";
+                    return true;
+                }
+
+                if (!allowDetailCurveFallback)
+                {
+                    reason = "geometry reference dimension failed; detail curve fallback is disabled for this dimension: " + geometryReason;
+                    referenceSource = "failed";
+                    aggregate.DimensionFallbackReason = AppendCurtainElevationWarning(
+                        aggregate.DimensionFallbackReason,
+                        reason);
+                    return false;
+                }
+
+                aggregate.DimensionFallbackReason = AppendCurtainElevationWarning(
+                    aggregate.DimensionFallbackReason,
+                    $"{axis} grid dimension used invisible detail curve fallback from curtain grid coordinates: {geometryReason}");
+
+                if (TryCreateCurtainElevationDetailCurveFallbackDimension(
+                    doc,
+                    view,
+                    frame,
+                    dimensionType,
+                    axis,
+                    distinct,
+                    minOther,
+                    maxOther,
+                    dimensionLineOffset,
+                    aggregate,
+                    out dimensionId,
+                    out string fallbackReason))
+                {
+                    referenceSource = "detail_curve_fallback_from_curtain_grid_coordinates";
+                    return true;
+                }
+
+                reason = $"geometry: {geometryReason}; detail curve fallback: {fallbackReason}";
+                referenceSource = "failed";
+                return false;
+            }
+            catch (Exception ex)
+            {
+                reason = ex.Message;
+                referenceSource = "failed";
+                return false;
+            }
+        }
+
+
+        private bool TryApplyExistingInvisibleLineStyle(Document doc, DetailCurve detailCurve)
+        {
+            if (doc == null || detailCurve == null)
+                return false;
+
+            try
+            {
+                GraphicsStyle style = TryFindExistingInvisibleLineStyle(doc);
+                if (style == null)
+                    return false;
+
+                detailCurve.LineStyle = style;
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        private GraphicsStyle TryFindExistingInvisibleLineStyle(Document doc)
+        {
+            if (doc == null)
+                return null;
+
+            try
+            {
+                var candidates = new List<Category>();
+
+                Category invisibleCategory = Category.GetCategory(doc, BuiltInCategory.OST_InvisibleLines);
+                if (invisibleCategory != null)
+                    candidates.Add(invisibleCategory);
+
+                try
+                {
+                    Category settingsInvisibleCategory = doc.Settings.Categories.get_Item(BuiltInCategory.OST_InvisibleLines);
+                    if (settingsInvisibleCategory != null && !candidates.Any(c => c.Id == settingsInvisibleCategory.Id))
+                        candidates.Add(settingsInvisibleCategory);
+                }
+                catch
+                {
+                    // Some Revit builds expose invisible lines only as a Lines subcategory.
+                }
+
+                try
+                {
+                    Category linesCategory = doc.Settings.Categories.get_Item(BuiltInCategory.OST_Lines);
+                    ElementId invisibleCategoryId = new ElementId(BuiltInCategory.OST_InvisibleLines);
+                    if (linesCategory != null)
+                    {
+                        foreach (Category subCategory in linesCategory.SubCategories)
+                        {
+                            if (subCategory != null && subCategory.Id == invisibleCategoryId)
+                                candidates.Add(subCategory);
+                        }
+                    }
+                }
+                catch
+                {
+                    // Best effort. Do not fall back to name guessing here.
+                }
+
+                foreach (Category category in candidates)
+                {
+                    GraphicsStyle style = category?.GetGraphicsStyle(GraphicsStyleType.Projection);
+                    if (style != null)
+                        return style;
+                }
+            }
+            catch
+            {
+            }
+
+            return null;
+        }
+
+        private bool TryCreateCurtainElevationDetailCurveFallbackDimension(
+            Document doc,
+            View view,
+            Transform frame,
+            DimensionType dimensionType,
+            string axis,
+            List<double> distinct,
+            double minOther,
+            double maxOther,
+            double dimensionLineOffset,
+            CurtainElevationDimensionResult aggregate,
+            out ElementId dimensionId,
+            out string reason)
+        {
+            dimensionId = null;
+            reason = null;
+            var createdReferenceCurves = new List<DetailCurve>();
+
+            try
+            {
+                var referenceArray = new ReferenceArray();
+                double stubMin = minOther;
+                double stubMax = maxOther;
+                if (Math.Abs(stubMax - stubMin) < 1e-6)
+                    stubMax = stubMin + (100.0 / 304.8);
+
+                foreach (double coordinate in distinct)
+                {
+                    Line referenceLine;
+                    if (axis == "horizontal")
+                    {
+                        referenceLine = Line.CreateBound(
+                            CurtainElevationPointAt2D(frame, coordinate, stubMin),
+                            CurtainElevationPointAt2D(frame, coordinate, stubMax));
+                    }
+                    else
+                    {
+                        referenceLine = Line.CreateBound(
+                            CurtainElevationPointAt2D(frame, stubMin, coordinate),
+                            CurtainElevationPointAt2D(frame, stubMax, coordinate));
+                    }
+
+                    DetailCurve detailCurve = doc.Create.NewDetailCurve(view, referenceLine);
+                    if (detailCurve == null)
+                    {
+                        reason = "failed to create reference detail curve.";
+                        DeleteCurtainElevationDetailCurves(doc, createdReferenceCurves);
+                        return false;
+                    }
+
+                    createdReferenceCurves.Add(detailCurve);
+                    Reference reference = detailCurve.GeometryCurve?.Reference;
+                    if (reference == null)
+                    {
+                        reason = "reference detail curve has no Reference before applying invisible line style.";
+                        DeleteCurtainElevationDetailCurves(doc, createdReferenceCurves);
+                        return false;
+                    }
+
+                    referenceArray.Append(reference);
+                }
+
+                Line dimensionLine;
+                if (axis == "horizontal")
+                {
+                    dimensionLine = Line.CreateBound(
+                        CurtainElevationPointAt2D(frame, distinct.First(), dimensionLineOffset),
+                        CurtainElevationPointAt2D(frame, distinct.Last(), dimensionLineOffset));
+                }
+                else
+                {
+                    dimensionLine = Line.CreateBound(
+                        CurtainElevationPointAt2D(frame, dimensionLineOffset, distinct.First()),
+                        CurtainElevationPointAt2D(frame, dimensionLineOffset, distinct.Last()));
+                }
+
+                Dimension dimension = doc.Create.NewDimension(view, dimensionLine, referenceArray);
+                if (dimension == null)
+                {
+                    reason = "Revit returned null Dimension.";
+                    DeleteCurtainElevationDetailCurves(doc, createdReferenceCurves);
+                    return false;
+                }
+
+                ApplyDimensionType(dimension, dimensionType);
+
+                GraphicsStyle invisibleLineStyle = TryFindExistingInvisibleLineStyle(doc);
+                bool invisibleLineStyleApplied = invisibleLineStyle != null;
+                foreach (DetailCurve detailCurve in createdReferenceCurves)
+                {
+                    aggregate.ReferenceCurveIds.Add(detailCurve.Id);
+
+                    if (invisibleLineStyle == null)
+                    {
+                        invisibleLineStyleApplied = false;
+                        continue;
+                    }
+
+                    try
+                    {
+                        detailCurve.LineStyle = invisibleLineStyle;
+                    }
+                    catch
+                    {
+                        invisibleLineStyleApplied = false;
+                    }
+                }
+
+                if (!invisibleLineStyleApplied)
+                {
+                    aggregate.Warnings.Add("Grid dimension detail-curve fallback succeeded, but Revit did not expose/apply BuiltInCategory.OST_InvisibleLines to the helper curves.");
+                    aggregate.DimensionFallbackReason = AppendCurtainElevationWarning(
+                        aggregate.DimensionFallbackReason,
+                        "detail curve fallback dimension succeeded, invisible line style was not applied.");
+                }
+
+                LastCurtainElevationDimensionTypeId = dimensionType.Id.GetIdValue();
+                dimensionId = dimension.Id;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                DeleteCurtainElevationDetailCurves(doc, createdReferenceCurves);
+                reason = ex.Message;
+                return false;
+            }
+        }
+
+        private void DeleteCurtainElevationDetailCurves(Document doc, IEnumerable<DetailCurve> detailCurves)
+        {
+            if (doc == null || detailCurves == null)
+                return;
+
+            foreach (DetailCurve detailCurve in detailCurves)
+            {
+                try
+                {
+                    if (detailCurve != null && detailCurve.Id != ElementId.InvalidElementId && doc.GetElement(detailCurve.Id) != null)
+                        doc.Delete(detailCurve.Id);
+                }
+                catch
+                {
+                    // Best effort cleanup for failed fallback references.
+                }
+            }
+        }
+
+        private bool TryCreateCurtainElevationGeometryReferenceDimension(
+            Document doc,
+            View view,
+            Transform frame,
+            DimensionType dimensionType,
+            string axis,
+            List<double> coordinates,
+            List<CurtainElevationGeometryReference> geometryReferences,
+            double dimensionLineOffset,
+            out ElementId dimensionId,
+            out string reason)
+        {
+            dimensionId = null;
+            reason = null;
+
+            try
+            {
+                if (geometryReferences == null || geometryReferences.Count < coordinates.Count)
+                {
+                    reason = $"not enough geometry references. Need {coordinates.Count}, got {geometryReferences?.Count ?? 0}.";
+                    return false;
+                }
+
+                var referenceArray = new ReferenceArray();
+                foreach (CurtainElevationGeometryReference geometryReference in geometryReferences)
+                {
+                    if (geometryReference?.Reference == null)
+                    {
+                        reason = "geometry reference contains null Reference.";
+                        return false;
+                    }
+
+                    referenceArray.Append(geometryReference.Reference);
+                }
+
+                Line dimensionLine;
+                if (axis == "horizontal")
+                {
+                    dimensionLine = Line.CreateBound(
+                        CurtainElevationPointAt2D(frame, coordinates.First(), dimensionLineOffset),
+                        CurtainElevationPointAt2D(frame, coordinates.Last(), dimensionLineOffset));
+                }
+                else
+                {
+                    dimensionLine = Line.CreateBound(
+                        CurtainElevationPointAt2D(frame, dimensionLineOffset, coordinates.First()),
+                        CurtainElevationPointAt2D(frame, dimensionLineOffset, coordinates.Last()));
+                }
+
+                Dimension dimension = doc.Create.NewDimension(view, dimensionLine, referenceArray);
+                if (dimension == null)
+                {
+                    reason = "Revit returned null Dimension for geometry references.";
+                    return false;
+                }
+
+                ApplyDimensionType(dimension, dimensionType);
+                LastCurtainElevationDimensionTypeId = dimensionType.Id.GetIdValue();
+                dimensionId = dimension.Id;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                reason = ex.Message;
+                return false;
+            }
+        }
+
+        private List<double> GetCurtainElevationGridCoordinates(
+            Document doc,
+            Wall wall,
+            Transform frame,
+            string targetOrientation,
+            double minX,
+            double maxX,
+            double minY,
+            double maxY)
+        {
+            var values = new List<double>();
+            if (targetOrientation == "vertical")
+            {
+                values.Add(minX);
+                values.Add(maxX);
+            }
+            else
+            {
+                values.Add(minY);
+                values.Add(maxY);
+            }
+
+            try
+            {
+                CurtainGrid grid = wall?.CurtainGrid;
+                if (grid == null)
+                    return NormalizeCurtainElevationDimensionCoordinates(values);
+
+                var gridIds = new List<ElementId>();
+                gridIds.AddRange(grid.GetUGridLineIds());
+                gridIds.AddRange(grid.GetVGridLineIds());
+
+                foreach (ElementId id in gridIds)
+                {
+                    CurtainGridLine gridLine = doc.GetElement(id) as CurtainGridLine;
+                    Curve curve = gridLine?.FullCurve;
+                    if (curve == null)
+                        continue;
+
+                    List<XYZ> points = curve.Tessellate()?.ToList() ?? new List<XYZ>();
+                    if (points.Count == 0)
+                    {
+                        points.Add(curve.GetEndPoint(0));
+                        points.Add(curve.GetEndPoint(1));
+                    }
+
+                    var local = points.Select(p => frame.Inverse.OfPoint(p)).ToList();
+                    double gxMin = local.Min(p => p.X);
+                    double gxMax = local.Max(p => p.X);
+                    double gyMin = local.Min(p => p.Y);
+                    double gyMax = local.Max(p => p.Y);
+                    double dx = gxMax - gxMin;
+                    double dy = gyMax - gyMin;
+
+                    if (targetOrientation == "vertical" && dy >= dx)
+                    {
+                        double x = local.Average(p => p.X);
+                        if (x > minX + 1e-4 && x < maxX - 1e-4)
+                            values.Add(x);
+                    }
+                    else if (targetOrientation == "horizontal" && dx > dy)
+                    {
+                        double y = local.Average(p => p.Y);
+                        if (y > minY + 1e-4 && y < maxY - 1e-4)
+                            values.Add(y);
+                    }
+                }
+            }
+            catch
+            {
+                // Grid dimensions are optional; total dimensions still represent the curtain elevation.
+            }
+
+            return NormalizeCurtainElevationDimensionCoordinates(values);
+        }
+
+        private List<CurtainElevationGeometryReference> CollectCurtainElevationGeometryReferences(
+            Document doc,
+            Wall wall,
+            View view,
+            Transform frame,
+            double minX,
+            double maxX,
+            double minY,
+            double maxY)
+        {
+            var references = new List<CurtainElevationGeometryReference>();
+            if (doc == null || wall == null || view == null || frame == null)
+                return references;
+
+            var options = new Options
+            {
+                ComputeReferences = true,
+                IncludeNonVisibleObjects = false
+            };
+            options.View = view;
+
+            foreach (ElementId id in GetCurtainElevationElementIds(wall, includeHostWall: false))
+            {
+                Element element = doc.GetElement(id);
+                if (element == null)
+                    continue;
+
+                try
+                {
+                    GeometryElement geometry = element.get_Geometry(options);
+                    CollectCurtainElevationGeometryReferences(geometry, references, frame, Transform.Identity, element);
+                }
+                catch
+                {
+                    // Some curtain sub-elements do not expose reference-bearing geometry in elevation views.
+                }
+            }
+
+            double tolerance = 5.0 / 304.8;
+            return references
+                .Where(r => r.Reference != null)
+                .Where(r => r.Length > tolerance)
+                .Where(r => r.MaxX >= minX - tolerance && r.MinX <= maxX + tolerance)
+                .Where(r => r.MaxY >= minY - tolerance && r.MinY <= maxY + tolerance)
+                .GroupBy(r => $"{r.ElementId.GetIdValue()}|{Math.Round(r.CenterX / tolerance)}|{Math.Round(r.CenterY / tolerance)}|{r.IsVertical}|{r.IsHorizontal}")
+                .Select(g => g.OrderByDescending(r => r.Length).First())
+                .ToList();
+        }
+
+        private void CollectCurtainElevationGeometryReferences(
+            GeometryElement geometry,
+            List<CurtainElevationGeometryReference> references,
+            Transform viewFrame,
+            Transform geometryTransform,
+            Element sourceElement)
+        {
+            if (geometry == null || references == null || viewFrame == null || sourceElement == null)
+                return;
+
+            foreach (GeometryObject obj in geometry)
+            {
+                if (obj == null)
+                    continue;
+
+                if (obj is GeometryInstance instance)
+                {
+                    try
+                    {
+                        Transform nextTransform = geometryTransform.Multiply(instance.Transform);
+                        CollectCurtainElevationGeometryReferences(instance.GetSymbolGeometry(), references, viewFrame, nextTransform, sourceElement);
+                    }
+                    catch
+                    {
+                        try
+                        {
+                            CollectCurtainElevationGeometryReferences(instance.GetInstanceGeometry(), references, viewFrame, geometryTransform, sourceElement);
+                        }
+                        catch
+                        {
+                            // Ignore geometry instance extraction failures.
+                        }
+                    }
+                    continue;
+                }
+
+                if (obj is Curve curve)
+                {
+                    AddCurtainElevationGeometryReference(curve.Reference, curve, references, viewFrame, geometryTransform, sourceElement);
+                    continue;
+                }
+
+                if (obj is Solid solid && solid.Edges != null)
+                {
+                    foreach (Edge edge in solid.Edges)
+                    {
+                        try
+                        {
+                            AddCurtainElevationGeometryReference(edge.Reference, edge.AsCurve(), references, viewFrame, geometryTransform, sourceElement);
+                        }
+                        catch
+                        {
+                            // Ignore malformed edge references.
+                        }
+                    }
+                }
+            }
+        }
+
+        private void AddCurtainElevationGeometryReference(
+            Reference reference,
+            Curve curve,
+            List<CurtainElevationGeometryReference> references,
+            Transform viewFrame,
+            Transform geometryTransform,
+            Element sourceElement)
+        {
+            if (reference == null || curve == null || references == null || viewFrame == null || sourceElement == null || !curve.IsBound)
+                return;
+
+            try
+            {
+                XYZ start = geometryTransform.OfPoint(curve.GetEndPoint(0));
+                XYZ end = geometryTransform.OfPoint(curve.GetEndPoint(1));
+                XYZ localStart = viewFrame.Inverse.OfPoint(start);
+                XYZ localEnd = viewFrame.Inverse.OfPoint(end);
+                double dx = Math.Abs(localEnd.X - localStart.X);
+                double dy = Math.Abs(localEnd.Y - localStart.Y);
+                double tolerance = 3.0 / 304.8;
+                bool isVertical = dx <= tolerance && dy > tolerance;
+                bool isHorizontal = dy <= tolerance && dx > tolerance;
+                if (!isVertical && !isHorizontal)
+                    return;
+
+                references.Add(new CurtainElevationGeometryReference
+                {
+                    Reference = reference,
+                    ElementId = sourceElement.Id,
+                    CategoryName = sourceElement.Category?.Name,
+                    Start = start,
+                    End = end,
+                    MinX = Math.Min(localStart.X, localEnd.X),
+                    MaxX = Math.Max(localStart.X, localEnd.X),
+                    MinY = Math.Min(localStart.Y, localEnd.Y),
+                    MaxY = Math.Max(localStart.Y, localEnd.Y),
+                    Length = Math.Sqrt(dx * dx + dy * dy),
+                    IsVertical = isVertical,
+                    IsHorizontal = isHorizontal
+                });
+            }
+            catch
+            {
+                // Reference classification is best effort; invalid curves are ignored.
+            }
+        }
+
+        private List<CurtainElevationGeometryReference> SelectCurtainElevationBoundaryReferences(
+            List<CurtainElevationGeometryReference> references,
+            string dimensionAxis,
+            double minX,
+            double maxX,
+            double minY,
+            double maxY)
+        {
+            double tolerance = 25.0 / 304.8;
+            if (dimensionAxis == "horizontal")
+            {
+                List<CurtainElevationGeometryReference> verticals = references.Where(r => r.IsVertical).ToList();
+                CurtainElevationGeometryReference left = verticals
+                    .Where(r => Math.Abs(r.CenterX - minX) <= tolerance)
+                    .OrderBy(r => Math.Abs(r.CenterX - minX))
+                    .ThenByDescending(r => r.Length)
+                    .FirstOrDefault();
+                CurtainElevationGeometryReference right = verticals
+                    .Where(r => Math.Abs(r.CenterX - maxX) <= tolerance)
+                    .OrderBy(r => Math.Abs(r.CenterX - maxX))
+                    .ThenByDescending(r => r.Length)
+                    .FirstOrDefault();
+                return left != null && right != null ? new List<CurtainElevationGeometryReference> { left, right } : new List<CurtainElevationGeometryReference>();
+            }
+
+            List<CurtainElevationGeometryReference> horizontals = references.Where(r => r.IsHorizontal).ToList();
+            CurtainElevationGeometryReference bottom = horizontals
+                .Where(r => Math.Abs(r.CenterY - minY) <= tolerance)
+                .OrderBy(r => Math.Abs(r.CenterY - minY))
+                .ThenByDescending(r => r.Length)
+                .FirstOrDefault();
+            CurtainElevationGeometryReference top = horizontals
+                .Where(r => Math.Abs(r.CenterY - maxY) <= tolerance)
+                .OrderBy(r => Math.Abs(r.CenterY - maxY))
+                .ThenByDescending(r => r.Length)
+                .FirstOrDefault();
+            return bottom != null && top != null ? new List<CurtainElevationGeometryReference> { bottom, top } : new List<CurtainElevationGeometryReference>();
+        }
+
+        private List<CurtainElevationGeometryReference> SelectCurtainElevationGridDimensionReferences(
+            List<CurtainElevationGeometryReference> boundaryReferences,
+            List<CurtainElevationGeometryReference> gridLineReferences,
+            string dimensionAxis,
+            List<double> coordinates)
+        {
+            var result = new List<CurtainElevationGeometryReference>();
+            List<double> distinct = NormalizeCurtainElevationDimensionCoordinates(coordinates);
+            if (distinct.Count == 0)
+                return result;
+
+            double tolerance = 10.0 / 304.8;
+            double minCoordinate = distinct.First();
+            double maxCoordinate = distinct.Last();
+
+            foreach (double coordinate in distinct)
+            {
+                bool isBoundary = Math.Abs(coordinate - minCoordinate) <= tolerance || Math.Abs(coordinate - maxCoordinate) <= tolerance;
+                List<CurtainElevationGeometryReference> candidates;
+                if (isBoundary)
+                {
+                    candidates = dimensionAxis == "horizontal"
+                        ? boundaryReferences.Where(r => r.IsVertical).ToList()
+                        : boundaryReferences.Where(r => r.IsHorizontal).ToList();
+                }
+                else
+                {
+                    candidates = dimensionAxis == "horizontal"
+                        ? gridLineReferences.Where(r => r.IsVertical).ToList()
+                        : gridLineReferences.Where(r => r.IsHorizontal).ToList();
+                }
+
+                CurtainElevationGeometryReference match = candidates
+                    .Where(r => Math.Abs((dimensionAxis == "horizontal" ? r.CenterX : r.CenterY) - coordinate) <= tolerance)
+                    .OrderBy(r => Math.Abs((dimensionAxis == "horizontal" ? r.CenterX : r.CenterY) - coordinate))
+                    .ThenByDescending(r => r.Length)
+                    .FirstOrDefault();
+
+                if (match == null || result.Any(r => r.Reference == match.Reference))
+                    return new List<CurtainElevationGeometryReference>();
+
+                result.Add(match);
+            }
+
+            return result;
+        }
+
+        private List<CurtainElevationGeometryReference> CollectCurtainElevationGridLineReferences(
+            Document doc,
+            Wall wall,
+            View view,
+            Transform frame,
+            double minX,
+            double maxX,
+            double minY,
+            double maxY)
+        {
+            var selected = new List<CurtainElevationGeometryReference>();
+            CurtainGrid grid = wall?.CurtainGrid;
+            if (doc == null || grid == null || frame == null)
+                return selected;
+
+            // CurtainGridLine references must come from the element geometry without binding
+            // extraction to the target elevation view's visibility/crop state.
+            var options = new Options
+            {
+                ComputeReferences = true,
+                IncludeNonVisibleObjects = false,
+                DetailLevel = ViewDetailLevel.Fine
+            };
+
+            var gridIds = new List<ElementId>();
+            gridIds.AddRange(grid.GetUGridLineIds());
+            gridIds.AddRange(grid.GetVGridLineIds());
+            double tolerance = 5.0 / 304.8;
+
+            foreach (ElementId id in gridIds.Distinct())
+            {
+                CurtainGridLine gridLine = doc.GetElement(id) as CurtainGridLine;
+                if (gridLine == null)
+                    continue;
+
+                try
+                {
+                    Curve fullCurve = gridLine.FullCurve;
+                    if (fullCurve == null || !fullCurve.IsBound)
+                        continue;
+
+                    XYZ fullStart = fullCurve.GetEndPoint(0);
+                    XYZ fullEnd = fullCurve.GetEndPoint(1);
+                    XYZ fullLocalStart = frame.Inverse.OfPoint(fullStart);
+                    XYZ fullLocalEnd = frame.Inverse.OfPoint(fullEnd);
+                    XYZ fullDirection = fullLocalEnd - fullLocalStart;
+                    if (fullDirection.GetLength() < tolerance)
+                        continue;
+                    fullDirection = fullDirection.Normalize();
+
+                    var candidates = new List<CurtainElevationGeometryReference>();
+                    // Prefer native CurtainGridLine curve references before solid geometry.
+                    try
+                    {
+                        AddCurtainElevationGeometryReference(fullCurve.Reference, fullCurve, candidates, frame, Transform.Identity, gridLine);
+                        foreach (Curve segment in gridLine.AllSegmentCurves ?? new List<Curve>())
+                            AddCurtainElevationGeometryReference(segment?.Reference, segment, candidates, frame, Transform.Identity, gridLine);
+                    }
+                    catch
+                    {
+                        // Some Revit versions expose FullCurve but not its Reference.
+                    }
+                    GeometryElement geometry = gridLine.get_Geometry(options);
+                    CollectCurtainElevationGeometryReferences(geometry, candidates, frame, Transform.Identity, gridLine);
+
+                    candidates = candidates
+                        .Where(r => r.Reference != null && r.Length > tolerance)
+                        .Where(r => r.MaxX >= minX - tolerance && r.MinX <= maxX + tolerance)
+                        .Where(r => r.MaxY >= minY - tolerance && r.MinY <= maxY + tolerance)
+                        .Where(r =>
+                        {
+                            XYZ direction = frame.Inverse.OfVector(r.End - r.Start);
+                            if (direction.GetLength() < tolerance)
+                                return false;
+                            double alignment = Math.Abs(direction.Normalize().DotProduct(fullDirection));
+                            return alignment >= 0.98;
+                        })
+                        .OrderByDescending(r => r.Length)
+                        .ToList();
+
+                    CurtainElevationGeometryReference best = candidates.FirstOrDefault();
+                    if (best == null)
+                        continue;
+
+                    best.CurtainGridLineId = id;
+                    best.GeometryObjectType = best.GeometryObjectType ?? "Curve";
+                    best.SelectedForDimension = true;
+                    best.SelectionReason = "longest_reference_aligned_with_full_curve";
+                    try
+                    {
+                        best.StableRepresentation = best.Reference.ConvertToStableRepresentation(doc);
+                    }
+                    catch
+                    {
+                        best.StableRepresentation = null;
+                    }
+                    selected.Add(best);
+                }
+                catch
+                {
+                    // A grid line can exist without reference-bearing project geometry.
+                }
+            }
+
+            return selected
+                .GroupBy(r => r.CurtainGridLineId ?? r.ElementId)
+                .Select(g => g.OrderByDescending(r => r.Length).First())
+                .ToList();
+        }
+        private List<double> NormalizeCurtainElevationDimensionCoordinates(IEnumerable<double> coordinates)
+        {
+            const double tolerance = 1.0 / 304.8;
+            var result = new List<double>();
+            foreach (double coordinate in coordinates.Where(c => !double.IsNaN(c) && !double.IsInfinity(c)).OrderBy(c => c))
+            {
+                if (result.Count == 0 || Math.Abs(result.Last() - coordinate) > tolerance)
+                    result.Add(coordinate);
+            }
+
+            return result;
+        }
+
+        private XYZ CurtainElevationPointAt2D(Transform frame, double x, double y)
+        {
+            return frame.Origin + frame.BasisX * x + frame.BasisY * y;
+        }
+
+        private Transform GetCurtainElevationDimensionFrame(ViewSection view, Transform sourceFrame)
+        {
+            if (view == null || sourceFrame == null)
+                return sourceFrame;
+
+            Transform frame = Transform.Identity;
+            frame.Origin = view.Origin ?? sourceFrame.Origin;
+            frame.BasisX = NormalizeOrFallback(view.RightDirection, sourceFrame.BasisX);
+            frame.BasisY = NormalizeOrFallback(view.UpDirection, sourceFrame.BasisY);
+            frame.BasisZ = NormalizeOrFallback(view.ViewDirection, sourceFrame.BasisZ);
+            return frame;
+        }
+
+        private CurtainElevationCropResult ConfigureCurtainElevationCrop(Document doc, ViewSection view, Wall wall, XYZ wallMidPoint, XYZ markerPoint, double horizontalMarginFt, double verticalMarginFt, double fallbackDepthFt)
+        {
+            var result = new CurtainElevationCropResult
+            {
+                FarClipDepthFt = fallbackDepthFt
+            };
+
+            if (view == null || wall == null)
+                return result;
+
+            BoundingBoxXYZ crop = view.CropBox;
+            if (crop == null)
+                return result;
+
+            CurtainElevationGeometryPointResult pointResult = GetCurtainElevationView2DPoints(doc, wall, view);
+            List<XYZ> points = pointResult.Points;
+            result.PointSource = pointResult.PointSource;
+            result.PointCount = points.Count;
+            result.FallbackElementCount = pointResult.FallbackElementCount;
+            result.UsedHostWallFallback = pointResult.UsedHostWallFallback;
+            result.ContributingElementIds = pointResult.ContributingElementIds.Select(id => id.GetIdValue()).ToList();
+            result.FallbackElementIds = pointResult.FallbackElementIds.Select(id => id.GetIdValue()).ToList();
+
+            if (pointResult.Records.Count == 0)
+                return result;
+
+            Transform cropFrame = crop.Transform;
+            Transform view2DFrame = GetCurtainElevationView2DFrame(view, cropFrame);
+            result.FrameSource = "view_2d_visible_bounds";
+            result.RightDirection = view2DFrame.BasisX;
+            result.UpDirection = view2DFrame.BasisY;
+            result.DepthDirection = cropFrame.BasisZ;
+            result.View2DOrigin = view2DFrame.Origin;
+            result.View2DRightDirection = view2DFrame.BasisX;
+            result.View2DUpDirection = view2DFrame.BasisY;
+            result.View2DPointCount = pointResult.Records.Count;
+            result.View2DSource = pointResult.PointSource;
+
+            CurtainElevationLocalExtents view2DExtents = GetCurtainElevationLocalExtents(pointResult.Records, view2DFrame);
+            if (view2DExtents == null)
+                return result;
+
+            CurtainElevationLocalExtents cropFrameExtents = ConvertCurtainElevationView2DExtentsToCropFrameExtents(
+                view2DFrame,
+                view2DExtents,
+                cropFrame,
+                horizontalMarginFt,
+                verticalMarginFt);
+            if (cropFrameExtents == null)
+                return result;
+
+            CurtainElevationFarClipResult farClipResult = CalculateCurtainElevationFarClipDepth(
+                view,
+                cropFrame,
+                pointResult.Records,
+                fallbackDepthFt);
+            if (farClipResult != null)
+            {
+                result.FarClipDepthFt = farClipResult.DepthFt;
+                result.FarClipMethod = farClipResult.Method;
+                result.FarClipRequestedDepthFt = farClipResult.DepthFt;
+                result.FarClipDepthOrigin = farClipResult.DepthOrigin;
+                result.FarClipLookDirection = farClipResult.LookDirection;
+                result.FarClipMinCandidateDepthFt = farClipResult.MinCandidateDepthFt;
+                result.FarClipMaxCandidateDepthFt = farClipResult.MaxCandidateDepthFt;
+                result.FarClipPositivePointCount = farClipResult.PositivePointCount;
+                result.FarClipWarning = farClipResult.Warning;
+                result.FarClipMarginFt = farClipResult.MarginFt;
+                result.FarClipNearestTargetFt = farClipResult.NearestTargetFt;
+                result.FarClipFarthestTargetFt = farClipResult.FarthestTargetFt;
+                result.FarClipPointSource = farClipResult.PointSource;
+                result.FarClipExtremeContributor = ToCurtainElevationPointContributor(farClipResult.ExtremeContributor);
+                result.FarClipCropBoxDepthApplied = farClipResult.CropBoxDepthApplied;
+                result.FarClipCropBoxDepthMethod = farClipResult.CropBoxDepthMethod;
+                result.FarClipViewOriginLocalZFt = farClipResult.ViewOriginLocalZFt;
+                result.FarClipLookDirectionLocalZ = farClipResult.LookDirectionLocalZ;
+                result.FarClipCropBoxMinZAfterFt = farClipResult.CropBoxMinZAfterFt;
+                result.FarClipCropBoxMaxZAfterFt = farClipResult.CropBoxMaxZAfterFt;
+                result.FarClipCropBoxDepthAfterFt = farClipResult.CropBoxDepthAfterFt;
+            }
+            result.LocalMin = cropFrameExtents.Min;
+            result.LocalMax = cropFrameExtents.Max;
+            result.FarClipCropBoxMinZBeforeFt = result.LocalMin.Z;
+            result.FarClipCropBoxMaxZBeforeFt = result.LocalMax.Z;
+            if (farClipResult?.CropBoxDepthApplied == true)
+            {
+                result.LocalMin = new XYZ(result.LocalMin.X, result.LocalMin.Y, farClipResult.CropBoxMinZAfterFt);
+                result.LocalMax = new XYZ(result.LocalMax.X, result.LocalMax.Y, farClipResult.CropBoxMaxZAfterFt);
+            }
+            result.ExtremeContributors = ToCurtainElevationExtremeContributors(view2DExtents);
+            result.View2DMin = new XYZ(view2DExtents.Min.X - horizontalMarginFt, view2DExtents.Min.Y - verticalMarginFt, view2DExtents.Min.Z);
+            result.View2DMax = new XYZ(view2DExtents.Max.X + horizontalMarginFt, view2DExtents.Max.Y + verticalMarginFt, view2DExtents.Max.Z);
+            result.View2DExtremeContributors = ToCurtainElevationExtremeContributors(view2DExtents);
+
+            view.CropBoxActive = true;
+            view.CropBoxVisible = false;
+            view.CropBox = new BoundingBoxXYZ
+            {
+                Transform = cropFrame,
+                Min = result.LocalMin,
+                Max = result.LocalMax
+            };
+
+            return result;
+        }
+
+        private CurtainElevationFarClipResult CalculateCurtainElevationFarClipDepth(
+            ViewSection view,
+            Transform cropFrame,
+            List<CurtainElevationPointRecord> records,
+            double fallbackDepthFt)
+        {
+            const double farClipMarginFt = 50.0 / 304.8;
+            const double minimumDepthFt = 50.0 / 304.8;
+
+            if (records == null || records.Count == 0)
+            {
+                return new CurtainElevationFarClipResult
+                {
+                    DepthFt = Math.Max(fallbackDepthFt, minimumDepthFt),
+                    MarginFt = farClipMarginFt,
+                    Method = "fallback_depth_no_target_points",
+                    PointSource = "none"
+                };
+            }
+
+            XYZ origin = view?.Origin;
+            XYZ lookDirection = GetCurtainElevationVisualLookDirection(view);
+            if (origin == null || lookDirection == null)
+            {
+                return new CurtainElevationFarClipResult
+                {
+                    DepthFt = Math.Max(fallbackDepthFt, minimumDepthFt),
+                    MarginFt = farClipMarginFt,
+                    Method = "fallback_depth_no_view_origin_or_look_direction",
+                    PointSource = "none",
+                    DepthOrigin = origin,
+                    LookDirection = lookDirection,
+                    Warning = "Cannot resolve view origin or visual look direction; used depthMm fallback."
+                };
+            }
+
+            bool canApplyCropBoxDepth = false;
+            double viewOriginLocalZ = 0;
+            double lookDirectionLocalZ = 0;
+            string cropBoxDepthWarning = null;
+            if (cropFrame != null)
+            {
+                try
+                {
+                    Transform inverse = cropFrame.Inverse;
+                    viewOriginLocalZ = inverse.OfPoint(origin).Z;
+                    lookDirectionLocalZ = inverse.OfVector(lookDirection).Z;
+                    canApplyCropBoxDepth = Math.Abs(lookDirectionLocalZ) > 1e-9;
+                }
+                catch (Exception ex)
+                {
+                    cropBoxDepthWarning = $"Cannot project far clip depth into crop box local Z: {ex.Message}";
+                }
+            }
+            else
+            {
+                cropBoxDepthWarning = "Cannot apply crop box depth because crop frame is null.";
+            }
+
+            double minDepth = double.MaxValue;
+            double maxDepth = double.MinValue;
+            double maxPositiveDepth = double.MinValue;
+            double maxAbsDepth = double.MinValue;
+            int positiveCount = 0;
+            CurtainElevationPointRecord maxPositiveRecord = null;
+            CurtainElevationPointRecord maxAbsRecord = null;
+
+            foreach (CurtainElevationPointRecord record in records)
+            {
+                XYZ point = record?.Point;
+                if (point == null)
+                    continue;
+
+                double depth = (point - origin).DotProduct(lookDirection);
+                minDepth = Math.Min(minDepth, depth);
+                maxDepth = Math.Max(maxDepth, depth);
+
+                if (depth > 0)
+                {
+                    positiveCount++;
+                    if (depth > maxPositiveDepth)
+                    {
+                        maxPositiveDepth = depth;
+                        maxPositiveRecord = record;
+                    }
+                }
+
+                double absDepth = Math.Abs(depth);
+                if (absDepth > maxAbsDepth)
+                {
+                    maxAbsDepth = absDepth;
+                    maxAbsRecord = record;
+                }
+            }
+
+            if (maxDepth == double.MinValue)
+            {
+                return new CurtainElevationFarClipResult
+                {
+                    DepthFt = Math.Max(fallbackDepthFt, minimumDepthFt),
+                    MarginFt = farClipMarginFt,
+                    Method = "fallback_depth_no_target_points",
+                    PointSource = "none",
+                    DepthOrigin = origin,
+                    LookDirection = lookDirection,
+                    Warning = "No valid target points after filtering; used depthMm fallback."
+                };
+            }
+
+            bool hasPositiveDepth = positiveCount > 0;
+            double targetDepthFt = hasPositiveDepth ? maxPositiveDepth : maxAbsDepth;
+            CurtainElevationPointRecord extremeRecord = hasPositiveDepth ? maxPositiveRecord : maxAbsRecord;
+            string warning = hasPositiveDepth
+                ? null
+                : "All target point depths were non-positive from view.Origin along visual look direction; used absolute max depth fallback.";
+            warning = AppendCurtainElevationWarning(warning, cropBoxDepthWarning);
+            double depthFt = Math.Max(targetDepthFt + farClipMarginFt, minimumDepthFt);
+            double cropBoxMinZAfter = 0;
+            double cropBoxMaxZAfter = 0;
+            if (canApplyCropBoxDepth)
+            {
+                if (lookDirectionLocalZ >= 0)
+                {
+                    cropBoxMinZAfter = viewOriginLocalZ;
+                    cropBoxMaxZAfter = viewOriginLocalZ + depthFt;
+                }
+                else
+                {
+                    cropBoxMinZAfter = viewOriginLocalZ - depthFt;
+                    cropBoxMaxZAfter = viewOriginLocalZ;
+                }
+
+                if (cropBoxMinZAfter > cropBoxMaxZAfter)
+                {
+                    double temp = cropBoxMinZAfter;
+                    cropBoxMinZAfter = cropBoxMaxZAfter;
+                    cropBoxMaxZAfter = temp;
+                }
+            }
+            else
+            {
+                warning = AppendCurtainElevationWarning(warning, "Crop box Z projection is unavailable; VIEWER_BOUND_OFFSET_FAR was still set.");
+            }
+
+            return new CurtainElevationFarClipResult
+            {
+                DepthFt = depthFt,
+                MarginFt = farClipMarginFt,
+                NearestTargetFt = minDepth,
+                FarthestTargetFt = maxDepth,
+                Method = hasPositiveDepth ? "view_origin_to_target_max_depth" : "view_origin_to_target_abs_depth_fallback",
+                PointSource = extremeRecord?.Source,
+                ExtremeContributor = extremeRecord,
+                DepthOrigin = origin,
+                LookDirection = lookDirection,
+                MinCandidateDepthFt = minDepth,
+                MaxCandidateDepthFt = maxDepth,
+                PositivePointCount = positiveCount,
+                Warning = warning,
+                CropBoxDepthApplied = false,
+                CropBoxDepthMethod = "diagnostic_only_viewer_bound_offset_controls_far_clip",
+                ViewOriginLocalZFt = viewOriginLocalZ,
+                LookDirectionLocalZ = lookDirectionLocalZ,
+                CropBoxMinZAfterFt = cropBoxMinZAfter,
+                CropBoxMaxZAfterFt = cropBoxMaxZAfter,
+                CropBoxDepthAfterFt = canApplyCropBoxDepth ? Math.Abs(cropBoxMaxZAfter - cropBoxMinZAfter) : 0
+            };
+        }
+
+        private Transform GetCurtainElevationView2DFrame(ViewSection view, Transform fallbackCropFrame)
+        {
+            Transform frame = Transform.Identity;
+            frame.Origin = fallbackCropFrame?.Origin ?? view?.Origin ?? XYZ.Zero;
+            frame.BasisX = NormalizeOrFallback(view?.RightDirection, fallbackCropFrame?.BasisX ?? XYZ.BasisX);
+            frame.BasisY = NormalizeOrFallback(view?.UpDirection, fallbackCropFrame?.BasisY ?? XYZ.BasisZ);
+            frame.BasisZ = NormalizeOrFallback(fallbackCropFrame?.BasisZ, view?.ViewDirection ?? XYZ.BasisY);
+            return frame;
+        }
+
+        private XYZ NormalizeOrFallback(XYZ value, XYZ fallback)
+        {
+            try
+            {
+                if (value != null && value.GetLength() > 1e-9)
+                    return value.Normalize();
+            }
+            catch
+            {
+                // Fall through to fallback.
+            }
+
+            try
+            {
+                if (fallback != null && fallback.GetLength() > 1e-9)
+                    return fallback.Normalize();
+            }
+            catch
+            {
+                // Fall through to basis X.
+            }
+
+            return XYZ.BasisX;
+        }
+
+        private CurtainElevationLocalExtents ConvertCurtainElevationView2DExtentsToCropFrameExtents(
+            Transform view2DFrame,
+            CurtainElevationLocalExtents view2DExtents,
+            Transform cropFrame,
+            double horizontalMarginFt,
+            double verticalMarginFt)
+        {
+            if (view2DFrame == null || view2DExtents?.Min == null || view2DExtents.Max == null || cropFrame == null)
+                return null;
+
+            double minX = view2DExtents.Min.X - horizontalMarginFt;
+            double maxX = view2DExtents.Max.X + horizontalMarginFt;
+            double minY = view2DExtents.Min.Y - verticalMarginFt;
+            double maxY = view2DExtents.Max.Y + verticalMarginFt;
+            double minZ = view2DExtents.Min.Z;
+            double maxZ = view2DExtents.Max.Z;
+
+            var cornerRecords = new List<CurtainElevationPointRecord>();
+            foreach (double x in new[] { minX, maxX })
+            {
+                foreach (double y in new[] { minY, maxY })
+                {
+                    foreach (double z in new[] { minZ, maxZ })
+                    {
+                        cornerRecords.Add(new CurtainElevationPointRecord
+                        {
+                            Point = view2DFrame.OfPoint(new XYZ(x, y, z)),
+                            Source = "view_2d_crop_corner"
+                        });
+                    }
+                }
+            }
+
+            return GetCurtainElevationLocalExtents(cornerRecords, cropFrame);
+        }
+
+        private void ApplyCurtainElevationCropRegionShape(
+            ViewSection view,
+            Transform cropFrame,
+            XYZ localMin,
+            XYZ localMax,
+            CurtainElevationCropResult result)
+        {
+            if (view == null || cropFrame == null || localMin == null || localMax == null || result == null)
+                return;
+
+            try
+            {
+                BoundingBoxXYZ currentCrop = view.CropBox;
+                Transform viewFrame = currentCrop?.Transform;
+                XYZ planeOrigin = viewFrame?.Origin ?? cropFrame.Origin;
+                XYZ planeNormal = FlattenAndNormalize(viewFrame?.BasisZ ?? cropFrame.BasisZ);
+                if (planeNormal == null)
+                {
+                    result.RegionShapeFallbackReason = "?��??�斷 crop region plane normal";
+                    return;
+                }
+
+                XYZ p0 = ProjectCurtainElevationPointToPlane(cropFrame.OfPoint(new XYZ(localMin.X, localMin.Y, 0)), planeOrigin, planeNormal);
+                XYZ p1 = ProjectCurtainElevationPointToPlane(cropFrame.OfPoint(new XYZ(localMax.X, localMin.Y, 0)), planeOrigin, planeNormal);
+                XYZ p2 = ProjectCurtainElevationPointToPlane(cropFrame.OfPoint(new XYZ(localMax.X, localMax.Y, 0)), planeOrigin, planeNormal);
+                XYZ p3 = ProjectCurtainElevationPointToPlane(cropFrame.OfPoint(new XYZ(localMin.X, localMax.Y, 0)), planeOrigin, planeNormal);
+
+                var loop = new CurveLoop();
+                loop.Append(Line.CreateBound(p0, p1));
+                loop.Append(Line.CreateBound(p1, p2));
+                loop.Append(Line.CreateBound(p2, p3));
+                loop.Append(Line.CreateBound(p3, p0));
+
+                ViewCropRegionShapeManager manager = view.GetCropRegionShapeManager();
+                if (manager == null)
+                {
+                    result.RegionShapeFallbackReason = "ViewCropRegionShapeManager unavailable";
+                    return;
+                }
+
+                if (!manager.IsCropRegionShapeValid(loop))
+                {
+                    result.RegionShapeFallbackReason = "wall-aligned crop loop is not valid for this view";
+                    return;
+                }
+
+                result.RegionShapeApplied = false;
+                result.RegionShapeFallbackReason = "disabled_for_diagnostics";
+            }
+            catch (Exception ex)
+            {
+                result.RegionShapeFallbackReason = ex.Message;
+            }
+        }
+
+        private CurveLoop BuildCurtainElevationCandidateCropLoop(
+            ViewSection view,
+            Transform cropFrame,
+            XYZ localMin,
+            XYZ localMax,
+            List<XYZ> projectedLoopPoints)
+        {
+            if (view == null || cropFrame == null || localMin == null || localMax == null)
+                return null;
+
+            BoundingBoxXYZ currentCrop = view.CropBox;
+            Transform viewFrame = currentCrop?.Transform;
+            XYZ planeOrigin = viewFrame?.Origin ?? cropFrame.Origin;
+            XYZ planeNormal = FlattenAndNormalize(viewFrame?.BasisZ ?? cropFrame.BasisZ);
+            if (planeNormal == null)
+                return null;
+
+            XYZ p0 = ProjectCurtainElevationPointToPlane(cropFrame.OfPoint(new XYZ(localMin.X, localMin.Y, 0)), planeOrigin, planeNormal);
+            XYZ p1 = ProjectCurtainElevationPointToPlane(cropFrame.OfPoint(new XYZ(localMax.X, localMin.Y, 0)), planeOrigin, planeNormal);
+            XYZ p2 = ProjectCurtainElevationPointToPlane(cropFrame.OfPoint(new XYZ(localMax.X, localMax.Y, 0)), planeOrigin, planeNormal);
+            XYZ p3 = ProjectCurtainElevationPointToPlane(cropFrame.OfPoint(new XYZ(localMin.X, localMax.Y, 0)), planeOrigin, planeNormal);
+
+            projectedLoopPoints?.AddRange(new[] { p0, p1, p2, p3 });
+
+            var loop = new CurveLoop();
+            loop.Append(Line.CreateBound(p0, p1));
+            loop.Append(Line.CreateBound(p1, p2));
+            loop.Append(Line.CreateBound(p2, p3));
+            loop.Append(Line.CreateBound(p3, p0));
+            return loop;
+        }
+
+        private XYZ ProjectCurtainElevationPointToPlane(XYZ point, XYZ planeOrigin, XYZ planeNormal)
+        {
+            if (point == null || planeOrigin == null || planeNormal == null)
+                return point;
+
+            XYZ normal = FlattenAndNormalize(planeNormal);
+            if (normal == null)
+                return point;
+
+            double distance = (point - planeOrigin).DotProduct(normal);
+            return point - normal * distance;
+        }
+
+        private Transform GetCurtainElevationWallAlignedCropFrame(Wall wall, XYZ wallMidPoint, XYZ markerPoint)
+        {
+            if (wall == null || wallMidPoint == null || markerPoint == null)
+                return null;
+
+            LocationCurve loc = wall.Location as LocationCurve;
+            Curve curve = loc?.Curve;
+            if (curve == null)
+                return null;
+
+            XYZ start;
+            XYZ end;
+            try
+            {
+                start = curve.GetEndPoint(0);
+                end = curve.GetEndPoint(1);
+            }
+            catch
+            {
+                return null;
+            }
+
+            XYZ right = FlattenAndNormalize(end - start);
+            XYZ up = XYZ.BasisZ;
+            XYZ depth = FlattenAndNormalize(markerPoint - wallMidPoint);
+            if (right == null || depth == null)
+                return null;
+
+            XYZ handedDepth = FlattenAndNormalize(right.CrossProduct(up));
+            if (handedDepth == null)
+                return null;
+
+            if (handedDepth.DotProduct(depth) < 0)
+            {
+                right = right.Negate();
+                handedDepth = handedDepth.Negate();
+            }
+
+            Transform transform = Transform.Identity;
+            transform.Origin = wallMidPoint;
+            transform.BasisX = right;
+            transform.BasisY = up;
+            transform.BasisZ = handedDepth;
+            return transform;
+        }
+
+        private bool IsCurtainElevationCropFrameEquivalent(Transform actual, Transform expected)
+        {
+            if (actual == null || expected == null)
+                return false;
+
+            const double directionTolerance = 0.999;
+            return Math.Abs(FlattenAndNormalize(actual.BasisX)?.DotProduct(FlattenAndNormalize(expected.BasisX)) ?? 0) >= directionTolerance
+                && Math.Abs(FlattenAndNormalize(actual.BasisY)?.DotProduct(FlattenAndNormalize(expected.BasisY)) ?? 0) >= directionTolerance
+                && Math.Abs(FlattenAndNormalize(actual.BasisZ)?.DotProduct(FlattenAndNormalize(expected.BasisZ)) ?? 0) >= directionTolerance;
+        }
+
+        private void ApplyCurtainElevationCropWithRevitTransformFallback(ViewSection view, Transform sourceFrame, XYZ localMin, XYZ localMax)
+        {
+            BoundingBoxXYZ currentCrop = view?.CropBox;
+            Transform targetFrame = currentCrop?.Transform;
+            if (view == null || sourceFrame == null || localMin == null || localMax == null || targetFrame == null)
+                return;
+
+            List<XYZ> worldCorners = GetCurtainElevationCropWorldCorners(sourceFrame, localMin, localMax);
+            Transform inverse = targetFrame.Inverse;
+            double minX = double.MaxValue;
+            double minY = double.MaxValue;
+            double minZ = double.MaxValue;
+            double maxX = double.MinValue;
+            double maxY = double.MinValue;
+            double maxZ = double.MinValue;
+
+            foreach (XYZ point in worldCorners)
+            {
+                XYZ local = inverse.OfPoint(point);
+                minX = Math.Min(minX, local.X);
+                minY = Math.Min(minY, local.Y);
+                minZ = Math.Min(minZ, local.Z);
+                maxX = Math.Max(maxX, local.X);
+                maxY = Math.Max(maxY, local.Y);
+                maxZ = Math.Max(maxZ, local.Z);
+            }
+
+            if (minX == double.MaxValue)
+                return;
+
+            view.CropBox = new BoundingBoxXYZ
+            {
+                Transform = targetFrame,
+                Min = new XYZ(minX, minY, minZ),
+                Max = new XYZ(maxX, maxY, maxZ)
+            };
+        }
+
+        private List<XYZ> GetCurtainElevationCropWorldCorners(Transform frame, XYZ min, XYZ max)
+        {
+            return new List<XYZ>
+            {
+                frame.OfPoint(new XYZ(min.X, min.Y, min.Z)),
+                frame.OfPoint(new XYZ(min.X, min.Y, max.Z)),
+                frame.OfPoint(new XYZ(min.X, max.Y, min.Z)),
+                frame.OfPoint(new XYZ(min.X, max.Y, max.Z)),
+                frame.OfPoint(new XYZ(max.X, min.Y, min.Z)),
+                frame.OfPoint(new XYZ(max.X, min.Y, max.Z)),
+                frame.OfPoint(new XYZ(max.X, max.Y, min.Z)),
+                frame.OfPoint(new XYZ(max.X, max.Y, max.Z))
+            };
+        }
+
+        private List<BoundingBoxXYZ> GetCurtainElevationElementBoundingBoxes(Document doc, Wall wall)
+        {
+            var boxes = new List<BoundingBoxXYZ>();
+            var ids = new HashSet<ElementId>();
+
+            AddCurtainElevationElementBoundingBox(doc, wall?.Id, ids, boxes);
+
+            try
+            {
+                CurtainGrid grid = wall?.CurtainGrid;
+                if (grid != null)
+                {
+                    foreach (ElementId id in grid.GetPanelIds())
+                        AddCurtainElevationElementBoundingBox(doc, id, ids, boxes);
+                    foreach (ElementId id in grid.GetMullionIds())
+                        AddCurtainElevationElementBoundingBox(doc, id, ids, boxes);
+                }
+            }
+            catch
+            {
+                // Fallback to host wall bbox if curtain sub-elements are not available.
+            }
+
+            try
+            {
+                foreach (ElementId id in wall.FindInserts(true, true, true, true))
+                    AddCurtainElevationElementBoundingBox(doc, id, ids, boxes);
+            }
+            catch
+            {
+                // Some wall/system states do not support inserts lookup.
+            }
+
+            return boxes;
+        }
+
+        private CurtainElevationGeometryPointResult GetCurtainElevationGeometryPoints(Document doc, Wall wall, ViewSection view)
+        {
+            var result = new CurtainElevationGeometryPointResult();
+            if (doc == null || wall == null)
+                return result;
+
+            var ids = GetCurtainElevationElementIds(wall, includeHostWall: false);
+            var options = new Options
+            {
+                IncludeNonVisibleObjects = false
+            };
+            options.View = view;
+
+            foreach (ElementId id in ids)
+                AddCurtainElevationElementGeometryPointRecords(doc, id, options, result, "geometry", false);
+
+            if (result.Points.Count == 0)
+            {
+                result.UsedHostWallFallback = true;
+                AddCurtainElevationElementGeometryPointRecords(doc, wall.Id, options, result, "host_wall_geometry", true);
+            }
+
+            return result;
+        }
+
+        private CurtainElevationGeometryPointResult GetCurtainElevationView2DPoints(Document doc, Wall wall, ViewSection view)
+        {
+            var result = new CurtainElevationGeometryPointResult();
+            if (doc == null || wall == null)
+                return result;
+
+            var ids = GetCurtainElevationElementIds(wall, includeHostWall: false);
+            var options = new Options
+            {
+                IncludeNonVisibleObjects = false
+            };
+            options.View = view;
+
+            foreach (ElementId id in ids)
+                AddCurtainElevationElementView2DPointRecords(doc, id, view, options, result, false);
+
+            if (result.Points.Count == 0)
+            {
+                result.UsedHostWallFallback = true;
+                AddCurtainElevationElementView2DPointRecords(doc, wall.Id, view, options, result, true);
+            }
+
+            return result;
+        }
+
+        private void AddCurtainElevationElementView2DPointRecords(
+            Document doc,
+            ElementId id,
+            View view,
+            Options options,
+            CurtainElevationGeometryPointResult result,
+            bool isHostWallFallback)
+        {
+            Element element = doc?.GetElement(id);
+            if (element == null || result == null)
+                return;
+
+            result.ElementCount++;
+
+            var viewBoxPoints = new List<XYZ>();
+            if (AddCurtainElevationBoundingBoxPoints(element, view, viewBoxPoints))
+            {
+                result.ViewSpecificBoundingBoxPointCount += viewBoxPoints.Count;
+                AddCurtainElevationPointRecords(viewBoxPoints, element, isHostWallFallback ? "host_wall_view_bbox" : "view_bbox", result);
+                return;
+            }
+
+            var elementPoints = new List<XYZ>();
+            try
+            {
+                GeometryElement geometry = element.get_Geometry(options);
+                AddCurtainElevationGeometryPoints(geometry, elementPoints);
+            }
+            catch
+            {
+                // Some system/family states cannot provide view-specific geometry.
+            }
+
+            if (elementPoints.Count > 0)
+            {
+                result.GeometryPointCount += elementPoints.Count;
+                AddCurtainElevationPointRecords(elementPoints, element, isHostWallFallback ? "host_wall_geometry" : "geometry", result);
+                return;
+            }
+
+            var bboxPoints = new List<XYZ>();
+            if (AddCurtainElevationBoundingBoxPoints(element, bboxPoints))
+            {
+                result.FallbackElementCount++;
+                result.FallbackElementIds.Add(id);
+                AddCurtainElevationPointRecords(bboxPoints, element, isHostWallFallback ? "host_wall_bbox_fallback" : "bbox_fallback", result);
+            }
+        }
+
+        private void AddCurtainElevationElementGeometryPointRecords(
+            Document doc,
+            ElementId id,
+            Options options,
+            CurtainElevationGeometryPointResult result,
+            string geometrySource,
+            bool isHostWallFallback)
+        {
+            Element element = doc?.GetElement(id);
+            if (element == null || result == null)
+                return;
+
+            result.ElementCount++;
+            var elementPoints = new List<XYZ>();
+
+            try
+            {
+                GeometryElement geometry = element.get_Geometry(options);
+                AddCurtainElevationGeometryPoints(geometry, elementPoints);
+            }
+            catch
+            {
+                // Some system/family states cannot provide view-specific geometry.
+            }
+
+            if (elementPoints.Count > 0)
+            {
+                result.GeometryPointCount += elementPoints.Count;
+                AddCurtainElevationPointRecords(elementPoints, element, geometrySource, result);
+                return;
+            }
+
+            var bboxPoints = new List<XYZ>();
+            if (AddCurtainElevationBoundingBoxPoints(element, bboxPoints))
+            {
+                result.FallbackElementCount++;
+                result.FallbackElementIds.Add(id);
+                AddCurtainElevationPointRecords(bboxPoints, element, isHostWallFallback ? "host_wall_bbox_fallback" : "bbox_fallback", result);
+            }
+        }
+
+        private void AddCurtainElevationPointRecords(List<XYZ> points, Element element, string source, CurtainElevationGeometryPointResult result)
+        {
+            if (points == null || element == null || result == null)
+                return;
+
+            foreach (XYZ point in points)
+            {
+                result.Points.Add(point);
+                result.Records.Add(new CurtainElevationPointRecord
+                {
+                    Point = point,
+                    ElementId = element.Id,
+                    CategoryName = element.Category?.Name,
+                    Source = source
+                });
+            }
+
+            result.ContributingElementIds.Add(element.Id);
+        }
+
+        private List<ElementId> GetCurtainElevationElementIds(Wall wall, bool includeHostWall)
+        {
+            var ids = new List<ElementId>();
+            var seen = new HashSet<ElementId>();
+
+            if (includeHostWall)
+                AddCurtainElevationElementId(wall?.Id, seen, ids);
+
+            try
+            {
+                CurtainGrid grid = wall?.CurtainGrid;
+                if (grid != null)
+                {
+                    foreach (ElementId id in grid.GetPanelIds())
+                        AddCurtainElevationElementId(id, seen, ids);
+                    foreach (ElementId id in grid.GetMullionIds())
+                        AddCurtainElevationElementId(id, seen, ids);
+                }
+            }
+            catch
+            {
+                // Fallback to host wall if curtain sub-elements are not available.
+            }
+
+            try
+            {
+                foreach (ElementId id in wall.FindInserts(true, true, true, true))
+                    AddCurtainElevationElementId(id, seen, ids);
+            }
+            catch
+            {
+                // Some wall/system states do not support inserts lookup.
+            }
+
+            return ids;
+        }
+
+        private void AddCurtainElevationElementId(ElementId id, HashSet<ElementId> seen, List<ElementId> ids)
+        {
+            if (id == null || id == ElementId.InvalidElementId || seen.Contains(id))
+                return;
+
+            seen.Add(id);
+            ids.Add(id);
+        }
+
+        private void AddCurtainElevationGeometryPoints(GeometryElement geometry, List<XYZ> points)
+        {
+            if (geometry == null || points == null)
+                return;
+
+            foreach (GeometryObject obj in geometry)
+                AddCurtainElevationGeometryObjectPoints(obj, points);
+        }
+
+        private void AddCurtainElevationGeometryObjectPoints(GeometryObject obj, List<XYZ> points)
+        {
+            if (obj == null || points == null)
+                return;
+
+            if (obj is Solid solid)
+            {
+                AddCurtainElevationSolidPoints(solid, points);
+                return;
+            }
+
+            if (obj is Mesh mesh)
+            {
+                foreach (XYZ point in mesh.Vertices)
+                    points.Add(point);
+                return;
+            }
+
+            if (obj is Curve curve)
+            {
+                AddCurtainElevationCurvePoints(curve, points);
+                return;
+            }
+
+            if (obj is GeometryInstance instance)
+            {
+                try
+                {
+                    AddCurtainElevationGeometryPoints(instance.GetInstanceGeometry(), points);
+                }
+                catch
+                {
+                    // Ignore geometry instance extraction failures; caller can bbox fallback per element.
+                }
+            }
+        }
+
+        private void AddCurtainElevationSolidPoints(Solid solid, List<XYZ> points)
+        {
+            if (solid == null || points == null || solid.Edges == null || solid.Edges.Size == 0)
+                return;
+
+            foreach (Edge edge in solid.Edges)
+            {
+                try
+                {
+                    IList<XYZ> tessellated = edge.Tessellate();
+                    foreach (XYZ point in tessellated)
+                        points.Add(point);
+                }
+                catch
+                {
+                    try
+                    {
+                        AddCurtainElevationCurvePoints(edge.AsCurve(), points);
+                    }
+                    catch
+                    {
+                        // Ignore bad edge geometry.
+                    }
+                }
+            }
+        }
+
+        private void AddCurtainElevationCurvePoints(Curve curve, List<XYZ> points)
+        {
+            if (curve == null || points == null)
+                return;
+
+            try
+            {
+                IList<XYZ> tessellated = curve.Tessellate();
+                if (tessellated != null && tessellated.Count > 0)
+                {
+                    foreach (XYZ point in tessellated)
+                        points.Add(point);
+                    return;
+                }
+            }
+            catch
+            {
+                // Fallback to endpoints below.
+            }
+
+            try
+            {
+                points.Add(curve.GetEndPoint(0));
+                points.Add(curve.GetEndPoint(1));
+            }
+            catch
+            {
+                // Unbound curves do not expose endpoints.
+            }
+        }
+
+        private bool AddCurtainElevationBoundingBoxPoints(Element element, List<XYZ> points)
+        {
+            if (element == null || points == null)
+                return false;
+
+            BoundingBoxXYZ box = element.get_BoundingBox(null);
+            if (box == null)
+                return false;
+
+            int before = points.Count;
+            AddCurtainElevationBoundingBoxPoints(box, points);
+            return points.Count > before;
+        }
+
+        private bool AddCurtainElevationBoundingBoxPoints(Element element, View view, List<XYZ> points)
+        {
+            if (element == null || view == null || points == null)
+                return false;
+
+            BoundingBoxXYZ box = element.get_BoundingBox(view);
+            if (box == null)
+                return false;
+
+            int before = points.Count;
+            AddCurtainElevationBoundingBoxPoints(box, points);
+            return points.Count > before;
+        }
+
+        private void AddCurtainElevationBoundingBoxPoints(BoundingBoxXYZ box, List<XYZ> points)
+        {
+            if (box == null || points == null)
+                return;
+
+            Transform transform = box.Transform ?? Transform.Identity;
+            points.Add(transform.OfPoint(new XYZ(box.Min.X, box.Min.Y, box.Min.Z)));
+            points.Add(transform.OfPoint(new XYZ(box.Min.X, box.Min.Y, box.Max.Z)));
+            points.Add(transform.OfPoint(new XYZ(box.Min.X, box.Max.Y, box.Min.Z)));
+            points.Add(transform.OfPoint(new XYZ(box.Min.X, box.Max.Y, box.Max.Z)));
+            points.Add(transform.OfPoint(new XYZ(box.Max.X, box.Min.Y, box.Min.Z)));
+            points.Add(transform.OfPoint(new XYZ(box.Max.X, box.Min.Y, box.Max.Z)));
+            points.Add(transform.OfPoint(new XYZ(box.Max.X, box.Max.Y, box.Min.Z)));
+            points.Add(transform.OfPoint(new XYZ(box.Max.X, box.Max.Y, box.Max.Z)));
+        }
+
+        private void AddCurtainElevationElementBoundingBox(Document doc, ElementId id, HashSet<ElementId> ids, List<BoundingBoxXYZ> boxes)
+        {
+            if (doc == null || id == null || id == ElementId.InvalidElementId || ids.Contains(id))
+                return;
+
+            ids.Add(id);
+            Element element = doc.GetElement(id);
+            BoundingBoxXYZ box = element?.get_BoundingBox(null);
+            if (box != null)
+                boxes.Add(box);
+        }
+
+        private List<XYZ> GetCurtainElevationBoundingPoints(List<BoundingBoxXYZ> boxes)
+        {
+            var points = new List<XYZ>();
+            foreach (BoundingBoxXYZ box in boxes)
+            {
+                points.Add(new XYZ(box.Min.X, box.Min.Y, box.Min.Z));
+                points.Add(new XYZ(box.Min.X, box.Min.Y, box.Max.Z));
+                points.Add(new XYZ(box.Min.X, box.Max.Y, box.Min.Z));
+                points.Add(new XYZ(box.Min.X, box.Max.Y, box.Max.Z));
+                points.Add(new XYZ(box.Max.X, box.Min.Y, box.Min.Z));
+                points.Add(new XYZ(box.Max.X, box.Min.Y, box.Max.Z));
+                points.Add(new XYZ(box.Max.X, box.Max.Y, box.Min.Z));
+                points.Add(new XYZ(box.Max.X, box.Max.Y, box.Max.Z));
+            }
+
+            return points;
+        }
+
+        private void ConfigureCurtainElevationFarClip(ViewSection view, CurtainElevationCropResult result, List<string> warnings)
+        {
+            double depthFt = result?.FarClipDepthFt ?? 0;
+            SetViewParameterByBuiltInName(view, "VIEWER_BOUND_ACTIVE_FAR", 1);
+            SetViewParameterByBuiltInName(view, "VIEWER_BOUND_FAR_CLIPPING", 2);
+            SetViewParameterByBuiltInName(view, "VIEWER_BOUND_OFFSET_FAR", depthFt);
+
+            if (result == null)
+                return;
+
+            result.FarClipRequestedDepthFt = depthFt;
+            try
+            {
+                view?.Document?.Regenerate();
+            }
+            catch (Exception ex)
+            {
+                result.FarClipWarning = AppendCurtainElevationWarning(result.FarClipWarning, $"Document regenerate after far clip write failed: {ex.Message}");
+            }
+
+            result.FarClipActualActive = GetViewIntegerParameterByBuiltInName(view, "VIEWER_BOUND_ACTIVE_FAR");
+            result.FarClipActualMode = GetViewIntegerParameterByBuiltInName(view, "VIEWER_BOUND_FAR_CLIPPING");
+            result.FarClipActualOffsetFt = GetViewDoubleParameterByBuiltInName(view, "VIEWER_BOUND_OFFSET_FAR");
+            BoundingBoxXYZ readbackCrop = view?.CropBox;
+            if (readbackCrop?.Min != null && readbackCrop.Max != null)
+            {
+                result.FarClipCropBoxMinZAfterFt = readbackCrop.Min.Z;
+                result.FarClipCropBoxMaxZAfterFt = readbackCrop.Max.Z;
+                result.FarClipCropBoxDepthAfterFt = Math.Abs(readbackCrop.Max.Z - readbackCrop.Min.Z);
+            }
+
+            if (!result.FarClipActualOffsetFt.HasValue)
+            {
+                result.FarClipPass = false;
+                result.FarClipDepthDeltaFt = depthFt;
+                result.FarClipWarning = AppendCurtainElevationWarning(result.FarClipWarning, "Cannot read VIEWER_BOUND_OFFSET_FAR after setting far clip.");
+            }
+            else if (Math.Abs(result.FarClipActualOffsetFt.Value - depthFt) > 1.0 / 304.8)
+            {
+                result.FarClipPass = false;
+                result.FarClipDepthDeltaFt = Math.Abs(result.FarClipActualOffsetFt.Value - depthFt);
+                result.FarClipWarning = AppendCurtainElevationWarning(
+                    result.FarClipWarning,
+                    $"VIEWER_BOUND_OFFSET_FAR readback differs from requested depth. Requested={Math.Round(depthFt * 304.8, 1)}mm, Actual={Math.Round(result.FarClipActualOffsetFt.Value * 304.8, 1)}mm.");
+            }
+            else
+            {
+                result.FarClipDepthDeltaFt = Math.Abs(result.FarClipActualOffsetFt.Value - depthFt);
+                result.FarClipPass = true;
+            }
+
+            if (result.FarClipActualActive.HasValue && result.FarClipActualActive.Value != 1)
+            {
+                result.FarClipPass = false;
+                result.FarClipWarning = AppendCurtainElevationWarning(result.FarClipWarning, $"VIEWER_BOUND_ACTIVE_FAR readback is {result.FarClipActualActive.Value}, expected 1.");
+            }
+
+            if (result.FarClipActualMode.HasValue && result.FarClipActualMode.Value != 2)
+            {
+                result.FarClipPass = false;
+                result.FarClipWarning = AppendCurtainElevationWarning(result.FarClipWarning, $"VIEWER_BOUND_FAR_CLIPPING readback is {result.FarClipActualMode.Value}, expected 2.");
+            }
+
+            if (!string.IsNullOrWhiteSpace(result.FarClipWarning))
+                warnings?.Add(result.FarClipWarning);
+        }
+
+        private void SetViewParameterByBuiltInName(View view, string builtInParameterName, double value)
+        {
+            if (!Enum.TryParse(builtInParameterName, out BuiltInParameter bip))
+                return;
+
+            Parameter parameter = view.get_Parameter(bip);
+            if (parameter == null || parameter.IsReadOnly)
+                return;
+
+            if (parameter.StorageType == StorageType.Double)
+                parameter.Set(value);
+            else if (parameter.StorageType == StorageType.Integer)
+                parameter.Set((int)Math.Round(value));
+        }
+
+        private double? GetViewDoubleParameterByBuiltInName(View view, string builtInParameterName)
+        {
+            if (view == null || !Enum.TryParse(builtInParameterName, out BuiltInParameter bip))
+                return null;
+
+            Parameter parameter = view.get_Parameter(bip);
+            if (parameter == null || parameter.StorageType != StorageType.Double)
+                return null;
+
+            return parameter.AsDouble();
+        }
+
+        private int? GetViewIntegerParameterByBuiltInName(View view, string builtInParameterName)
+        {
+            if (view == null || !Enum.TryParse(builtInParameterName, out BuiltInParameter bip))
+                return null;
+
+            Parameter parameter = view.get_Parameter(bip);
+            if (parameter == null || parameter.StorageType != StorageType.Integer)
+                return null;
+
+            return parameter.AsInteger();
+        }
+
+        private string AppendCurtainElevationWarning(string current, string warning)
+        {
+            if (string.IsNullOrWhiteSpace(warning))
+                return current;
+
+            if (string.IsNullOrWhiteSpace(current))
+                return warning;
+
+            return $"{current} {warning}";
+        }
+
+        private View FindCurtainElevationViewTemplate(Document doc, string templateName)
+        {
+            return new FilteredElementCollector(doc)
+                .OfClass(typeof(View))
+                .Cast<View>()
+                .FirstOrDefault(v => v.IsTemplate && v.Name == templateName);
+        }
+
+        private void ConfigureCurtainElevationViewTemplate(Document doc, View template, List<string> warnings)
+        {
+            var keepCategories = new HashSet<ElementId>
+            {
+                new ElementId((IdType)(int)BuiltInCategory.OST_Walls),
+                new ElementId((IdType)(int)BuiltInCategory.OST_CurtainWallPanels),
+                new ElementId((IdType)(int)BuiltInCategory.OST_CurtainWallMullions),
+                new ElementId((IdType)(int)BuiltInCategory.OST_Doors),
+                new ElementId((IdType)(int)BuiltInCategory.OST_Windows),
+                new ElementId((IdType)(int)BuiltInCategory.OST_Levels),
+                new ElementId((IdType)(int)BuiltInCategory.OST_WallTags),
+                new ElementId((IdType)(int)BuiltInCategory.OST_Dimensions),
+                new ElementId((IdType)(int)BuiltInCategory.OST_Lines)
+            };
+
+            foreach (Category category in doc.Settings.Categories)
+            {
+                if (category == null)
+                    continue;
+                if (category.CategoryType != CategoryType.Model && category.CategoryType != CategoryType.Annotation)
+                    continue;
+
+                TrySetCurtainTemplateCategoryHidden(template, category.Id, true, warnings);
+            }
+
+            foreach (ElementId id in keepCategories)
+            {
+                TrySetCurtainTemplateCategoryHidden(template, id, false, warnings);
+            }
+
+            ExcludeCurtainElevationCropAndFarClipFromTemplate(template, warnings);
+        }
+
+        private void TrySetCurtainTemplateCategoryHidden(View template, ElementId categoryId, bool hidden, List<string> warnings)
+        {
+            try
+            {
+                if (template.CanCategoryBeHidden(categoryId))
+                    template.SetCategoryHidden(categoryId, hidden);
+            }
+            catch (Exception ex)
+            {
+                warnings.Add($"Category {categoryId.GetIdValue()} visibility skipped: {ex.Message}");
+            }
+        }
+
+        private void ExcludeCurtainElevationCropAndFarClipFromTemplate(View template, List<string> warnings)
+        {
+            try
+            {
+                HashSet<ElementId> allTemplateParams = template.GetTemplateParameterIds().ToHashSet();
+                HashSet<ElementId> nonControlled = template.GetNonControlledTemplateParameterIds().ToHashSet();
+
+                foreach (BuiltInParameter bip in Enum.GetValues(typeof(BuiltInParameter)))
+                {
+                    string name = bip.ToString();
+                    bool isCropOrFarClip =
+                        name.IndexOf("CROP", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                        name.IndexOf("VIEWER_BOUND", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                        name.IndexOf("FAR_CLIP", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                        name.IndexOf("CLIPPING", StringComparison.OrdinalIgnoreCase) >= 0;
+
+                    if (!isCropOrFarClip)
+                        continue;
+
+                    ElementId paramId = new ElementId((IdType)(int)bip);
+                    if (allTemplateParams.Contains(paramId))
+                        nonControlled.Add(paramId);
+                }
+
+                template.SetNonControlledTemplateParameterIds(nonControlled);
+            }
+            catch (Exception ex)
+            {
+                warnings.Add($"View template non-controlled crop/far clip parameters skipped: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// 建�??��?帷�??�板類�?（含?��?�?
         /// </summary>
         private object CreateCurtainPanelType(JObject parameters)
         {
@@ -231,20 +4594,20 @@ namespace RevitMCP.Core
             string basePanelTypeName = parameters["basePanelType"]?.Value<string>();
 
             if (string.IsNullOrEmpty(typeName))
-                throw new Exception("請指定新類型名稱 (typeName)");
+                throw new Exception("請�?定新類�??�稱 (typeName)");
 
-            // 解析顏色
+            // �??顏色
             colorHex = colorHex.TrimStart('#');
             byte r = Convert.ToByte(colorHex.Substring(0, 2), 16);
             byte g = Convert.ToByte(colorHex.Substring(2, 2), 16);
             byte b = Convert.ToByte(colorHex.Substring(4, 2), 16);
             Color revitColor = new Color(r, g, b);
 
-            using (Transaction trans = new Transaction(doc, "建立帷幕面板類型"))
+            using (Transaction trans = new Transaction(doc, "建�?帷�??�板類�?"))
             {
                 trans.Start();
 
-                // 1. 找到基礎面板類型來複製
+                // 1. ?�到?��??�板類�?來�?�?
                 ElementType basePanelType = null;
 
                 if (!string.IsNullOrEmpty(basePanelTypeName))
@@ -258,7 +4621,7 @@ namespace RevitMCP.Core
 
                 if (basePanelType == null)
                 {
-                    // 使用預設的 System Panel
+                    // 使用?�設??System Panel
                     basePanelType = new FilteredElementCollector(doc)
                         .OfCategory(BuiltInCategory.OST_CurtainWallPanels)
                         .WhereElementIsElementType()
@@ -267,9 +4630,9 @@ namespace RevitMCP.Core
                 }
 
                 if (basePanelType == null)
-                    throw new Exception("找不到可用的帷幕面板類型作為基礎");
+                    throw new Exception("?��??�可?��?帷�??�板類�?作為?��?");
 
-                // 2. 檢查是否已存在同名類型
+                // 2. 檢查?�否已�??��??��???
                 ElementType existingType = new FilteredElementCollector(doc)
                     .OfCategory(BuiltInCategory.OST_CurtainWallPanels)
                     .WhereElementIsElementType()
@@ -285,12 +4648,12 @@ namespace RevitMCP.Core
                 }
                 else
                 {
-                    // 3. 複製類型
+                    // 3. 複製類�?
                     newPanelType = basePanelType.Duplicate(typeName) as ElementType;
                     isNewType = true;
                 }
 
-                // 4. 建立或更新材料
+                // 4. 建�??�更?��???
                 string materialName = $"CW_PNL_{typeName}";
                 Material material = new FilteredElementCollector(doc)
                     .OfClass(typeof(Material))
@@ -299,16 +4662,16 @@ namespace RevitMCP.Core
 
                 if (material == null)
                 {
-                    // 建立新材料
+                    // 建�??��???
                     ElementId newMatId = Material.Create(doc, materialName);
                     material = doc.GetElement(newMatId) as Material;
                 }
 
-                // 設定材料屬性
+                // 設�??��?屬�?
                 material.Color = revitColor;
                 material.Transparency = transparency;
 
-                // 5. 將材料指派給面板類型
+                // 5. 將�??��?派給?�板類�?
                 Parameter matParam = newPanelType.get_Parameter(BuiltInParameter.MATERIAL_ID_PARAM);
                 if (matParam != null && !matParam.IsReadOnly)
                 {
@@ -328,17 +4691,17 @@ namespace RevitMCP.Core
                     Color = $"#{r:X2}{g:X2}{b:X2}",
                     Transparency = transparency,
                     Message = isNewType
-                        ? $"成功建立新面板類型: {typeName}"
-                        : $"已更新既有面板類型: {typeName}"
+                        ? $"?��?建�??�面?��??? {typeName}"
+                        : $"已更?�既?�面?��??? {typeName}"
                 };
             }
         }
 
         /// <summary>
-        /// 批次套用面板排列模式
-        /// 支援兩種模式：
-        /// 1. typeMapping + matrix: 使用字母矩陣配合類型映射
-        /// 2. pattern: 直接使用 TypeId 矩陣
+        /// ?�次套用?�板?��?模�?
+        /// ?�援?�種模�?�?
+        /// 1. typeMapping + matrix: 使用字�??�陣?��?類�??��?
+        /// 2. pattern: ?�接使用 TypeId ?�陣
         /// </summary>
         private object ApplyPanelPattern(JObject parameters)
         {
@@ -350,7 +4713,7 @@ namespace RevitMCP.Core
             JArray matrix = parameters["matrix"] as JArray;
             JArray patternArray = parameters["pattern"] as JArray;
 
-            // 取得帷幕牆
+            // ?��?帷�???
             Wall wall = null;
             if (wallElementId.HasValue)
             {
@@ -366,13 +4729,13 @@ namespace RevitMCP.Core
             }
 
             if (wall == null)
-                throw new Exception("找不到帷幕牆，請指定 elementId 或選取帷幕牆");
+                throw new Exception("?��??�帷幕�?，�??��? elementId ?�選?�帷幕�?");
 
             CurtainGrid grid = wall.CurtainGrid;
             if (grid == null)
-                throw new Exception("此牆不是帷幕牆");
+                throw new Exception("Selected wall is not a curtain wall.");
 
-            // 建立類型映射字典
+            // 建�?類�??��?字典
             var typeMappingDict = new Dictionary<string, IdType>();
             if (typeMapping != null)
             {
@@ -382,15 +4745,15 @@ namespace RevitMCP.Core
                 }
             }
 
-            // 決定使用哪種模式
+            // 決�?使用?�種模�?
             JArray sourceMatrix = matrix ?? patternArray;
             if (sourceMatrix == null)
-                throw new Exception("請提供 matrix（字母矩陣 + typeMapping）或 pattern（TypeId 矩陣）");
+                throw new Exception("Provide matrix with typeMapping, or pattern with typeId values.");
 
-            // 取得所有面板
+            // ?��??�?�面??
             var panelIds = grid.GetPanelIds().ToList();
 
-            // 建立面板位置映射 (依據幾何位置排序)
+            // 建�??�板位置?��? (依�?幾�?位置?��?)
             var panelPositions = new List<(ElementId Id, XYZ Center)>();
 
             foreach (ElementId panelId in panelIds)
@@ -405,11 +4768,11 @@ namespace RevitMCP.Core
                 panelPositions.Add((panelId, center));
             }
 
-            // 依照位置排序並分配 Row/Col
-            // 先依 Z (高度) 分組（由上到下），再依 X 或 Y 排序（由左到右）
+            // 依照位置?��?並�???Row/Col
+            // ?��? Z (高度) ?��?（由上到下�?，�?�?X ??Y ?��?（由左到?��?
             var sortedByZ = panelPositions.OrderByDescending(p => p.Center.Z).ToList();
 
-            // 分組 by Z
+            // ?��? by Z
             var rowGroups = new List<List<(ElementId Id, XYZ Center)>>();
             double zTolerance = 0.5; // 0.5 feet
 
@@ -431,7 +4794,7 @@ namespace RevitMCP.Core
                 }
             }
 
-            // 建立 Row/Col 到 PanelId 的映射
+            // 建�? Row/Col ??PanelId ?��?�?
             var panelGrid = new Dictionary<(int row, int col), ElementId>();
             int rowIndex = 0;
             foreach (var rowGroup in rowGroups)
@@ -446,12 +4809,12 @@ namespace RevitMCP.Core
                 rowIndex++;
             }
 
-            // 套用模式
+            // 套用模�?
             int successCount = 0;
             int failCount = 0;
             var failedPanels = new List<object>();
 
-            using (Transaction trans = new Transaction(doc, "套用帷幕面板排列"))
+            using (Transaction trans = new Transaction(doc, "套用帷�??�板?��?"))
             {
                 trans.Start();
 
@@ -464,25 +4827,25 @@ namespace RevitMCP.Core
                     {
                         if (!panelGrid.ContainsKey((r, c))) continue;
 
-                        // 取得目標類型 ID
+                        // ?��??��?類�? ID
                         IdType targetTypeId = 0;
                         var cellValue = rowData[c];
 
                         if (cellValue.Type == JTokenType.String)
                         {
-                            // 字母模式，從 typeMapping 查找
+                            // 字�?模�?，�? typeMapping ?�找
                             string key = cellValue.Value<string>();
                             if (string.IsNullOrEmpty(key)) continue;
                             if (!typeMappingDict.TryGetValue(key, out targetTypeId))
                             {
-                                failedPanels.Add(new { Row = r, Col = c, Reason = $"找不到映射: {key}" });
+                                failedPanels.Add(new { Row = r, Col = c, Reason = $"?��??��?�? {key}" });
                                 failCount++;
                                 continue;
                             }
                         }
                         else if (cellValue.Type == JTokenType.Integer)
                         {
-                            // 直接 TypeId 模式
+                            // ?�接 TypeId 模�?
                             targetTypeId = cellValue.Value<IdType>();
                         }
 
@@ -499,16 +4862,16 @@ namespace RevitMCP.Core
 
                         try
                         {
-                            // 取得目標類型
+                            // ?��??��?類�?
                             ElementType targetType = doc.GetElement(new ElementId(targetTypeId)) as ElementType;
                             if (targetType == null)
                             {
-                                failedPanels.Add(new { PanelId = panelId.GetIdValue(), Row = r, Col = c, Reason = $"找不到 TypeId: {targetTypeId}" });
+                                failedPanels.Add(new { PanelId = panelId.GetIdValue(), Row = r, Col = c, Reason = $"?��???TypeId: {targetTypeId}" });
                                 failCount++;
                                 continue;
                             }
 
-                            // 變更面板類型
+                            // 變更?�板類�?
                             panel.ChangeTypeId(new ElementId(targetTypeId));
                             successCount++;
                         }
@@ -532,24 +4895,24 @@ namespace RevitMCP.Core
                 FailCount = failCount,
                 FailedPanels = failedPanels,
                 GridSize = new { Rows = rowGroups.Count, Columns = rowGroups.FirstOrDefault()?.Count ?? 0 },
-                Message = $"成功套用 {successCount} 個面板，失敗 {failCount} 個"
+                Message = $"Applied curtain panel pattern: success={successCount}, failed={failCount}."
             };
         }
 
         // ============================
-        // 立面面板 (Facade Panel) 相關
+        // 立面?�板 (Facade Panel) ?��?
         // ============================
 
         /// <summary>
-        /// 建立單片立面面板 (DirectShape)
-        /// 支援多種幾何類型：curved_panel（弧形面板）、beveled_opening（斜切凹窗框）、flat_panel（平面面板）
+        /// 建�??��?立面?�板 (DirectShape)
+        /// ?�援多種幾�?類�?：curved_panel（弧形面?��??�beveled_opening（�??�凹窗�?）、flat_panel（平?�面?��?
         /// </summary>
         private object CreateFacadePanel(JObject parameters)
         {
             Document doc = _uiApp.ActiveUIDocument.Document;
             UIDocument uidoc = _uiApp.ActiveUIDocument;
 
-            // 解析共用參數
+            // �???�用?�數
             IdType? wallId = parameters["wallId"]?.Value<IdType>();
             double positionAlongWall = parameters["positionAlongWall"]?.Value<double>() ?? 0;
             double positionZ = parameters["positionZ"]?.Value<double>() ?? 0;
@@ -579,7 +4942,7 @@ namespace RevitMCP.Core
             double cornerRadius = parameters["cornerRadius"]?.Value<double>() ?? 100;
             string openingShape = parameters["openingShape"]?.Value<string>() ?? "rounded_rect";
 
-            // 取得牆體
+            // ?��??��?
             Wall wall = null;
             if (wallId.HasValue)
             {
@@ -593,24 +4956,24 @@ namespace RevitMCP.Core
             }
 
             if (wall == null)
-                throw new Exception("找不到牆體，請指定 wallId 或選取牆體");
+                throw new Exception("Provide wallId or select a wall.");
 
             LocationCurve wallLoc = wall.Location as LocationCurve;
             if (wallLoc == null)
-                throw new Exception("無法取得牆體位置線");
+                throw new Exception("Wall has no location curve.");
 
             Line wallLine = wallLoc.Curve as Line;
             if (wallLine == null)
-                throw new Exception("目前僅支援直線牆");
+                throw new Exception("?��??�支?�直線�?");
 
             XYZ wallDir = wallLine.Direction.Normalize();
-            // 使用 wall.Orientation 取得外牆面法線（永遠指向室外）
+            // 使用 wall.Orientation ?��?外�??��?線�?永�??��?室�?�?
             XYZ wallNormal = wall.Orientation.Normalize();
-            // 將起始點從牆中心線偏移到外牆面（半個牆厚度）
-            double halfWallThickness = wall.Width / 2.0; // 已經是 feet
+            // 將起始�?從�?中�?線�?移到外�??��??�個�??�度�?
+            double halfWallThickness = wall.Width / 2.0; // 已�???feet
             XYZ wallExteriorStart = wallLine.GetEndPoint(0) + wallNormal * halfWallThickness;
 
-            using (Transaction trans = new Transaction(doc, $"建立立面面板: {panelName}"))
+            using (Transaction trans = new Transaction(doc, $"建�?立面?�板: {panelName}"))
             {
                 trans.Start();
 
@@ -659,14 +5022,14 @@ namespace RevitMCP.Core
                             break;
                     }
 
-                    // 建立 DirectShape
+                    // 建�? DirectShape
                     DirectShape ds = DirectShape.CreateElement(
                         doc, new ElementId((IdType)(int)BuiltInCategory.OST_GenericModel));
                     ds.ApplicationId = "RevitMCP_FacadePanel";
                     ds.ApplicationDataId = panelName;
                     ds.SetShape(new GeometryObject[] { solid });
 
-                    // 材料覆寫
+                    // ?��?覆寫
                     Material mat = FindOrCreateFacadeMaterial(doc, colorHex, panelName);
                     ApplyMaterialOverride(doc, ds.Id, mat);
 
@@ -682,20 +5045,20 @@ namespace RevitMCP.Core
                         Height = height,
                         Depth = depth,
                         Color = colorHex,
-                        Message = $"成功建立立面面板: {panelName} ({geometryType}), ID: {ds.Id.GetIdValue()}"
+                        Message = $"?��?建�?立面?�板: {panelName} ({geometryType}), ID: {ds.Id.GetIdValue()}"
                     };
                 }
                 catch (Exception ex)
                 {
                     if (trans.GetStatus() == TransactionStatus.Started)
                         trans.RollBack();
-                    throw new Exception($"建立立面面板失敗: {ex.Message}");
+                    throw new Exception($"建�?立面?�板失�?: {ex.Message}");
                 }
             }
         }
 
         /// <summary>
-        /// 建立弧形面板 Solid（弧形截面沿 Z 軸擠出）
+        /// 建�?弧形?�板 Solid（弧形截?�沿 Z 軸�??��?
         /// </summary>
         private Solid CreateCurvedPanelSolid(
             XYZ wallStart, XYZ wallDir, XYZ wallNormal,
@@ -738,8 +5101,8 @@ namespace RevitMCP.Core
         }
 
         /// <summary>
-        /// 建立斜切凹窗框 Solid（外框 + 斜切面，中心開口）
-        /// bevelDirection: "center"(均勻), "up"(上深), "down"(下深), "left"(左深), "right"(右深)
+        /// 建�??��??��?�?Solid（�?�?+ ?��??��?中�??�口�?
+        /// bevelDirection: "center"(?�勻), "up"(上深), "down"(下深), "left"(左深), "right"(?�深)
         /// </summary>
         private Solid CreateBeveledOpeningSolid(
             XYZ wallStart, XYZ wallDir, XYZ wallNormal,
@@ -757,17 +5120,17 @@ namespace RevitMCP.Core
             double posA = posAlongMm / 304.8;
             double posZ = posZMm / 304.8;
 
-            // 外框位置
+            // 外�?位置
             XYZ center = wallStart + wallDir * posA + wallNormal * off;
 
-            // 外框四角（牆面上，Z = posZ）
-            XYZ oA = center - wallDir * (fw / 2) + new XYZ(0, 0, posZ);           // 左下
-            XYZ oB = center + wallDir * (fw / 2) + new XYZ(0, 0, posZ);           // 右下
-            XYZ oC = center + wallDir * (fw / 2) + new XYZ(0, 0, posZ + fh);      // 右上
-            XYZ oD = center - wallDir * (fw / 2) + new XYZ(0, 0, posZ + fh);      // 左上
+            // 外�??��?（�??��?，Z = posZ�?
+            XYZ oA = center - wallDir * (fw / 2) + new XYZ(0, 0, posZ);           // 左�?
+            XYZ oB = center + wallDir * (fw / 2) + new XYZ(0, 0, posZ);           // ?��?
+            XYZ oC = center + wallDir * (fw / 2) + new XYZ(0, 0, posZ + fh);      // ?��?
+            XYZ oD = center - wallDir * (fw / 2) + new XYZ(0, 0, posZ + fh);      // 左�?
 
-            // 內開口四角（深入 bevelDepth 的位置）
-            // 根據 bevelDirection 調整各邊的深度
+            // ?��????角�?深入 bevelDepth ?��?置�?
+            // ?��? bevelDirection 調整?��??�深�?
             double dTop = bd, dBottom = bd, dLeft = bd, dRight = bd;
 
             switch (bevelDirection)
@@ -776,7 +5139,7 @@ namespace RevitMCP.Core
                 case "down":  dTop = bd * 1.5; dBottom = bd * 0.3; break;
                 case "left":  dLeft = bd * 0.3; dRight = bd * 1.5; break;
                 case "right": dLeft = bd * 1.5; dRight = bd * 0.3; break;
-                // center: 均勻深度
+                // center: ?�勻深度
             }
 
             double innerCenterX_offset = 0;
@@ -789,7 +5152,7 @@ namespace RevitMCP.Core
             XYZ iC = innerCenter + wallDir * (ow / 2) + new XYZ(0, 0, posZ + (fh + oh) / 2);
             XYZ iD = innerCenter - wallDir * (ow / 2) + new XYZ(0, 0, posZ + (fh + oh) / 2);
 
-            // 對斜切方向做微調：偏移內開口位置
+            // 對�??�方?��?微調：�?移內?�口位置
             XYZ dirShift = XYZ.Zero;
             switch (bevelDirection)
             {
@@ -803,11 +5166,11 @@ namespace RevitMCP.Core
             iC = iC + dirShift;
             iD = iD + dirShift;
 
-            // 建立幾何：用 4 個梯形面 + 外框背面組成的實體
-            // 使用 BooleanOperationsUtils：外框實體 - 內開口金字塔形空間
-            // 方法：建立外框 box，建立內部的金字塔形 void，做布林減法
+            // 建�?幾�?：用 4 ?�梯形面 + 外�??�面組�??�實�?
+            // 使用 BooleanOperationsUtils：�?框實�?- ?��????字�?形空??
+            // ?��?：建立�?�?box，建立內?��??��?塔形 void，�?布�?減�?
 
-            // 外框 solid：矩形截面沿法線擠出
+            // 外�? solid：矩形截?�沿法�??�出
             CurveLoop outerProfile = new CurveLoop();
             XYZ oA2 = new XYZ(oA.X, oA.Y, oA.Z);
             XYZ oB2 = new XYZ(oB.X, oB.Y, oB.Z);
@@ -825,8 +5188,8 @@ namespace RevitMCP.Core
                 bd + ft
             );
 
-            // 內部金字塔形切割：用 CreateBlendGeometry 或逐面構建
-            // 簡化：用較小的矩形在 bevelDepth 位置建立，做布林減法
+            // ?�部?��?塔形?�割：用 CreateBlendGeometry ?�逐面構建
+            // 簡�?：用較�??�矩形在 bevelDepth 位置建�?，�?布�?減�?
             CurveLoop innerProfile = new CurveLoop();
             innerProfile.Append(Line.CreateBound(iA, iB));
             innerProfile.Append(Line.CreateBound(iB, iC));
@@ -836,10 +5199,10 @@ namespace RevitMCP.Core
             Solid innerVoid = GeometryCreationUtilities.CreateExtrusionGeometry(
                 new List<CurveLoop> { innerProfile },
                 wallNormal,
-                ft + 0.01 // 穿透整個厚度
+                ft + 0.01 // 穿透整?��?�?
             );
 
-            // 布林減法：外框 - 內開口
+            // 布�?減�?：�?�?- ?��???
             Solid result = BooleanOperationsUtils.ExecuteBooleanOperation(
                 outerBox, innerVoid, BooleanOperationsType.Difference);
 
@@ -847,7 +5210,7 @@ namespace RevitMCP.Core
         }
 
         /// <summary>
-        /// 建立平面面板 Solid（簡單矩形截面沿法線擠出）
+        /// 建�?平面?�板 Solid（簡?�矩形截?�沿法�??�出�?
         /// </summary>
         private Solid CreateFlatPanelSolid(
             XYZ wallStart, XYZ wallDir, XYZ wallNormal,
@@ -878,8 +5241,8 @@ namespace RevitMCP.Core
         }
 
         /// <summary>
-        /// 建立傾斜平板 Solid（平面面板繞軸旋轉一定角度）
-        /// tiltAxis: "horizontal"（繞水平軸前後傾斜）, "vertical"（繞垂直軸左右傾斜）
+        /// 建�??��?平板 Solid（平?�面?��?軸�?轉�?定�?度�?
+        /// tiltAxis: "horizontal"（�?水平軸�?後傾?��?, "vertical"（�??�直軸左?�傾?��?
         /// </summary>
         private Solid CreateAngledPanelSolid(
             XYZ wallStart, XYZ wallDir, XYZ wallNormal,
@@ -896,16 +5259,16 @@ namespace RevitMCP.Core
 
             XYZ center = wallStart + wallDir * posA + wallNormal * off;
 
-            // 面板四角（未傾斜時）
-            XYZ p1 = new XYZ(-w / 2, 0, 0);       // 左下
-            XYZ p2 = new XYZ(w / 2, 0, 0);         // 右下
-            XYZ p3 = new XYZ(w / 2, 0, h);          // 右上
-            XYZ p4 = new XYZ(-w / 2, 0, h);         // 左上
+            // ?�板?��?（未?��??��?
+            XYZ p1 = new XYZ(-w / 2, 0, 0);       // 左�?
+            XYZ p2 = new XYZ(w / 2, 0, 0);         // ?��?
+            XYZ p3 = new XYZ(w / 2, 0, h);          // ?��?
+            XYZ p4 = new XYZ(-w / 2, 0, h);         // 左�?
 
-            // 套用傾斜
+            // 套用?��?
             if (tiltAxis == "horizontal")
             {
-                // 繞水平軸（wallDir）旋轉：上邊前傾或後傾
+                // 繞水平軸（wallDir）�?轉�?上�??�傾?��???
                 double dz = Math.Sin(angleRad) * h / 2;
                 double dy = (1 - Math.Cos(angleRad)) * h / 2;
                 p1 = new XYZ(p1.X, p1.Y + dy - Math.Sin(angleRad) * 0, p1.Z - dz);
@@ -913,7 +5276,7 @@ namespace RevitMCP.Core
                 p3 = new XYZ(p3.X, p3.Y - dy + Math.Sin(angleRad) * h, p3.Z + dz - h + h * Math.Cos(angleRad));
                 p4 = new XYZ(p4.X, p4.Y - dy + Math.Sin(angleRad) * h, p4.Z + dz - h + h * Math.Cos(angleRad));
 
-                // 簡化：直接偏移上下邊的 normal 方向
+                // 簡�?：直?��?移�?下�???normal ?��?
                 double topOffset = Math.Tan(angleRad) * h / 2;
                 p1 = new XYZ(-w / 2, -topOffset, 0);
                 p2 = new XYZ(w / 2, -topOffset, 0);
@@ -922,7 +5285,7 @@ namespace RevitMCP.Core
             }
             else // vertical
             {
-                // 繞垂直軸旋轉：左右邊前後偏移
+                // 繞�??�軸?��?：左?��??��??�移
                 double sideOffset = Math.Tan(angleRad) * w / 2;
                 p1 = new XYZ(-w / 2, -sideOffset, 0);
                 p2 = new XYZ(w / 2, sideOffset, 0);
@@ -930,7 +5293,7 @@ namespace RevitMCP.Core
                 p4 = new XYZ(-w / 2, -sideOffset, h);
             }
 
-            // 轉換到世界座標
+            // 轉�??��??�座�?
             Transform localToWorld = Transform.Identity;
             localToWorld.BasisX = wallDir;
             localToWorld.BasisY = wallNormal;
@@ -942,7 +5305,7 @@ namespace RevitMCP.Core
             XYZ wp3 = localToWorld.OfPoint(p3);
             XYZ wp4 = localToWorld.OfPoint(p4);
 
-            // 建立前面
+            // 建�??�面
             CurveLoop frontProfile = new CurveLoop();
             frontProfile.Append(Line.CreateBound(wp1, wp2));
             frontProfile.Append(Line.CreateBound(wp2, wp3));
@@ -954,8 +5317,8 @@ namespace RevitMCP.Core
         }
 
         /// <summary>
-        /// 建立圓角開口 Solid（厚牆上的圓角矩形開口）
-        /// openingShape: "rounded_rect"（圓角矩形）, "arch"（上方圓拱）, "stadium"（上下半圓）
+        /// 建�??��??�口 Solid（�??��??��?角矩形�????
+        /// openingShape: "rounded_rect"（�?角矩形�?, "arch"（�??��??��?, "stadium"（�?下�??��?
         /// </summary>
         private Solid CreateRoundedOpeningSolid(
             XYZ wallStart, XYZ wallDir, XYZ wallNormal,
@@ -974,12 +5337,12 @@ namespace RevitMCP.Core
             double posA = posAlongMm / 304.8;
             double posZ = posZMm / 304.8;
 
-            // 確保圓角半徑不超過開口尺寸的一半
+            // 確�??��??��?不�??��???��寸�?一??
             cr = Math.Min(cr, Math.Min(ow / 2, oh / 2));
 
             XYZ center = wallStart + wallDir * posA + wallNormal * off;
 
-            // 外框 solid（矩形截面，沿法線擠出）
+            // 外�? solid（矩形截?��?沿�?線�??��?
             XYZ oA = center - wallDir * (fw / 2) + new XYZ(0, 0, posZ);
             XYZ oB = center + wallDir * (fw / 2) + new XYZ(0, 0, posZ);
             XYZ oC = center + wallDir * (fw / 2) + new XYZ(0, 0, posZ + fh);
@@ -994,8 +5357,8 @@ namespace RevitMCP.Core
             Solid outerBox = GeometryCreationUtilities.CreateExtrusionGeometry(
                 new List<CurveLoop> { outerProfile }, wallNormal, dep + ft);
 
-            // 內開口 solid（圓角矩形，用於布林減法）
-            XYZ iCenter = center + wallNormal * ft; // 從表面厚度之後開始
+            // ?��???solid（�?角矩形�??�於布�?減�?�?
+            XYZ iCenter = center + wallNormal * ft; // 從表?��?度�?後�?�?
             double iLeft = -ow / 2;
             double iRight = ow / 2;
             double iBottom = posZ + (fh - oh) / 2;
@@ -1012,7 +5375,7 @@ namespace RevitMCP.Core
         }
 
         /// <summary>
-        /// 建立圓角矩形 CurveLoop 輪廓
+        /// 建�??��??�形 CurveLoop 輪�?
         /// </summary>
         private CurveLoop CreateRoundedRectProfile(
             XYZ center, XYZ wallDir,
@@ -1021,14 +5384,14 @@ namespace RevitMCP.Core
         {
             CurveLoop loop = new CurveLoop();
 
-            XYZ pBL = center + wallDir * left + new XYZ(0, 0, bottom);   // 左下
-            XYZ pBR = center + wallDir * right + new XYZ(0, 0, bottom);  // 右下
-            XYZ pTR = center + wallDir * right + new XYZ(0, 0, top);     // 右上
-            XYZ pTL = center + wallDir * left + new XYZ(0, 0, top);      // 左上
+            XYZ pBL = center + wallDir * left + new XYZ(0, 0, bottom);   // 左�?
+            XYZ pBR = center + wallDir * right + new XYZ(0, 0, bottom);  // ?��?
+            XYZ pTR = center + wallDir * right + new XYZ(0, 0, top);     // ?��?
+            XYZ pTL = center + wallDir * left + new XYZ(0, 0, top);      // 左�?
 
             if (radius <= 0.001 || shape == "rect")
             {
-                // 無圓角
+                // ?��?�?
                 loop.Append(Line.CreateBound(pBL, pBR));
                 loop.Append(Line.CreateBound(pBR, pTR));
                 loop.Append(Line.CreateBound(pTR, pTL));
@@ -1040,72 +5403,72 @@ namespace RevitMCP.Core
 
             if (shape == "arch")
             {
-                // 上方圓拱：下方直角，上方半圓弧
+                // 上方?�拱：�??�直角�?上方?��?�?
                 double archRadius = (right - left) / 2;
                 double archCenterZ = top - archRadius;
 
-                // 下左 → 下右
+                // 下左 ??下右
                 loop.Append(Line.CreateBound(pBL, pBR));
-                // 下右 → 右側拱起點
+                // 下右 ???�側?�起�?
                 XYZ archStartR = center + wallDir * right + new XYZ(0, 0, archCenterZ);
                 loop.Append(Line.CreateBound(pBR, archStartR));
-                // 右側 → 圓拱頂 → 左側
+                // ?�側 ???�拱????左側
                 XYZ archTop = center + new XYZ(0, 0, top);
                 XYZ archStartL = center + wallDir * left + new XYZ(0, 0, archCenterZ);
                 Arc arch = Arc.Create(archStartR, archStartL, archTop);
                 loop.Append(arch);
-                // 左側拱終點 → 下左
+                // 左側?��?�???下左
                 loop.Append(Line.CreateBound(archStartL, pBL));
                 return loop;
             }
 
-            // rounded_rect / stadium：四角帶圓弧
-            // 各角的圓弧中心
+            // rounded_rect / stadium：�?角帶?�弧
+            // ?��??��?弧中�?
             XYZ cBL = center + wallDir * (left + r) + new XYZ(0, 0, bottom + r);
             XYZ cBR = center + wallDir * (right - r) + new XYZ(0, 0, bottom + r);
             XYZ cTR = center + wallDir * (right - r) + new XYZ(0, 0, top - r);
             XYZ cTL = center + wallDir * (left + r) + new XYZ(0, 0, top - r);
 
-            // 底邊（左下角結束 → 右下角開始）
+            // 底�?（左下�?結�? ???��?角�?始�?
             XYZ bl_end = center + wallDir * (left + r) + new XYZ(0, 0, bottom);
             XYZ br_start = center + wallDir * (right - r) + new XYZ(0, 0, bottom);
             if (bl_end.DistanceTo(br_start) > 0.001)
                 loop.Append(Line.CreateBound(bl_end, br_start));
 
-            // 右下角圓弧
+            // ?��?角�?�?
             XYZ br_end = center + wallDir * right + new XYZ(0, 0, bottom + r);
             XYZ br_mid = cBR + (wallDir * r + new XYZ(0, 0, -r)).Normalize() * r;
             Arc arcBR = Arc.Create(br_start, br_end, br_mid);
             loop.Append(arcBR);
 
-            // 右邊
+            // ?��?
             XYZ tr_start = center + wallDir * right + new XYZ(0, 0, top - r);
             if (br_end.DistanceTo(tr_start) > 0.001)
                 loop.Append(Line.CreateBound(br_end, tr_start));
 
-            // 右上角圓弧
+            // ?��?角�?�?
             XYZ tr_end = center + wallDir * (right - r) + new XYZ(0, 0, top);
             XYZ tr_mid = cTR + (wallDir * r + new XYZ(0, 0, r)).Normalize() * r;
             Arc arcTR = Arc.Create(tr_start, tr_end, tr_mid);
             loop.Append(arcTR);
 
-            // 頂邊
+            // ?��?
             XYZ tl_start = center + wallDir * (left + r) + new XYZ(0, 0, top);
             if (tr_end.DistanceTo(tl_start) > 0.001)
                 loop.Append(Line.CreateBound(tr_end, tl_start));
 
-            // 左上角圓弧
+            // 左�?角�?�?
             XYZ tl_end = center + wallDir * left + new XYZ(0, 0, top - r);
             XYZ tl_mid = cTL + (wallDir * (-r) + new XYZ(0, 0, r)).Normalize() * r;
             Arc arcTL = Arc.Create(tl_start, tl_end, tl_mid);
             loop.Append(arcTL);
 
-            // 左邊
+            // 左�?
             XYZ bl_start = center + wallDir * left + new XYZ(0, 0, bottom + r);
             if (tl_end.DistanceTo(bl_start) > 0.001)
                 loop.Append(Line.CreateBound(tl_end, bl_start));
 
-            // 左下角圓弧
+            // 左�?角�?�?
             XYZ bl_mid = cBL + (wallDir * (-r) + new XYZ(0, 0, -r)).Normalize() * r;
             Arc arcBL = Arc.Create(bl_start, bl_end, bl_mid);
             loop.Append(arcBL);
@@ -1114,7 +5477,7 @@ namespace RevitMCP.Core
         }
 
         /// <summary>
-        /// 為 DirectShape 套用材料覆寫
+        /// ??DirectShape 套用?��?覆寫
         /// </summary>
         private void ApplyMaterialOverride(Document doc, ElementId elementId, Material mat)
         {
@@ -1140,23 +5503,23 @@ namespace RevitMCP.Core
         }
 
         /// <summary>
-        /// 批次建立整面立面（根據 AI 分析結果）
+        /// ?�次建�??�面立面（根??AI ?��?結�?�?
         /// </summary>
         private object CreateFacadeFromAnalysis(JObject parameters)
         {
             Document doc = _uiApp.ActiveUIDocument.Document;
             UIDocument uidoc = _uiApp.ActiveUIDocument;
 
-            // 解析參數
+            // �???�數
             IdType? wallId = parameters["wallId"]?.Value<IdType>();
 
             JObject facadeLayers = parameters["facadeLayers"] as JObject;
             if (facadeLayers == null)
-                throw new Exception("請提供 facadeLayers 參數");
+                throw new Exception("請�?�?facadeLayers ?�數");
 
             JObject outerLayer = facadeLayers["outer"] as JObject;
             if (outerLayer == null)
-                throw new Exception("請提供 facadeLayers.outer 參數");
+                throw new Exception("請�?�?facadeLayers.outer ?�數");
 
             double globalOffset = outerLayer["offset"]?.Value<double>() ?? 200;
             double gap = outerLayer["gap"]?.Value<double>() ?? 20;
@@ -1167,11 +5530,11 @@ namespace RevitMCP.Core
             JArray patternArray = outerLayer["pattern"] as JArray;
 
             if (panelTypesArray == null || panelTypesArray.Count == 0)
-                throw new Exception("請提供至少一個 panelTypes");
+                throw new Exception("請�?供至少�???panelTypes");
             if (patternArray == null || patternArray.Count == 0)
-                throw new Exception("請提供 pattern 排列矩陣");
+                throw new Exception("請�?�?pattern ?��??�陣");
 
-            // 取得牆體
+            // ?��??��?
             Wall wall = null;
             if (wallId.HasValue)
             {
@@ -1185,33 +5548,33 @@ namespace RevitMCP.Core
             }
 
             if (wall == null)
-                throw new Exception("找不到牆體，請指定 wallId 或選取牆體");
+                throw new Exception("Provide wallId or select a wall.");
 
-            // 取得牆的位置和方向
+            // ?��??��?位置?�方??
             LocationCurve wallLoc = wall.Location as LocationCurve;
             if (wallLoc == null)
-                throw new Exception("無法取得牆體位置線");
+                throw new Exception("Wall has no location curve.");
 
             Line wallLine = wallLoc.Curve as Line;
             if (wallLine == null)
-                throw new Exception("目前僅支援直線牆");
+                throw new Exception("?��??�支?�直線�?");
 
             XYZ wallDir = wallLine.Direction.Normalize();
-            // 使用 wall.Orientation 取得外牆面法線（永遠指向室外）
+            // 使用 wall.Orientation ?��?外�??��?線�?永�??��?室�?�?
             XYZ wallNormal = wall.Orientation.Normalize();
-            // 將起始點從牆中心線偏移到外牆面（半個牆厚度）
-            double halfWallThickness = wall.Width / 2.0; // 已經是 feet
+            // 將起始�?從�?中�?線�?移到外�??��??�個�??�度�?
+            double halfWallThickness = wall.Width / 2.0; // 已�???feet
             XYZ wallStart = wallLine.GetEndPoint(0) + wallNormal * halfWallThickness;
-            double wallLength = wallLine.Length * 304.8; // ft → mm
+            double wallLength = wallLine.Length * 304.8; // ft ??mm
 
-            // 取得牆的基準高程（Level 高程 + Base Offset）
+            // ?��??��??��?高�?（Level 高�? + Base Offset�?
             Level baseLevel = doc.GetElement(wall.LevelId) as Level;
             double wallBaseZ = baseLevel != null ? baseLevel.Elevation : 0; // feet
             Parameter baseOffsetParam = wall.get_Parameter(BuiltInParameter.WALL_BASE_OFFSET);
             double baseOffset = baseOffsetParam != null ? baseOffsetParam.AsDouble() : 0; // feet
             double wallBaseElevationMm = (wallBaseZ + baseOffset) * 304.8; // mm
 
-            // 解析面板類型
+            // �???�板類�?
             var typeDict = new Dictionary<string, JObject>();
             foreach (JObject ptObj in panelTypesArray)
             {
@@ -1220,17 +5583,17 @@ namespace RevitMCP.Core
                     typeDict[id] = ptObj;
             }
 
-            // 開始建立
+            // ?��?建�?
             int successCount = 0;
             int failCount = 0;
             var createdPanels = new List<object>();
             var failedPanels = new List<object>();
 
-            using (Transaction trans = new Transaction(doc, "建立立面面板組"))
+            using (Transaction trans = new Transaction(doc, "Create curtain facade panels"))
             {
                 trans.Start();
 
-                // 預先建立所有材料和 DirectShapeType
+                // ?��?建�??�?��??��? DirectShapeType
                 var materialCache = new Dictionary<string, Material>();
                 var dsTypeCache = new Dictionary<string, DirectShapeType>();
                 foreach (var kvp in typeDict)
@@ -1242,7 +5605,7 @@ namespace RevitMCP.Core
                         materialCache[kvp.Key] = FindOrCreateFacadeMaterial(doc, colorHex, userName);
                     }
 
-                    // 建立 DirectShapeType，命名規則: FP_{TypeId}_{名稱}
+                    // 建�? DirectShapeType，命?��??? FP_{TypeId}_{?�稱}
                     string dsTypeName = $"FP_{kvp.Key}_{userName}";
                     DirectShapeType existingType = new FilteredElementCollector(doc)
                         .OfClass(typeof(DirectShapeType))
@@ -1262,7 +5625,7 @@ namespace RevitMCP.Core
                     }
                 }
 
-                // 取得實心填滿圖案
+                // ?��?實�?填滿?��?
                 FillPatternElement solidFill = FillPatternElement.GetFillPatternElementByName(
                     doc, FillPatternTarget.Drafting, "<Solid fill>");
                 if (solidFill == null)
@@ -1275,16 +5638,16 @@ namespace RevitMCP.Core
 
                 View activeView = doc.ActiveView;
 
-                // 遍歷每一層
+                // ?�歷每�?�?
                 for (int floor = 0; floor < patternArray.Count; floor++)
                 {
                     string rowPattern = patternArray[floor]?.Value<string>() ?? "";
                     if (string.IsNullOrEmpty(rowPattern)) continue;
 
-                    double panelH = floorHeight - bandHeight; // 面板高度
-                    double zBase = wallBaseElevationMm + floor * floorHeight; // 此層底部 Z (mm)，加上牆基準高程
+                    double panelH = floorHeight - bandHeight; // ?�板高度
+                    double zBase = wallBaseElevationMm + floor * floorHeight; // 此層底部 Z (mm)，�?上�??��?高�?
 
-                    // 計算此列所有面板的總寬度（用於對齊）
+                    // 計�?此�??�?�面?��?總寬度�??�於對�?�?
                     double totalRowWidth = 0;
                     for (int c = 0; c < rowPattern.Length; c++)
                     {
@@ -1296,7 +5659,7 @@ namespace RevitMCP.Core
                         }
                     }
 
-                    // 起始 X 位置（置中對齊）
+                    // 起�? X 位置（置中�?齊�?
                     double startX = (wallLength - totalRowWidth) / 2;
                     double x = startX;
 
@@ -1314,7 +5677,7 @@ namespace RevitMCP.Core
                         string pName = pt["name"]?.Value<string>() ?? $"FP_{typeId}";
                         string pGeomType = pt["geometryType"]?.Value<string>() ?? "curved_panel";
 
-                        // 各幾何類型專用參數
+                        // ?�幾何�??��??��???
                         double pTiltAngle = pt["tiltAngle"]?.Value<double>() ?? 15;
                         string pTiltAxis = pt["tiltAxis"]?.Value<string>() ?? "horizontal";
                         double pCornerRadius = pt["cornerRadius"]?.Value<double>() ?? 100;
@@ -1327,7 +5690,7 @@ namespace RevitMCP.Core
                         {
                             double posAlongMm = x + pw / 2;
 
-                            // 根據 geometryType 呼叫對應方法
+                            // ?��? geometryType ?�叫對�??��?
                             Solid solid;
                             switch (pGeomType)
                             {
@@ -1370,7 +5733,7 @@ namespace RevitMCP.Core
                                     break;
                             }
 
-                            // DirectShape — 命名規則: FP_{TypeId}_F{樓層}_C{欄位}
+                            // DirectShape ???��?規�?: FP_{TypeId}_F{樓層}_C{欄�?}
                             string dsName = $"FP_{typeId}_F{floor + 1}_C{col + 1}";
                             DirectShape ds = DirectShape.CreateElement(
                                 doc,
@@ -1380,13 +5743,13 @@ namespace RevitMCP.Core
                             ds.ApplicationDataId = dsName;
                             ds.SetShape(new GeometryObject[] { solid });
 
-                            // 指定 DirectShapeType
+                            // ?��? DirectShapeType
                             if (dsTypeCache.ContainsKey(typeId))
                             {
                                 ds.SetTypeId(dsTypeCache[typeId].Id);
                             }
 
-                            // 材料覆寫
+                            // ?��?覆寫
                             if (materialCache.ContainsKey(typeId))
                             {
                                 ApplyMaterialOverride(doc, ds.Id, materialCache[typeId]);
@@ -1419,10 +5782,10 @@ namespace RevitMCP.Core
                     }
                 }
 
-                // 建立水平分隔帶（如果有）
+                // 建�?水平?��?帶�?如�??��?
                 if (bandHeight > 0)
                 {
-                    // 建立分隔帶 DirectShapeType
+                    // 建�??��?�?DirectShapeType
                     string bandTypeName = $"FP_Band_H{bandHeight}";
                     DirectShapeType bandType = new FilteredElementCollector(doc)
                         .OfClass(typeof(DirectShapeType))
@@ -1440,11 +5803,11 @@ namespace RevitMCP.Core
                         double panelH = floorHeight - bandHeight;
                         double bandZ = (wallBaseElevationMm + floor * floorHeight + panelH) / 304.8;
                         double bh_ft = bandHeight / 304.8;
-                        double bandThick = 50 / 304.8; // 分隔帶厚度 50mm
+                        double bandThick = 50 / 304.8; // ?��?帶�?�?50mm
 
                         try
                         {
-                            // 分隔帶為簡單矩形擠出
+                            // ?��?帶為簡單?�形?�出
                             XYZ b1 = wallStart + wallNormal * (globalOffset / 304.8);
                             XYZ b2 = b1 + wallDir * (wallLength / 304.8);
                             XYZ b3 = b2 + wallNormal * bandThick;
@@ -1478,7 +5841,7 @@ namespace RevitMCP.Core
                         }
                         catch
                         {
-                            // 分隔帶建立失敗不影響主流程
+                            // ?��?帶建立失?��?影響主�?�?
                         }
                     }
                 }
@@ -1495,12 +5858,12 @@ namespace RevitMCP.Core
                 FailCount = failCount,
                 CreatedPanels = createdPanels,
                 FailedPanels = failedPanels,
-                Message = $"成功建立 {successCount} 片立面面板，失敗 {failCount} 片"
+                Message = $"Created curtain facade panels: success={successCount}, failed={failCount}."
             };
         }
 
         /// <summary>
-        /// 建立或取得立面面板材料
+        /// 建�??��?得�??�面?��???
         /// </summary>
         private Material FindOrCreateFacadeMaterial(Document doc, string colorHex, string baseName)
         {

--- a/domain/curtain-wall-elevation-workflow.md
+++ b/domain/curtain-wall-elevation-workflow.md
@@ -1,0 +1,861 @@
+---
+name: curtain-wall-elevation-workflow
+description: "帷幕牆外立面視圖生成 SOP：當使用者要求帷幕立面、帷幕表、curtain wall elevation、create_curtain_wall_elevations 時觸發；規範如何用 Revit 原生 ElevationMarker 為每道 curtain wall 建立外側 elevation view、套用「帷幕立面」View Template、回報 skipped reason，並區分 MCP tool discovery / deployment 問題。"
+metadata:
+  version: "1.3"
+  updated: "2026-07-12"
+  created: "2026-07-12"
+  references: []
+  related:
+    - curtain-wall-pattern.md
+    - element-query-workflow.md
+    - tool-capability-boundary.md
+    - view-link-cleanup-workflow.md
+    - wall-check.md
+  referenced_by:
+    - curtain-wall
+    - create_curtain_wall_elevations
+    - diagnose_curtain_wall_elevation_direction
+    - diagnose_curtain_wall_elevation_directions
+  contributors:
+    - "gpt-5"
+  tags: [帷幕牆, 帷幕立面, 帷幕表, curtain-wall, elevation, view-template, ElevationMarker, Revit API]
+---
+
+# 帷幕牆外立面視圖生成 Workflow
+
+這份 domain 的目的，是讓 AI client 遇到「帷幕立面 / 帷幕表 / curtain wall elevation」需求時，直接呼叫 MCP tool，而不是掃專案檔案或自己猜 Revit API。
+
+核心 tool：
+
+```text
+create_curtain_wall_elevations
+```
+
+Direction debug tool:
+```text
+diagnose_curtain_wall_elevation_direction
+diagnose_curtain_wall_elevation_directions
+```
+
+## Trigger
+
+使用者提到下列任一需求時，應優先使用本 workflow：
+
+- 帷幕立面
+- 帷幕表
+- 帷幕牆外立面
+- curtain wall elevation
+- curtain schedule
+- curtain wall legend
+- `create_curtain_wall_elevations`
+- `diagnose_curtain_wall_elevation_direction`
+- `diagnose_curtain_wall_elevation_directions`
+
+## 不要做的事
+
+如果使用者只是要求「生成帷幕牆外立面」，不要先跑：
+
+```powershell
+Get-ChildItem
+rg
+dir
+```
+
+正確行為是直接呼叫 MCP tool。搜尋 repo 只適用於開發者要修改這個 tool 的原始碼時。
+
+## Tool Contract
+
+### Input
+
+| 參數 | 型別 | 預設 | 說明 |
+|---|---:|---:|---|
+| `placementViewId` | number | optional | 指定用來建立 `ElevationMarker` 的 `ViewPlan`。 |
+| `placementViewName` | string | optional | 指定 placement view 名稱。 |
+| `scale` | number | `50` | 立面比例。 |
+| `offsetMm` | number | `1500` | marker 放在牆外側的距離。 |
+| `horizontalMarginMm` | number | `0` | crop 左右 margin；預設貼合帷幕 bounding box。 |
+| `verticalMarginMm` | number | `0` | crop 上下 margin；預設貼合帷幕 bounding box。 |
+| `depthMm` | number | `1200` | 無法由帷幕元素 bounding box 推算深度時的 fallback far clip depth。 |
+| `viewTemplateName` | string | `"帷幕立面"` | 要套用或建立的 View Template 名稱。 |
+| `elevationViewTypeName` | string | `"帷幕立面"` | 要使用或自動建立的立面圖類型名稱。 |
+| `applyViewTemplate` | boolean | `true` | 是否套用 View Template。 |
+| `nameSeparator` | string | `"-"` | `{LevelName}` 與 `{Mark}` 中間的分隔字串。 |
+| `dryRun` | boolean | `false` | 只預覽結果，不建立 view。 |
+
+### Output
+
+| 欄位 | 說明 |
+|---|---|
+| `Success` | command 是否完成。 |
+| `DryRun` | 是否 dry run。 |
+| `TotalCurtainWalls` | 目前文件內 `Wall.CurtainGrid != null` 的牆數。 |
+| `CreatedCount` | 成功建立的 elevation view 數。 |
+| `SkippedCount` | 跳過或建立失敗的牆數。 |
+| `ViewTemplateId` | 使用的 template id；dry run 為 `0`。 |
+| `ViewTemplateName` | 使用的 template 名稱。 |
+| `TemplateCreated` | 是否新建 template。 |
+| `TemplateUpdated` | 是否更新 template category / non-controlled params。 |
+| `Created[]` | 每道成功牆的結果。 |
+| `Skipped[]` | 每道失敗或跳過牆的原因。 |
+| `TemplateWarnings[]` | category 或 template parameter 無法處理時的 warning。 |
+
+`Created[]` item 範例：
+
+```json
+{
+  "WallId": 12345,
+  "ViewId": 67890,
+  "ViewName": "1FCW-01",
+  "LevelName": "1F",
+  "Mark": "CW-01",
+  "MarkerId": 24680,
+  "FarClipDepthMm": 186.5,
+  "DirectionDot": 1.0,
+  "DirectionFixApplied": false,
+  "DesiredLookDirection": { "X": -1.0, "Y": 0.0, "Z": 0.0 },
+  "FinalVisualLookDirection": { "X": -1.0, "Y": 0.0, "Z": 0.0 },
+  "WallOrientation": { "X": 1.0, "Y": 0.0, "Z": 0.0 },
+  "CropPointSource": "geometry",
+  "CropPointCount": 128,
+  "CropFallbackElementCount": 0,
+  "CropFrameSource": "wall_location_curve",
+  "CropRightDirection": { "X": 0.0, "Y": 1.0, "Z": 0.0 },
+  "CropUpDirection": { "X": 0.0, "Y": 0.0, "Z": 1.0 },
+  "CropDepthDirection": { "X": -1.0, "Y": 0.0, "Z": 0.0 },
+  "CropLocalMin": { "X": -8.0, "Y": 0.0, "Z": -0.2 },
+  "CropLocalMax": { "X": 8.0, "Y": 3.2, "Z": 0.2 },
+  "CropUsedRevitTransformFallback": false,
+  "CropUsedHostWallFallback": false,
+  "CropContributingElementIds": [12346, 12347],
+  "CropFallbackElementIds": [],
+  "CropExtremeContributors": {
+    "MinX": { "ElementId": 12346, "Category": "Curtain Panels", "Source": "geometry" }
+  },
+  "CropRegionShapeApplied": false,
+  "CropRegionShapeFallbackReason": "disabled_for_diagnostics",
+  "MarkerPoint": { "X": 100.0, "Y": 20.0, "Z": 0.0 },
+  "WallMidPoint": { "X": 95.0, "Y": 20.0, "Z": 0.0 }
+}
+```
+
+`Skipped[]` item 範例：
+
+```json
+{
+  "WallId": 12345,
+  "LevelName": "1F",
+  "Mark": "CW-01",
+  "Reason": "立面方向驗證失敗，DirectionDot=0.1234"
+}
+```
+
+## Revit API Method
+
+### 1. Collect Curtain Walls
+
+只處理目前 Revit document，不處理 linked models。
+
+判斷條件：
+
+```csharp
+wall.CurtainGrid != null
+```
+
+排序：
+
+1. `wall.LevelId`
+2. `wall.Id`
+
+### 2. Level and Mark
+
+Level：
+
+```csharp
+doc.GetElement(wall.LevelId) as Level
+```
+
+Mark：
+
+```csharp
+wall.get_Parameter(BuiltInParameter.ALL_MODEL_MARK)?.AsString()
+```
+
+Mark 空白時 fallback：
+
+```text
+CW-{ElementId}
+```
+
+View name：
+
+```text
+{LevelName}{nameSeparator}{Mark}
+```
+
+`nameSeparator` 預設為 `-`，因此標準視圖命名為：
+
+```text
+{LevelName}-{Mark}
+```
+
+重名時自動加：
+
+```text
+_2, _3, _4 ...
+```
+
+Elevation view type:
+
+- 預設使用 `elevationViewTypeName = "帷幕立面"`。
+- 若文件中已有同名 `ViewFamilyType` 且 `ViewFamily == Elevation`，直接使用。
+- 若不存在，從第一個可用 Elevation `ViewFamilyType` 複製建立一個新類型並命名為 `帷幕立面`。
+- 所有新建立的帷幕立面 view 都必須使用這個 view type。
+
+### 3. Placement View Resolution
+
+`ElevationMarker.CreateElevation(...)` 需要一張 `ViewPlan` 作為 placement view。
+
+解析順序：
+
+1. `placementViewId`
+2. `placementViewName`
+3. active view，如果 active view 是 non-template `FloorPlan`
+4. 該 wall `LevelId` 對應的第一張 non-template `FloorPlan`
+
+找不到時該牆進入 `Skipped[]`。
+
+### 4. Exterior Side and Direction Rule
+
+`wall.Orientation` 是 API exterior normal，但不一定等於使用者在平面圖中視覺認定的雙箭頭 / flip control 所在側。不要用同樓層牆群中心、房間中心、bounding box 中心或平面幾何中心去猜外側，這些 heuristic 會在凹角、斜牆、突出量體或非凸平面中把原本正確的牆反轉。
+
+目前經使用者標記的 regression sample 顯示，使用者認定的帷幕外側應用 `wall.Flipped` 解析：
+
+```text
+wall.Flipped == true  -> api_orientation      -> wall.Orientation
+wall.Flipped == false -> opposite_orientation -> -wall.Orientation
+```
+
+這個規則只負責 marker placement side。marker 建立後仍要用 `markerPoint -> wallMid` 做視覺觀看方向對齊與 `DirectionDot >= 0.98` 驗證。若未來出現 `wall.Flipped` 無法解釋的反例，不要再改全域 heuristic；下一步應加 per-wall override。
+
+方向錯誤時先跑 `diagnose_curtain_wall_elevation_direction`，取得可重複診斷資料，再決定是否更新生成邏輯。固定 regression sample：`WallId = 365849` 目前 API `wall.Orientation = (-1, 0)`，但使用者視覺期待外側在右側。
+
+marker 放置點：
+
+```text
+markerPoint = wallMid + resolvedExteriorDirection * (wall.Width / 2 + offsetMm)
+```
+
+外立面的幾何觀看方向必須是：
+
+```text
+desiredLookDirection = wallMid - markerPoint
+```
+
+也就是從牆外側 marker 位置看回帷幕牆中心。
+
+不要把 `View.ViewDirection` 直接當成口語上的「鏡頭看向哪裡」。Revit elevation marker 的可視方向與 API `ViewDirection` 容易相反。本 workflow 明確定義：
+
+```csharp
+visualLookDirection = FlattenAndNormalize(view.ViewDirection.Negate());
+desiredLookDirection = FlattenAndNormalize(wallMid - markerPoint);
+```
+
+方向驗證：
+
+```text
+visualLookDirection · desiredLookDirection >= 0.98
+```
+
+如果第一次旋轉後 dot `< 0`，代表 marker 仍背對牆，應再旋轉 `Math.PI` 並重新 `doc.Regenerate()`。若最終 dot 仍 `< 0.98`，不可把該 view 當成功結果；應刪除剛建立的 view/marker，並把該牆寫入 `Skipped[]` 或回傳明確方向 warning。
+
+### 5. Create Elevation
+
+建立流程：
+
+```csharp
+ElevationMarker marker = ElevationMarker.CreateElevationMarker(doc, elevationType.Id, markerPoint, scale);
+ViewSection view = marker.CreateElevation(doc, placementView.Id, 0);
+doc.Regenerate();
+
+XYZ desiredLookDirection = wallMid - markerPoint;
+Align marker visual look direction to desiredLookDirection;
+doc.Regenerate();
+
+Validate visualLookDirection dot desiredLookDirection;
+```
+
+`doc.Regenerate()` 是必要步驟。剛建立的 elevation view / marker 若未 regenerate，`ViewDirection`、`CropBox`、可旋轉狀態可能尚未穩定。
+
+### 6. Crop and Far Clip
+
+> Current rule, use this first: crop is calculated after the elevation view is created, using the target curtain wall elements as they appear in that elevation view's 2D coordinate system.
+
+正式 crop method：
+
+```text
+view_2d_visible_bounds
+```
+
+流程：
+
+1. 先建立方向正確的 native `ElevationMarker` / elevation `ViewSection`。
+2. 將 crop / far clip 暫時放大並 `doc.Regenerate()`，讓 view-specific bounds 穩定。
+3. 只收集目標帷幕牆自己的元素：
+   - `CurtainGrid.GetPanelIds()`
+   - `CurtainGrid.GetMullionIds()`
+   - `Wall.FindInserts(true, true, true, true)`，包含 hosted doors / windows / openings
+4. 對每個元素優先取：
+   - `element.get_BoundingBox(view)`，也就是該 elevation view 內的 view-specific bounds
+   - 若取不到，再用 `element.get_Geometry(new Options { View = view, DetailLevel = Fine, IncludeNonVisibleObjects = false })`
+   - 最後才 fallback 到 `element.get_BoundingBox(null)`
+5. 使用 elevation view 的 2D 畫面座標計算最小矩形：
+   - X 軸：`view.RightDirection`
+   - Y 軸：`view.UpDirection`
+   - `u = (point - origin) · view.RightDirection`
+   - `v = (point - origin) · view.UpDirection`
+6. 將 2D 矩形四角轉回 Revit 實際 `view.CropBox.Transform` local space，只設定 `CropBox.Min` / `CropBox.Max`。
+
+重要限制：
+
+- 不要把自訂 `BoundingBoxXYZ.Transform` 當作 crop frame 寫回。Revit 設定 `View.CropBox` 時會忽略 input transform，只吃 `Min` / `Max`。
+- 不要用 `ViewCropRegionShapeManager.SetCropShape()` 做這個功能。先前實測斜向帷幕會更偏，正式生成必須維持 `CropRegionShapeApplied = false`。
+- 不要用 world-axis-aligned `get_BoundingBox(null)` 當主要來源；它只允許作最後 fallback。
+- host wall 只允許在 panel / mullion / insert 完全沒有任何可用 bounds/geometry 時作 fallback。
+
+`Created[]` 需要回傳：
+
+- `CropMethod`: `view_2d_visible_bounds`
+- `Crop2DOrigin`
+- `Crop2DRightDirection`
+- `Crop2DUpDirection`
+- `Crop2DMin`
+- `Crop2DMax`
+- `Crop2DPointCount`
+- `Crop2DSource`
+- `Crop2DExtremeContributors`
+- `CropUsedHostWallFallback`
+- `CropFallbackElementIds`
+- `CropRegionShapeApplied = false`
+
+debug SOP：
+
+- 如果 crop 還是偏大，先跑 `diagnose_curtain_wall_elevation_directions` 並設定 `includeCropDiagnostics = true`。
+- 先看 `View2DExtremeContributors` / `Crop2DExtremeContributors`，確認是哪個 element/category/source 造成 Min/Max。
+- 若來源是 `view_bbox` 且包含不可見控制點，下一步只針對該 category/element 改用 view geometry points，不再全域改方向或 crop frame。
+
+每張 view 建立後直接設定：
+
+- `CropBoxActive = true`
+- `CropBoxVisible = false`
+- crop box 貼合帷幕所有相關元素在 elevation view 2D 畫面中的最小矩形範圍
+- `VIEWER_BOUND_ACTIVE_FAR = 1`
+- `VIEWER_BOUND_FAR_CLIPPING = 2`，也就是 UI 的「剪裁含線」
+- `VIEWER_BOUND_OFFSET_FAR = autoDepthFt`
+
+遠剪裁深度規則適用所有帷幕，不分水平、垂直或斜向。正式方法：
+
+```text
+FarClipMethod = view_origin_to_target_max_depth
+```
+
+計算方式：
+
+```csharp
+visualLookDirection = GetCurtainElevationVisualLookDirection(view);
+depth = (targetPoint - view.Origin).DotProduct(visualLookDirection);
+farClipDepthFt = Max(depth where depth > 0) + 50mm;
+```
+
+target points 使用與 crop 相同的目標帷幕元素集合：panels、mullions、hosted doors/windows/inserts；host wall 只作最後 fallback。
+
+不要用 `markerPoint` 到帷幕中心的距離當遠剪裁深度；marker offset 只是平面放置距離，不是 Revit `VIEWER_BOUND_OFFSET` 的起算基準。也不要用 `Abs(localMaxZ - localMinZ)`，那只代表帷幕本體厚度，不是從立面切平面到最遠目標點的 offset。`depthMm` 只允許在完全無法取得 target points、`view.Origin` 或 visual look direction 時當 fallback。
+
+遠剪裁正式控制來源是：
+
+- `VIEWER_BOUND_ACTIVE_FAR = 1`
+- `VIEWER_BOUND_FAR_CLIPPING = 2`
+- `VIEWER_BOUND_OFFSET_FAR = farClipDepthFt`
+
+不要用 `CropBox.Min.Z / CropBox.Max.Z` 判定 far clip 是否成功。實測顯示 elevation view 讀回的 `CropBox` Z depth 可能保留 Revit 內部視圖範圍，會出現 10m 以上的值，但不等於 UI 的「遠剪裁偏移」。`CropBox` Z 只能當診斷參考，不可當 `FarClipPass` 條件。
+
+Revit 2024 `BuiltInParameter` 的正確 enum 名稱是 `VIEWER_BOUND_ACTIVE_FAR` 與 `VIEWER_BOUND_OFFSET_FAR`。不要使用不存在的 `VIEWER_BOUND_ACTIVE` 或 `VIEWER_BOUND_OFFSET`，否則 readback 會是 `null`，且實際遠剪裁不會被設定。
+
+`Created[]` 需回傳 far clip 診斷欄位：
+
+- `FarClipMethod`
+- `FarClipDepthMm`
+- `FarClipRequestedDepthMm`
+- `FarClipActualOffsetMm`
+- `FarClipDepthOrigin`
+- `FarClipLookDirection`
+- `FarClipMinCandidateDepthMm`
+- `FarClipMaxCandidateDepthMm`
+- `FarClipPositivePointCount`
+- `FarClipWarning`
+- `FarClipMarginMm`
+- `FarClipNearestTargetMm`
+- `FarClipFarthestTargetMm`
+- `FarClipPointSource`
+- `FarClipExtremeContributor`
+- `FarClipCropBoxDepthApplied`
+- `FarClipCropBoxDepthMethod`
+- `FarClipViewOriginLocalZMm`
+- `FarClipLookDirectionLocalZ`
+- `FarClipCropBoxMinZBeforeMm`
+- `FarClipCropBoxMaxZBeforeMm`
+- `FarClipCropBoxMinZAfterMm`
+- `FarClipCropBoxMaxZAfterMm`
+- `FarClipCropBoxDepthAfterMm`
+- `FarClipDepthDeltaMm`
+- `FarClipPass`
+
+不要直接用 `element.get_BoundingBox(null)` 的 8 個角點當主要 crop 來源。`get_BoundingBox(null)` 是 world-axis-aligned bounding box；斜向帷幕會先被世界 X/Y 軸放大，再投影到立面座標，造成 crop 過寬。
+
+Revit API 對 `View.CropBox` 有一個關鍵限制：設定 crop box 時，input `BoundingBoxXYZ.Transform` 會被忽略，只使用 `Min` / `Max`。因此正式生成不可嘗試改 `CropBox.Transform`，也不可把模型中的 wall-aligned transform 寫回 view。
+
+正確流程是：建立並旋轉 elevation view 後，使用 `view.RightDirection` / `view.UpDirection` 計算帷幕相關元素在立面 2D 畫面中的最小矩形，再把該矩形轉回 Revit 實際 `view.CropBox.Transform` local space，只設定 `CropBox.Min` / `CropBox.Max`。
+
+actual crop frame 語意：
+
+```text
+X = screen right
+Y = screen up
+Z = toward user
+```
+
+這代表斜向帷幕的 crop 不能靠 world AABB，也不能靠自訂 rotated BoundingBoxXYZ。業務 crop frame 是 elevation view 2D 畫面座標；Revit crop frame 只作為最後寫回 `Min` / `Max` 的座標系。
+
+曾經嘗試用二次 crop region shape：
+
+```text
+ViewCropRegionShapeManager.SetCropShape(wallAlignedRectangleLoop)
+```
+
+但實測斜向帷幕可能更偏，因為 wall-aligned loop 投影到 Revit elevation crop plane 後不一定等於 UI 看到的裁切座標。正式生成目前必須停用 `SetCropShape`，回傳：
+
+```text
+CropRegionShapeApplied = false
+CropRegionShapeFallbackReason = disabled_for_diagnostics
+```
+
+後續若要恢復 shape crop，必須先用 crop diagnostics 證明 `CandidateCropLoopIsValid` 且候選 loop 與 Revit 實際 crop plane 一致。
+
+主要點來源應為實際 geometry，且不要把 host wall 本體當 primary source：
+
+- `CurtainGrid.GetPanelIds()`
+- `CurtainGrid.GetMullionIds()`
+- `Wall.FindInserts(true, true, true, true)`，包含 hosted doors / windows / openings
+
+host wall 只允許在完全沒有 panel / mullion / insert points 時作最後 fallback。這是為了避免 wall join、flip controls、不可見 host geometry 或 model-axis bbox 把斜向帷幕 crop 撐大。
+
+每個元素先用 `element.get_Geometry(new Options { View = view, DetailLevel = Fine, IncludeNonVisibleObjects = false })` 收集：
+
+- `Solid` edge tessellation points
+- `Mesh` vertices
+- `Curve` tessellated points / endpoints
+- `GeometryInstance.GetInstanceGeometry()` 內部 geometry
+
+只有當某個元素無法取得 geometry points 時，才 fallback 到該元素 `get_BoundingBox(null)` 的角點。所有點都必須先投影到 actual view crop frame 後再算 local min/max。
+
+遠剪裁深度不可使用 `Abs(localMaxZ - localMinZ)`。`VIEWER_BOUND_OFFSET_FAR` 必須從 `view.Origin` 沿 `GetCurtainElevationVisualLookDirection(view)` 量到目標帷幕元素最遠正向點，再加 50mm margin。`FarClipPass` 只比較 `VIEWER_BOUND_OFFSET_FAR` readback 與 expected depth；`CropBoxDepthAfterMm` 只用來診斷 Revit 內部 crop depth，不可當失敗依據。如果完全無法取得 geometry / bbox points、`view.Origin` 或 visual look direction，才使用 `depthMm` 當 fallback。
+
+每次修改 far clip 前先跑：
+
+```powershell
+.\scripts\test-curtain-elevation-geometry.ps1
+```
+
+這個測試不需要 Revit，會檢查水平、垂直、斜向、負深度 fallback、crop local Z 反向等 deterministic cases。
+
+`Created[]` 需回傳 crop 診斷欄位：
+
+- `CropPointSource`: `geometry` / `geometry_with_bbox_fallback` / `bbox_fallback`
+- `CropPointCount`
+- `CropFallbackElementCount`
+- `CropFrameSource`: `wall_location_curve` / `revit_crop_transform`
+- `CropRightDirection`
+- `CropUpDirection`
+- `CropDepthDirection`
+- `CropLocalMin`
+- `CropLocalMax`
+- `CropUsedRevitTransformFallback`
+- `CropUsedHostWallFallback`
+- `CropContributingElementIds`
+- `CropFallbackElementIds`
+- `CropExtremeContributors`
+- `CropRegionShapeApplied`
+- `CropRegionShapeFallbackReason`
+
+### Crop Diagnostics
+
+方向診斷工具可加：
+
+```json
+{
+  "includeCropDiagnostics": true
+}
+```
+
+批次診斷範例：
+
+```json
+{
+  "wallIds": [365849],
+  "includeTemporaryMarker": true,
+  "includeCropDiagnostics": true
+}
+```
+
+crop diagnostics 在 rollback transaction 內建立 temporary elevation view，讀取後回滾，不留下永久 view / marker。回傳重點：
+
+- `ViewCropTransform`
+- `ViewRightDirection`
+- `ViewUpDirection`
+- `ViewDirection`
+- `CropBoxTransform`
+- `ViewCropMin`
+- `ViewCropMax`
+- `WallAlignedFrame`
+- `GeometryPointCount`
+- `GeometryLocalExtentsInActualCropFrame`
+- `GeometryLocalExtentsInViewCropFrame`
+- `GeometryLocalExtentsInWallAlignedFrame`
+- `ExtremeContributors`
+- `PointSourceCountsByCategory`
+- `CandidateCropLoopPoints`
+- `CandidateCropLoopIsValid`
+- `CropRegionShapeManagerAvailable`
+- `FallbackElementIds`
+
+若 crop 過大，先看 `FallbackElementIds` 是否有 host wall 或異常 insert bbox 撐大，再決定是否排除該元素或改用 view 內可見 outline。
+
+## View Template Rule
+
+Template name 預設：
+
+```text
+帷幕立面
+```
+
+解析順序：
+
+1. 找名稱相同且 `View.IsTemplate == true` 的 view template。
+2. 找不到時，用第一張成功建立的 elevation view 呼叫 `CreateViewTemplate()`。
+3. 將 template 命名為 `帷幕立面`。
+
+### Visible Categories
+
+template 只保留這些 category visible：
+
+| BuiltInCategory | 說明 |
+|---|---|
+| `OST_Walls` | curtain wall host / wall body |
+| `OST_CurtainWallPanels` | curtain wall panels |
+| `OST_CurtainWallMullions` | curtain wall mullions |
+| `OST_Doors` | 以門族實作的帷幕 panel |
+| `OST_Windows` | 以窗族實作的帷幕 panel |
+| `OST_Levels` | level lines |
+| `OST_WallTags` | wall tags |
+| `OST_Dimensions` | 自動建立的總寬、總高、網格間距尺寸 |
+| `OST_Lines` | 尺寸 fallback reference detail curves；實際線型應套 Invisible |
+
+### Non-Controlled Template Parameters
+
+template 不控制：
+
+- crop box
+- crop region visibility
+- far clipping
+- far clip offset / depth
+
+因此每張帷幕立面仍可保留自己的 crop box 與 far clip depth。
+
+## Failure Semantics
+
+### Delete Safety Rule
+
+`create_curtain_wall_elevations` 建立的是永久 elevation views，不是 temporary artifact。
+
+硬規則：
+
+- 執行 `create_curtain_wall_elevations` 後，不得自動呼叫 `delete_element`。
+- `FL1CW-*`、`{Level}{Mark}`、或 `Created[].ViewName` 回傳的 elevation views 都是成果，不能當作 cleanup target。
+- `Created[].IsPersistentOutput = true`、`PersistentViewsCreated = true`、`CleanupRequired = false`、`DeleteGeneratedViews = false` 時，AI client 必須保留這些 views。
+- 若使用者沒有明確說「刪除舊帷幕立面」或「清理剛生成的帷幕立面」，不得刪任何既有或新建帷幕 views。
+- 若使用者要求清理，必須先列出 view id / view name / source wall id 對應表並取得確認；不能直接批次刪除。
+
+唯一允許的自動刪除是 C# core 內部方向驗證失敗時，刪除同一 transaction 內剛建立但未通過 `DirectionDot >= 0.98` 的 marker/view。這不是 MCP `delete_element`，也不是清理成功成果。
+
+### Command Not Implemented
+
+如果 MCP 回：
+
+```text
+未知命令: create_curtain_wall_elevations
+```
+
+這通常是 Revit add-in DLL 還沒部署或 Revit 還載入舊 DLL。
+
+檢查：
+
+1. Revit 2024 是否重新啟動過。
+2. `%APPDATA%\Autodesk\Revit\Addins\2024\RevitMCP.addin` 的 `<Assembly>` 指向哪裡。
+3. 正確部署位置通常是：
+
+```text
+%APPDATA%\Autodesk\Revit\Addins\2024\RevitMCP\RevitMCP.dll
+```
+
+不是：
+
+```text
+%APPDATA%\Autodesk\Revit\Addins\2024\RevitMCP.dll
+```
+
+4. 關閉 Revit 後再覆蓋 DLL，因為 Revit 會鎖住已載入的 DLL。
+
+### AI Client Runs `Get-ChildItem`
+
+如果 Antigravity / AI client 看到 `create_curtain_wall_elevations` 後開始跑：
+
+```powershell
+Get-ChildItem
+```
+
+代表 client 沒有把需求對到 MCP tool。這不是 Revit 幾何問題。
+
+檢查：
+
+1. client 是否開在 repo root：
+
+```text
+D:\RevitMCP\REVIT_MCP_study
+```
+
+2. `.mcp.json` 是否被 client 載入。
+3. `MCP-Server/build/tools/curtain-wall-tools.js` 是否包含 `create_curtain_wall_elevations`。
+4. `MCP_PROFILE` 是否是 `full` 或 `architect`。
+5. Revit add-in 是否正在 `localhost:8964` listening。
+
+### CreatedCount = 0, SkippedCount > 0
+
+優先讀 `Skipped[].Reason`。
+
+常見原因：
+
+| Reason | 原因 | 處理 |
+|---|---|---|
+| 找不到可用 placement view | 沒有 active floor plan，也沒有 wall level 對應 floor plan | 指定 `placementViewId` 或建立樓層平面。 |
+| 沒有 LocationCurve | wall geometry 不支援 | 檢查該 `WallId`。 |
+| 無法取得 BoundingBox | view/document 狀態無法提供 bbox | 檢查模型狀態。 |
+| 無法判斷 wall.Orientation | 外側方向不可用 | 檢查該 `WallId`。 |
+| 立面方向驗證失敗 | marker 視覺方向無法穩定對到 `markerPoint -> wallMid` | 讀 `DirectionDot`、`DesiredLookDirection`、`FinalVisualLookDirection`，回報模型案例。 |
+
+### CreatedCount > 0 but Views Look Wrong
+
+先看 `Created[].DirectionDot`：
+
+- 接近 `1.0`：方向數學驗證通過，問題可能在 crop、template 或 Revit marker 顯示。
+- `< 0.98`：不應出現在 `Created[]`；這代表 tool 有 bug，需修正。
+
+再檢查：
+
+1. marker 是否真的在牆外側。
+2. 黑色三角是否看回帷幕牆。
+3. crop 是否被 template 控制。
+4. far clip 是否被 template 控制。
+5. template category 是否誤藏必要元素。
+
+### Direction Debug SOP
+
+方向錯誤時不要盲改 `wall.Orientation`、`ViewDirection` 或 marker rotation。先執行非破壞診斷：
+
+```json
+{
+  "wallId": 365849
+}
+```
+
+`diagnose_curtain_wall_elevation_direction` 會在 rollback transaction 中建立暫時 `ElevationMarker` / `ViewSection`，讀取方向後回滾，不留下永久 view 或 marker。
+
+診斷結果重點：
+- `WallDirection`
+- `WallOrientation`
+- `ApiExteriorMarkerPoint`
+- `ApiExteriorLookDirection`
+- `UiArrowSideCandidate`
+- `UiArrowMarkerPoint`
+- `InitialViewDirection`
+- `InitialVisualLookDirection`
+- `TemporaryViewDirection`
+- `TemporaryVisualLookDirection`
+- `DirectionDot`
+- `WouldPassDirectionCheck`
+
+點座標單位為 mm，方向向量為 unitless。`UiArrowSideCandidate` 目前只是診斷假設，不可直接當生成邏輯來源；只有在多個錯誤案例驗證後，才可正式更新 `create_curtain_wall_elevations`。
+
+正式生成結果若方向錯，優先比對：
+
+- `WallFlipped`
+- `ResolvedExteriorSide`
+- `ResolvedExteriorDirection`
+- `WallOrientation`
+- 批次診斷中的 `KnownExteriorSide`
+- 批次診斷中的 `AutoResolvedCandidate`
+- 批次診斷中的 `AutoMatchesKnownExteriorSide`
+
+如果 `AutoMatchesKnownExteriorSide = false`，代表目前 `wall.Flipped` 規則遇到反例，應收集該牆資料並改走 per-wall override。
+
+### Batch Direction Debug SOP
+
+不要用單一道牆推論全域外側規則。當同一模型裡有些帷幕 marker 方向正確、有些錯誤時，先跑批次診斷：
+
+```json
+{
+  "wallIds": [365849],
+  "knownExteriorSideByWallId": {
+    "365849": "opposite_orientation"
+  }
+}
+```
+
+`diagnose_curtain_wall_elevation_directions` 是非破壞工具。它會在 rollback transaction 內建立暫時 `ElevationMarker` / `ViewSection`，並且對每道帷幕牆同時比較兩個候選外側：
+
+| Candidate | Meaning |
+|---|---|
+| `api_orientation` | marker side is `wall.Orientation` |
+| `opposite_orientation` | marker side is `-wall.Orientation` |
+
+如果沒有提供 `wallIds`，tool 會診斷目前文件內所有 `CurtainGrid != null` 的 `Wall`。`knownExteriorSideByWallId` 只放使用者已確認的真值；沒有標記時，`Recommendation` 必須維持 `ambiguous_requires_user_label`，不能自動假設全部牆都用同一側。
+
+批次診斷會額外回傳 `AutoResolvedCandidate`，使用與正式生成相同的 `wall.Flipped` 規則：
+
+```text
+Flipped = true  -> api_orientation
+Flipped = false -> opposite_orientation
+```
+
+若有提供 `knownExteriorSideByWallId`，`AutoMatchesKnownExteriorSide` 應為 `true`。目前固定 regression samples：
+
+| WallId | Flipped | KnownExteriorSide |
+|---:|---:|---|
+| 365849 | false | `opposite_orientation` |
+| 366415 | true | `api_orientation` |
+| 366541 | true | `api_orientation` |
+| 365321 | false | `opposite_orientation` |
+| 365569 | false | `opposite_orientation` |
+
+後續若要再修改正式生成邏輯，至少要保留這些 regression labels：
+
+- `365849 = opposite_orientation`
+- 兩道目前生成方向正確的牆
+- 兩道目前生成方向錯誤的牆
+
+如果未來 regression labels 顯示 `wall.Flipped` 規則不穩定，下一步應該做 per-wall override，而不是繼續猜新的全域外側 heuristic。
+
+## Manual Verification Checklist
+
+執行 tool 後檢查：
+
+- 每道 `CurtainGrid != null` 的 curtain wall 產生一張 elevation view。
+- view name 符合 `{LevelName}-{Mark}`。
+- view type 名稱為 `帷幕立面`。
+- mark 空白 fallback 為 `CW-{ElementId}`。
+- 重名 fallback 為 `_2`, `_3`。
+- marker 在牆外側。
+- 黑色三角方向看回帷幕牆。
+- `Created[].DirectionDot` 應接近 `1.0`，至少 `>= 0.98`。
+- View Template 名稱為 `帷幕立面`。
+- template 只顯示 walls、curtain wall panels、curtain wall mullions、doors、windows、levels、wall tags、dimensions。
+- crop box 貼合帷幕 bounding box。
+- far clip mode 是「剪裁含線」。
+- crop box / far clip depth 不被 template 鎖住。
+- `Skipped[]` 有具體 reason，沒有 silent failure。
+
+## Dimension Annotation Rule
+
+`create_curtain_wall_elevations` 預設會在每張帷幕立面建立 Revit `Dimension`。沒有提供 `dimensionTypeId` 時，不得中斷立面生成，也不得要求使用者先選型；tool 會自行使用最近一次成功使用的標註類型、Revit 預設線性標註類型，或第一個可用 `DimensionType`。
+
+如果使用者明確要求先選標註類型，呼叫時設定：
+
+```json
+{
+  "dimensionTypeSelectionMode": "prompt"
+}
+```
+
+在 `prompt` 模式下，若沒有 `dimensionTypeId` / `dimensionTypeName`，tool 必須回傳 `WorkflowState = "awaiting_dimension_type_selection"` 與 `NextAction = "call_list_dimension_types"`，且不得建立任何 view。
+
+標註配置：
+
+- 上方第一道：總寬。
+- 上方第二道：水平帷幕網格間距。
+- 右側第一道：總高。
+- 右側第二道：垂直帷幕網格間距。
+
+尺寸依據使用已驗證的 elevation view 2D visible bounds：
+
+- X 軸使用 `view.RightDirection`。
+- Y 軸使用 `view.UpDirection`。
+- 總寬 / 總高使用 `Crop2DMin` / `Crop2DMax`。
+- 網格間距使用 curtain grid line 在同一個 view 2D frame 內的投影座標。
+
+Dimension type resolution 順序：
+
+1. `dimensionTypeId`
+2. `dimensionTypeName`
+3. current Revit/MCP process 最近一次成功使用的 curtain elevation dimension type
+4. Revit default linear `DimensionType`
+5. 第一個可用 `DimensionType`
+
+如果完全找不到 `DimensionType`，仍然建立帷幕立面，只略過尺寸並在 `DimensionWarnings[]` 回報。
+
+`Created[]` 需要回傳：
+
+- `DimensionsCreatedCount`
+- `DimensionsFailedCount`
+- `DimensionTypeId`
+- `DimensionTypeName`
+- `DimensionTypeSource`
+- `TotalWidthDimensionReferenceSource`
+- `TotalHeightDimensionReferenceSource`
+- `HorizontalGridDimensionReferenceSource`
+- `VerticalGridDimensionReferenceSource`
+- `GeometryReferenceCount`
+- `GeometryReferenceCategories`
+- `DimensionFallbackReason`
+- `TotalWidthDimensionId`
+- `HorizontalGridDimensionId`
+- `TotalHeightDimensionId`
+- `VerticalGridDimensionId`
+- `ReferenceCurveIds`
+- `DimensionStatus`
+- `DimensionWarnings[]`
+
+Dimension reference rule:
+
+- 優先使用帷幕本身 geometry references。
+- geometry references 來源包含 curtain panels、mullions、hosted doors/windows/inserts。
+- reference collection 必須使用 `Options.View = elevationView` 與 `ComputeReferences = true`。
+- 只有真實 geometry reference 不足或 Revit 拒絕建立 dimension 時，才使用 invisible detail curve fallback。
+- `DimensionReferenceSource` 類欄位必須標出 `geometry_reference`、`detail_curve_fallback`、`skipped` 或 `failed`。
+
+Dimension debug SOP:
+
+- 如果畫面上沒有尺寸，先執行 `diagnose_curtain_wall_elevation_dimensions`，不要直接改標註演算法。
+- 預設使用 `rollback = true`，測試產生的 dimension / reference plane 不得留在模型。
+- 先確認 `DimensionTypeId` 有值，再看 `AttemptedDimensions[]` 的 `Success`、`FailureMessage`、`ExistsAfterCreate`、`OwnerViewId`。
+- `reference_plane_fallback` 是保底對照組；如果它也失敗，代表問題在 dimension 建立流程或 view plane，不是 curtain geometry reference。
+- production `create_curtain_wall_elevations` 必須回傳 `DimensionAttemptCount`、`DimensionVerifiedCount`、`DimensionCreationErrors[]`；`addDimensions = true` 但 `DimensionVerifiedCount = 0` 時不得視為尺寸成功。
+
+## Boundaries
+
+這個 workflow 不處理：
+
+- linked model curtain wall
+- 自動修正 wall orientation
+- 自動新增牆標籤
+- sheet 排版
+- 帷幕表編號
+- panel / mullion 統計表


### PR DESCRIPTION
# 帷幕牆立面生成與尺寸標註

## Summary

新增帷幕牆立面生成工作流，針對目前文件內的 Curtain Wall 建立永久外立面視圖，完成方向解析、視圖樣板、2D crop、far clip 與尺寸標註診斷。

本次同時改善帷幕網格尺寸標註的 reference 收集，優先使用 `CurtainGridLine` 幾何中的原生 `Curve.Reference`，細部線僅保留為最後 fallback。

## Implemented

- 新增 `create_curtain_wall_elevations`。
- 找出文件內所有 `Wall` 且 `CurtainGrid != null` 的帷幕牆。
- 使用 `ElevationMarker` 建立永久 elevation views。
- 外側由 `wall.Flipped` 解析，並完成 marker 方向驗證。
- 視圖命名為 `{樓層}-{標記}`，重名時自動產生唯一名稱。
- 建立或套用立面圖類型 `帷幕立面`。
- 建立或套用 View Template `帷幕立面`。
- Template 保留帷幕牆、帷幕面板、帷幕豎框、樓層與牆標籤等必要可見類別。
- Template 不控制 crop box、crop region 與 far clip 參數。
- crop 使用 elevation view 內的 2D visible bounds，支援斜向與非矩形帷幕。
- far clip 依 view origin 到帷幕目標元素最遠點計算，並讀回驗證實際值。
- 流程順序固定為：建立 view、套 template、設定 crop/far clip、建立 dimensions、Regenerate、readback 驗證。
- 產生的 views 是永久成果，不應由 AI client 自動呼叫 `delete_element` 清理。

## Dimension Workflow

- 支援總寬、總高、水平網格與垂直網格尺寸。
- DimensionType 解析支援指定 ID、名稱、最近一次使用類型、Revit 預設類型與第一個可用類型。
- 新增 `diagnose_curtain_wall_elevation_dimensions`，可在 rollback transaction 中測試 DimensionType、ReferenceArray、NewDimension 與 OwnerViewId。
- CurtainGridLine reference 收集改為：
  - 不指定 `Options.View`。
  - 使用 `ComputeReferences = true`。
  - 逐條讀取 `CurtainGridLine` 的 `FullCurve`、segment curves 與 element geometry。
  - 依 FullCurve 方向與 elevation view-local 投影座標選取唯一有效 reference。
  - 儲存 stable representation 與 reference 選取診斷資料。
- 網格標註優先使用 CurtainGridLine 原生幾何 reference。
- Mullion centerline 不作為主要 dimension reference。
- 找不到足夠原生 reference 時才使用 detail curve fallback。
- 找不到既有不可見線型不會刪除已成功建立的 Dimension，會以 warning 回報。

## Diagnostics

`create_curtain_wall_elevations` 與診斷工具會回傳：

- Dimension 建立與 readback 結果。
- `CurtainGridLineReferenceCount`。
- `CurtainGridLineReferenceSamples`。
- Grid line orientation、projected coordinate、length、stable representation。
- Dimension reference source、fallback reason 與 reference curve IDs。
- Direction、crop、far clip 的計算與實際讀回資料。



應確認：

- `CurtainGridLineReferenceCount` 大於 0。
- 網格 dimensions 的 reference source 為 `geometry_reference`。
- `ReferenceCurveIds` 不包含網格尺寸所使用的輔助線。
- rollback 後模型沒有留下測試 Dimension 或 ReferencePlane。

若仍回傳 `detail_curve_fallback`，需查看 `CurtainGridLineReferenceSamples` 與 `CurtainGridLineReferenceFailures`，確認是 Revit 沒有提供 reference，或 `NewDimension` 拒絕該 reference array。

## Scope

本次不包含 sheet 排版、尺寸標註自動避讓、帷幕表編號與 linked model 處理。