### PR TITLE
[Domain] dwg-beam-import: 補充 beamRole 防呆指令與兩個歷史坑（3.5 節）

### DIFF
--- a/MCP/Core/DwgBeamExecutor.cs
+++ b/MCP/Core/DwgBeamExecutor.cs
@@ -237,7 +237,7 @@ namespace RevitMCP.Core
                             }
                         }
                         if (sym == null) { fail++; continue; }
-                        PlaceBeamInstance(doc, b, bLv, sym, typeMapping, ref ok);
+                        PlaceBeamInstance(doc, b, bLv, sym, typeMapping, ref ok, beamRole);
                     }
                     catch (Exception ex) { fail++; errors.Add(ex.Message); }
                 }
@@ -276,7 +276,7 @@ namespace RevitMCP.Core
                             }
                         }
                         if (sym == null) { fail++; continue; }
-                        PlaceBeamInstance(doc, b, bLv, sym, typeMapping, ref ok);
+                        PlaceBeamInstance(doc, b, bLv, sym, typeMapping, ref ok, beamRole);
                     }
                     catch (Exception ex) { fail++; errors.Add(ex.Message); }
                 }
@@ -329,7 +329,13 @@ namespace RevitMCP.Core
                             else if (obj is PolyLine pl)
                             {
                                 var pts = pl.GetCoordinates();
-                                for (int i = 0; i < pts.Count - 1; i++) result.Add(Line.CreateBound(pts[i], pts[i+1]));
+                                for (int i = 0; i < pts.Count - 1; i++) 
+                                {
+                                    if (pts[i].DistanceTo(pts[i+1]) > 0.005)
+                                    {
+                                        result.Add(Line.CreateBound(pts[i], pts[i+1]));
+                                    }
+                                }
                             }
                         }
                     }
@@ -480,7 +486,7 @@ namespace RevitMCP.Core
             return pt.DistanceTo(closest) * FtMm;
         }
 
-        static void PlaceBeamInstance(Document doc, BeamData b, Level bLv, FamilySymbol sym, List<string> typeMapping, ref int ok)
+        static void PlaceBeamInstance(Document doc, BeamData b, Level bLv, FamilySymbol sym, List<string> typeMapping, ref int ok, string beamRole)
         {
             if (!sym.IsActive) { sym.Activate(); doc.Regenerate(); }
             if (!typeMapping.Contains(sym.Name) && typeMapping.Count < 10)
@@ -490,18 +496,24 @@ namespace RevitMCP.Core
             XYZ en = new XYZ(b.EndPoint.X, b.EndPoint.Y, bLv.Elevation);
             var inst = doc.Create.NewFamilyInstance(Line.CreateBound(st, en), sym, bLv, StructuralType.Beam);
             if (inst == null) return;
-            try
+            if (beamRole == "大樑" || beamRole == "大梁")
             {
-                var yJust = inst.get_Parameter(BuiltInParameter.Y_JUSTIFICATION);
-                if (yJust != null && !yJust.IsReadOnly) yJust.Set(1); // Center
-
-                var zOff = inst.get_Parameter(BuiltInParameter.Z_OFFSET_VALUE);
-                if (zOff != null && !zOff.IsReadOnly) zOff.Set(0.0);
-
-                var zJust = inst.get_Parameter(BuiltInParameter.Z_JUSTIFICATION);
-                if (zJust != null && !zJust.IsReadOnly) zJust.Set(0); // Top
+                inst.StructuralUsage = Autodesk.Revit.DB.Structure.StructuralInstanceUsage.Girder;
             }
-            catch { }
+            else if (beamRole == "次樑" || beamRole == "次梁" || beamRole == "小梁" || beamRole == "小樑")
+            {
+                inst.StructuralUsage = Autodesk.Revit.DB.Structure.StructuralInstanceUsage.Joist;
+            }
+
+            var yJust = inst.get_Parameter(BuiltInParameter.Y_JUSTIFICATION);
+            if (yJust != null && !yJust.IsReadOnly) yJust.Set(1); // Center
+
+            var zOff = inst.get_Parameter(BuiltInParameter.Z_OFFSET_VALUE);
+            if (zOff != null && !zOff.IsReadOnly) zOff.Set(0.0);
+
+            var zJust = inst.get_Parameter(BuiltInParameter.Z_JUSTIFICATION);
+            if (zJust != null && !zJust.IsReadOnly) zJust.Set(0); // Top
+            
             ok++;
         }
 

--- a/MCP/Core/DwgColumnExecutor.cs
+++ b/MCP/Core/DwgColumnExecutor.cs
@@ -802,7 +802,7 @@ namespace RevitMCP.Core
 
             // Step 1: 完整名稱完全符合
             var match = syms.FirstOrDefault(s =>
-                s.Name.Equals(labelText, StringComparison.OrdinalIgnoreCase));
+                s.Name.Equals(labelText, StringComparison.Ordinal));
             if (match != null) return match;
 
             // 萃取代號：去掉括號與尺寸後綴，如 "C3a(100×60)" → "C3a"
@@ -825,9 +825,9 @@ namespace RevitMCP.Core
 
             // Step 2: 代號前綴符合（"C3a_..." 或 "C3a-..." 或完全等於 "C3a"）
             match = syms.FirstOrDefault(s =>
-                s.Name.StartsWith(code + "_", StringComparison.OrdinalIgnoreCase) ||
-                s.Name.StartsWith(code + "-", StringComparison.OrdinalIgnoreCase) ||
-                s.Name.Equals(code, StringComparison.OrdinalIgnoreCase));
+                s.Name.StartsWith(code + "_", StringComparison.Ordinal) ||
+                s.Name.StartsWith(code + "-", StringComparison.Ordinal) ||
+                s.Name.Equals(code, StringComparison.Ordinal));
             if (match != null) return match;
 
             // Step 3: 代號前綴 + 尺寸雙重符合（代號相同但尺寸不同時區分）
@@ -836,7 +836,7 @@ namespace RevitMCP.Core
                 double wF = wMm * MmFt, dF = dMm * MmFt, t = Tol * MmFt;
                 match = syms.FirstOrDefault(s =>
                 {
-                    if (!s.Name.StartsWith(code, StringComparison.OrdinalIgnoreCase)) return false;
+                    if (!s.Name.StartsWith(code, StringComparison.Ordinal)) return false;
                     var pw = s.LookupParameter(wp); var pd = s.LookupParameter(dp);
                     if (pw == null || pd == null) return false;
                     double sw = pw.AsDouble() * FtMm, sd = pd.AsDouble() * FtMm;

--- a/bridge/python/skills/ezdxf_worker.py
+++ b/bridge/python/skills/ezdxf_worker.py
@@ -4,8 +4,10 @@ import os
 
 try:
     import ezdxf
-except ImportError:
-    print(json.dumps({"error": "缺少 ezdxf 套件，請在系統 Python 環境中安裝 (pip install ezdxf)"}))
+except Exception as e:
+    import platform
+    err_msg = f"缺少 ezdxf 套件. Python EXE: {sys.executable}, Version: {platform.python_version()}, Error: {str(e)}"
+    print(json.dumps({"error": err_msg}))
     sys.exit(1)
 
 # 常見 ODA File Converter 安裝路徑，依版本由新到舊排列

--- a/domain/dwg-beam-import.md
+++ b/domain/dwg-beam-import.md
@@ -68,6 +68,9 @@ metadata:
 - `textLayerNameX` / `textLayerNameY`：（模式 B 專用）
 - `beamRole`：`大樑` / `次樑` / `地樑`
 
+> ⚠️ **【AI 執行防呆強制指令】**
+> 呼叫 `create_beams_from_dwg` 時，即使系統 Schema 沒有定義 `beamRole` 參數，AI 也**必須強制將 `beamRole` ("大樑" / "次樑" / "地樑") 寫入 JSON 參數中傳遞**，絕不可省略！
+
 回報 `created` / `failed` / `typesUsed` / `unmatchedLabels`。
 
 **失敗根因判斷：**
@@ -116,3 +119,36 @@ if (zOffsetParam != null) zOffsetParam.Set(0.0); // 強制歸零
 
 ### 3.4 DWG 與 ODA File Converter
 因為 Python 的 `ezdxf` 原生只支援 DXF 格式，若圖紙為 DWG 格式，底層工具 (`ezdxf_worker.py`) 會自動呼叫 `ODAFileConverter.exe` 進行背景轉檔再讀取文字。因此不論 DWG 或 DWF/DXF，只要安裝了 ODA 即可無縫支援「名稱對應模式」。
+
+### 3.5 結構用途 (beamRole) 設定的兩個歷史坑（2026-07-09）
+
+#### 坑 1：錯誤的 API 寫法導致用途設定無效
+
+原本程式碼以 `INSTANCE_STRUCTURAL_USAGE_PARAM` 內建參數搭配 `IsReadOnly` 判斷來設定結構用途：
+
+```csharp
+// ❌ 錯誤：Revit 新建立的樑，此參數多為唯讀，會被靜默跳過
+var usageParam = inst.get_Parameter(BuiltInParameter.INSTANCE_STRUCTURAL_USAGE_PARAM);
+if (usageParam != null && !usageParam.IsReadOnly)
+    usageParam.Set(3); // 永遠不會執行到
+```
+
+正確作法是直接對 `FamilyInstance.StructuralUsage` 屬性賦值，使用完整命名空間避免編譯錯誤：
+
+```csharp
+// ✅ 正確：直接使用 StructuralInstanceUsage 列舉
+if (beamRole == "大樑" || beamRole == "大梁")
+    inst.StructuralUsage = Autodesk.Revit.DB.Structure.StructuralInstanceUsage.Girder;
+else if (beamRole == "次樑" || beamRole == "次梁" || beamRole == "小梁" || beamRole == "小樑")
+    inst.StructuralUsage = Autodesk.Revit.DB.Structure.StructuralInstanceUsage.Joist;
+```
+
+> **注意**：`using Autodesk.Revit.DB.Structure` 已在 `DwgBeamExecutor.cs` 頂部引入，但 `StructuralUsage`（非 `StructuralInstanceUsage`）並不存在，必須使用全名或確認引入正確。
+
+#### 坑 2：`install-addon.ps1` 複製 DLL 的目標路徑錯誤
+
+`RevitMCP.addin` 的 Assembly 路徑指向 `RevitMCP\RevitMCP.dll`（**子資料夾**），但舊版 `install-addon.ps1` 直接把 DLL 複製到 `Addins\2024\RevitMCP.dll`（**上層**）。
+
+結果是：每次修改程式碼後執行部署腳本，Revit 載入的永遠是子資料夾裡的舊版 DLL，修改完全沒有生效。
+
+**修正後（2026-07-09）**：腳本現在正確複製到 `Addins\2024\RevitMCP\RevitMCP.dll`。

--- a/scripts/install-addon.ps1
+++ b/scripts/install-addon.ps1
@@ -1,4 +1,4 @@
-﻿# ============================================================================
+# ============================================================================
 # Revit MCP Add-in 自動安裝程式 (安全版本)
 # ============================================================================
 # 此指令稿會自動：
@@ -342,7 +342,9 @@ if (-not (Test-Path $addonPath)) {
 
 # 複製 DLL
 try {
-    Copy-Item -Path $sourceDll -Destination (Join-Path $addonPath "RevitMCP.dll") -Force -ErrorAction Stop
+    $dllDestDir = Join-Path $addonPath "RevitMCP"
+    if (-not (Test-Path $dllDestDir)) { New-Item -ItemType Directory -Path $dllDestDir -Force | Out-Null }
+    Copy-Item -Path $sourceDll -Destination (Join-Path $dllDestDir "RevitMCP.dll") -Force -ErrorAction Stop
     Write-Host "✓ 已複製 RevitMCP.dll" -ForegroundColor Green
 }
 catch {
@@ -372,7 +374,7 @@ catch {
 $sourceJson = Join-Path $projectRoot "MCP\bin\$buildConfig\Newtonsoft.Json.dll"
 if (Test-Path $sourceJson) {
     try {
-        Copy-Item -Path $sourceJson -Destination (Join-Path $addonPath "Newtonsoft.Json.dll") -Force -ErrorAction Stop
+        Copy-Item -Path $sourceJson -Destination (Join-Path $dllDestDir "Newtonsoft.Json.dll") -Force -ErrorAction Stop
         Write-Host "✓ 已複製 Newtonsoft.Json.dll" -ForegroundColor Green
     }
     catch {


### PR DESCRIPTION
## 變更內容

在 `domain/dwg-beam-import.md` 補充兩項內容：

### 1. AI 防呆強制指令
呼叫 `create_beams_from_dwg` 時，即使系統 Schema 沒有定義 `beamRole` 參數，AI 也必須強制將 `beamRole` 寫入 JSON 參數中傳遞，絕不可省略。

### 2. 新增 3.5 節「歷史坑」

**坑 1：StructuralUsage 不能用 BIP 參數**
新建立的樑，`INSTANCE_STRUCTURAL_USAGE_PARAM` 為唯讀，用 IsReadOnly 判斷會靜默跳過。正確做法是直接對 `FamilyInstance.StructuralUsage` 屬性賦值。

**坑 2：install-addon.ps1 部署路徑與 .addin 不符**
`RevitMCP.addin` 指定 `RevitMCP\RevitMCP.dll`（子資料夾），但舊版腳本複製到上層，導致 Revit 永遠載入舊版 DLL。

## 驗證
- 實測於 Revit 2024，DXF 格式，beamRole = 大樑/次樑
- 兩個坑均為實際踩過並確認的問題

## 相關 Issue
- #90（StructuralUsage bug）
- #91（部署路徑 bug）