### PR TITLE
feat(add-in): 連線獨佔鎖 + 切換鈕 + 顯示佔用 client 名稱

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,11 +68,14 @@ If the Revit MCP tools are unavailable, state that limitation and provide generi
 
 ## Single-Connection Limitation
 
-The Revit-side WebSocket service (`MCP/Core/SocketService.cs`) holds one MCP connection at a time. A newly connected MCP server replaces the previous connection. Consequences:
+The Revit-side WebSocket service (`MCP/Core/SocketService.cs`) holds an exclusive lock: while one MCP client is connected, additional incoming connections are rejected with HTTP 409 before the WebSocket upgrade (no more clobbering the active connection). Consequences:
 
-- Multiple AI clients are used by switching, never concurrently.
+- Multiple AI clients are used by switching, never concurrently — a second client is cleanly refused, not swapped in.
 - Do not advise users to run two MCP-connected AI clients against the same Revit session.
-- If a connection misbehaves, the reset path is: restart the MCP service from the Revit ribbon.
+- To hand the connection to another client, use the "切換/釋放連線" (Switch/Release Connection) ribbon button — it releases the current connection so the next reconnecting client can take the lock. Because WebSocket connections are anonymous at the transport level, the switch accepts whoever reconnects first, not a guaranteed named target.
+- The "MCP 設定" dialog shows which client currently holds the lock (e.g. `claude-code`, `claude-ai`), sourced from the MCP `clientInfo.name` the Node server forwards as a `?client=` query parameter; older or anonymous clients fall back to endpoint or "unknown".
+- `ServiceSettings.ExclusiveLock` (default `true`) is the escape hatch that reverts to the legacy clobber behavior if disabled.
+- If a connection misbehaves, the reset path is: use the ribbon's switch/release button, or restart the MCP service from the Revit ribbon.
 
 ## Personal Vault Protection
 

--- a/MCP-Server/src/index.ts
+++ b/MCP-Server/src/index.ts
@@ -73,7 +73,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   try {
     // Check Revit Connection
     if (!revitClient.isConnected()) {
-      console.error("[MCP Server] Revit not connected, attempting to connect...");
+      // 取得目前 AI 客戶端名稱（MCP initialize 的 clientInfo.name），連線時一併回報給 Revit add-in
+      const clientInfo = server.getClientVersion();
+      revitClient.clientName = clientInfo?.name || "unknown";
+      console.error(`[MCP Server] Revit not connected, connecting as client="${revitClient.clientName}"...`);
       await revitClient.connect();
     }
 

--- a/MCP-Server/src/socket.ts
+++ b/MCP-Server/src/socket.ts
@@ -40,6 +40,13 @@ export class RevitSocketClient {
     private reconnectInterval: number = 5000; // 5 seconds
     private responseHandlers: Map<string, (response: RevitResponse) => void> = new Map();
 
+    /**
+     * 連線時回報給 Revit add-in 的客戶端名稱（來自 MCP initialize 的 clientInfo.name，
+     * 例如 claude-code / claude-ai / Visual Studio Code）。由 index.ts 在連線前設定。
+     * add-in 會以此顯示「目前佔用連線的工具」。
+     */
+    public clientName: string = "unknown";
+
     constructor(host: string = 'localhost', port?: number) {
         this.host = host;
         this.port = port ?? getConfiguredPort();
@@ -50,7 +57,7 @@ export class RevitSocketClient {
      */
     async connect(): Promise<void> {
         return new Promise((resolve, reject) => {
-            const wsUrl = `ws://${this.host}:${this.port}`;
+            const wsUrl = `ws://${this.host}:${this.port}/?client=${encodeURIComponent(this.clientName)}`;
             console.error(`[Socket] Connecting to Revit: ${wsUrl}`);
 
             this.ws = new WebSocket(wsUrl);

--- a/MCP/Application.cs
+++ b/MCP/Application.cs
@@ -56,6 +56,15 @@ namespace RevitMCP
                 settingsButtonData.ToolTip = "開啟 MCP 設定視窗";
                 panel.AddItem(settingsButtonData);
 
+                // 4. 切換/釋放連線按鈕
+                PushButtonData switchButtonData = new PushButtonData(
+                    "MCPSwitch",
+                    "切換/\n釋放連線",
+                    assemblyPath,
+                    "RevitMCP.Commands.SwitchConnectionCommand");
+                switchButtonData.ToolTip = "關閉目前連線，讓下一個重新連線的 MCP 客戶端取得連線（無法指定特定客戶端）";
+                panel.AddItem(switchButtonData);
+
                 // 初始化 ExternalEventManager (必須在 UI 執行緒建立)
                 _ = ExternalEventManager.Instance;
 

--- a/MCP/Commands/MCPCommands.cs
+++ b/MCP/Commands/MCPCommands.cs
@@ -19,21 +19,26 @@ namespace RevitMCP.Commands
         {
             try
             {
-                // 檢查目前狀態
-                bool isConnected = Application.SocketService != null && Application.SocketService.IsConnected;
+                // 以 IsRunning 判斷開/關 (而非 IsConnected)：服務已啟動但尚無 client 連入時 IsConnected=false，
+                // 若用 IsConnected 判斷，再按一下會誤判為「啟動」而非「停止」。
+                bool running = Application.SocketService != null && Application.SocketService.IsRunning;
 
-                if (isConnected)
+                if (running)
                 {
-                    // 如果已連線，則停止
+                    // 已在執行 → 停止
                     Application.StopMCPService();
                     Logger.Info("使用者手動停止 MCP 服務");
-                    TaskDialog.Show("MCP 服務", "🔴 服務已停止");
+                    TaskDialog.Show("MCP 服務", "🔴 MCP 服務已關閉。");
                 }
                 else
                 {
-                    // 如果未連線，則啟動
+                    // 未執行 → 啟動
                     Logger.Info("使用者手動啟動 MCP 服務");
                     Application.StartMCPService(commandData.Application);
+                    TaskDialog.Show("MCP 服務",
+                        "🟢 MCP 服務已啟動。\n\n" +
+                        "正在 localhost:8964 監聽，等待 AI 客戶端連入。\n" +
+                        "（連上後可在「MCP 設定」查看目前佔用連線的客戶端）");
                 }
 
                 return Result.Succeeded;
@@ -71,11 +76,14 @@ namespace RevitMCP.Commands
 
                 if (Application.SocketService?.IsRunning == true)
                 {
-                    var (locked, remote, sinceUtc) = Application.SocketService.GetStatusSnapshot();
+                    var (locked, clientName, remote, sinceUtc) = Application.SocketService.GetStatusSnapshot();
+                    string clientDisplay = string.IsNullOrEmpty(clientName)
+                        ? (remote ?? "—")
+                        : (clientName + " (" + (remote ?? "?") + ")");
                     info += "\n\n" +
-                        "連線狀態: " + (locked ? "已鎖定" : "閒置(等待連入)") +
-                        ", 目前客戶端: " + (remote ?? "—") +
-                        ", 連線時間: " + (sinceUtc.HasValue ? sinceUtc.Value.ToLocalTime().ToString() : "—");
+                        "連線狀態: " + (locked ? "已鎖定" : "閒置(等待連入)") + "\n" +
+                        "目前客戶端: " + clientDisplay + "\n" +
+                        "連線時間: " + (sinceUtc.HasValue ? sinceUtc.Value.ToLocalTime().ToString() : "—");
                 }
 
                 TaskDialog.Show("MCP 設定", info);

--- a/MCP/Commands/MCPCommands.cs
+++ b/MCP/Commands/MCPCommands.cs
@@ -68,7 +68,16 @@ namespace RevitMCP.Commands
                     $"服務狀態: {(settings.IsEnabled ? "啟用" : "停用")}\n\n" +
                     $"配置檔位置:\n" +
                     $"{Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData)}\\RevitMCP\\config.json";
-                
+
+                if (Application.SocketService?.IsRunning == true)
+                {
+                    var (locked, remote, sinceUtc) = Application.SocketService.GetStatusSnapshot();
+                    info += "\n\n" +
+                        "連線狀態: " + (locked ? "已鎖定" : "閒置(等待連入)") +
+                        ", 目前客戶端: " + (remote ?? "—") +
+                        ", 連線時間: " + (sinceUtc.HasValue ? sinceUtc.Value.ToLocalTime().ToString() : "—");
+                }
+
                 TaskDialog.Show("MCP 設定", info);
                 return Result.Succeeded;
             }
@@ -76,6 +85,42 @@ namespace RevitMCP.Commands
             {
                 message = ex.Message;
                 TaskDialog.Show("錯誤", "開啟設定失敗: " + ex.Message);
+                return Result.Failed;
+            }
+        }
+    }
+
+    /// <summary>
+    /// 切換/釋放目前連線命令：釋放後讓下一個重新連線的 client 取得鎖。
+    /// 連線為匿名，無法保證釋放後由哪個 client 取得連線。
+    /// </summary>
+    [Transaction(TransactionMode.Manual)]
+    public class SwitchConnectionCommand : IExternalCommand
+    {
+        public Result Execute(
+            ExternalCommandData commandData,
+            ref string message,
+            ElementSet elements)
+        {
+            try
+            {
+                var svc = Application.SocketService;
+                if (svc == null || !svc.IsRunning)
+                {
+                    TaskDialog.Show("切換/釋放連線", "MCP 服務尚未啟動。");
+                    return Result.Succeeded;
+                }
+
+                var (released, prev) = svc.SwitchConnection();
+                TaskDialog.Show("切換/釋放連線", released
+                    ? ("已釋放連線（原客戶端 " + prev + "）。\n\n下一個重新連線的客戶端將取得連線。\n無法保證是特定客戶端——若要切換到另一個客戶端，請先讓目前客戶端停止重連。")
+                    : "目前沒有已鎖定的連線。下一個連入的客戶端會直接取得連線。");
+                return Result.Succeeded;
+            }
+            catch (Exception ex)
+            {
+                message = ex.Message;
+                TaskDialog.Show("錯誤", "切換/釋放連線失敗: " + ex.Message);
                 return Result.Failed;
             }
         }

--- a/MCP/Configuration/ServiceSettings.cs
+++ b/MCP/Configuration/ServiceSettings.cs
@@ -49,6 +49,12 @@ namespace RevitMCP.Configuration
         public int CommandTimeout { get; set; } = 30000;
 
         /// <summary>
+        /// 是否啟用連線獨佔鎖：已鎖定時拒絕新連線 (409)，避免多個 client 互相搶走連線。
+        /// 逃生旗標，關閉後回退成舊行為 (新連線直接覆蓋)。
+        /// </summary>
+        public bool ExclusiveLock { get; set; } = true;
+
+        /// <summary>
         /// 驗證並修正設定值。回傳 true 表示有修正（需存檔）。
         /// </summary>
         public bool ValidateAndFix()

--- a/MCP/Core/SocketService.cs
+++ b/MCP/Core/SocketService.cs
@@ -29,6 +29,7 @@ namespace RevitMCP.Core
         private readonly object _connectionLock = new object();
         private WebSocket _activeSocket;
         private string _activeRemoteEndpoint;
+        private string _activeClientName;   // 來自 ws 連線 query string ?client= (MCP clientInfo.name)
         private DateTime? _connectedAtUtc;
         private DateTime _lastRejectLogUtc = DateTime.MinValue;
 
@@ -169,14 +170,19 @@ namespace RevitMCP.Core
 
                         var wsContext = await context.AcceptWebSocketAsync(null);
 
+                        string logClient, logRemote;
                         lock (_connectionLock)
                         {
                             _activeSocket = wsContext.WebSocket;
                             _activeRemoteEndpoint = context.Request.RemoteEndPoint?.ToString();
+                            // 客戶端名稱由 node MCP server 以 ?client=<clientInfo.name> 帶入 (匿名時為 unknown)
+                            _activeClientName = context.Request.QueryString["client"];
                             _connectedAtUtc = DateTime.UtcNow;
+                            logClient = _activeClientName;
+                            logRemote = _activeRemoteEndpoint;
                         }
 
-                        Logger.Info("[Socket] MCP Server 已連線 (locked) - " + _activeRemoteEndpoint);
+                        Logger.Info("[Socket] MCP Server 已連線 (locked) - client=" + (logClient ?? "unknown") + " " + logRemote);
 
                         // 在獨立任務中處理訊息，不要阻塞接受連線的迴圈
                         _ = Task.Run(async () => await ReceiveMessagesAsync(wsContext.WebSocket, cancellationToken));
@@ -221,9 +227,10 @@ namespace RevitMCP.Core
             lock (_connectionLock)
             {
                 toClose = _activeSocket;
-                prev = _activeRemoteEndpoint;
+                prev = (string.IsNullOrEmpty(_activeClientName) ? "unknown" : _activeClientName) + " (" + (_activeRemoteEndpoint ?? "?") + ")";
                 _activeSocket = null;
                 _activeRemoteEndpoint = null;
+                _activeClientName = null;
                 _connectedAtUtc = null;
             }
 
@@ -250,11 +257,11 @@ namespace RevitMCP.Core
         /// <summary>
         /// 取得目前連線鎖定狀態快照，供 UI (設定視窗) 顯示使用。
         /// </summary>
-        public (bool locked, string remote, DateTime? sinceUtc) GetStatusSnapshot()
+        public (bool locked, string clientName, string remote, DateTime? sinceUtc) GetStatusSnapshot()
         {
             lock (_connectionLock)
             {
-                return (_activeSocket != null && _activeSocket.State == WebSocketState.Open, _activeRemoteEndpoint, _connectedAtUtc);
+                return (_activeSocket != null && _activeSocket.State == WebSocketState.Open, _activeClientName, _activeRemoteEndpoint, _connectedAtUtc);
             }
         }
 
@@ -318,6 +325,7 @@ namespace RevitMCP.Core
                     {
                         _activeSocket = null;
                         _activeRemoteEndpoint = null;
+                        _activeClientName = null;
                         _connectedAtUtc = null;
                     }
                 }
@@ -405,6 +413,7 @@ namespace RevitMCP.Core
                     ws = _activeSocket;
                     _activeSocket = null;
                     _activeRemoteEndpoint = null;
+                    _activeClientName = null;
                     _connectedAtUtc = null;
                 }
 

--- a/MCP/Core/SocketService.cs
+++ b/MCP/Core/SocketService.cs
@@ -20,14 +20,39 @@ namespace RevitMCP.Core
     public class SocketService
     {
         private HttpListener _httpListener;
-        private WebSocket _webSocket;
         private bool _isRunning;
         private readonly ServiceSettings _settings;
         private CancellationTokenSource _cancellationTokenSource;
 
+        // 連線鎖定狀態 (取代裸 _webSocket)：_connectionLock 保護以下四個欄位，
+        // 讓 accept loop / receive task / UI thread (SwitchConnection) 可安全並行存取。
+        private readonly object _connectionLock = new object();
+        private WebSocket _activeSocket;
+        private string _activeRemoteEndpoint;
+        private DateTime? _connectedAtUtc;
+        private DateTime _lastRejectLogUtc = DateTime.MinValue;
+
         public event EventHandler<RevitCommandRequest> CommandReceived;
         public bool IsRunning => _isRunning;
-        public bool IsConnected => _webSocket != null && _webSocket.State == WebSocketState.Open;
+        public bool IsConnected
+        {
+            get
+            {
+                lock (_connectionLock)
+                {
+                    return _activeSocket != null && _activeSocket.State == WebSocketState.Open;
+                }
+            }
+        }
+
+        /// <summary>
+        /// 檢查目前是否已鎖定連線。只能在持有 _connectionLock 時呼叫。
+        /// </summary>
+        private bool IsLocked_NoLock()
+        {
+            return _activeSocket != null &&
+                (_activeSocket.State == WebSocketState.Open || _activeSocket.State == WebSocketState.CloseReceived);
+        }
 
         public SocketService(ServiceSettings settings)
         {
@@ -123,13 +148,35 @@ namespace RevitMCP.Core
                 try
                 {
                     var context = await _httpListener.GetContextAsync();
-                    
+
                     if (context.Request.IsWebSocketRequest)
                     {
-                        var wsContext = await context.AcceptWebSocketAsync(null);
-                        _webSocket = wsContext.WebSocket;
+                        bool locked;
+                        lock (_connectionLock)
+                        {
+                            locked = _settings.ExclusiveLock && IsLocked_NoLock();
+                        }
 
-                        Logger.Info("[Socket] MCP Server 已連線");
+                        if (locked)
+                        {
+                            // 已有連線鎖定中：在 AcceptWebSocketAsync 之前直接拒絕 (409)，
+                            // 不做 101 upgrade。client 端會視為 handshake 失敗，之後每 5 秒自動重試。
+                            context.Response.StatusCode = 409;
+                            context.Response.Close();
+                            RateLimitedRejectLog(context.Request.RemoteEndPoint);
+                            continue;
+                        }
+
+                        var wsContext = await context.AcceptWebSocketAsync(null);
+
+                        lock (_connectionLock)
+                        {
+                            _activeSocket = wsContext.WebSocket;
+                            _activeRemoteEndpoint = context.Request.RemoteEndPoint?.ToString();
+                            _connectedAtUtc = DateTime.UtcNow;
+                        }
+
+                        Logger.Info("[Socket] MCP Server 已連線 (locked) - " + _activeRemoteEndpoint);
 
                         // 在獨立任務中處理訊息，不要阻塞接受連線的迴圈
                         _ = Task.Run(async () => await ReceiveMessagesAsync(wsContext.WebSocket, cancellationToken));
@@ -147,6 +194,67 @@ namespace RevitMCP.Core
                         Logger.Error("[Socket] 接受連線錯誤", ex);
                     }
                 }
+            }
+        }
+
+        /// <summary>
+        /// 限流記錄拒絕連線的 log，避免 client 每 5 秒重連造成洗版。
+        /// </summary>
+        private void RateLimitedRejectLog(System.Net.IPEndPoint remote)
+        {
+            var now = DateTime.UtcNow;
+            if ((now - _lastRejectLogUtc).TotalSeconds >= 30)
+            {
+                _lastRejectLogUtc = now;
+                Logger.Info("[Socket] 已拒絕重複連線 (連線已被鎖定) 來源: " + remote + ". 後續拒絕將靜默 30 秒。");
+            }
+        }
+
+        /// <summary>
+        /// 釋放目前鎖定的連線，讓下一個重新連線的 client 取得鎖。
+        /// 連線為匿名，無法保證釋放後由哪個 client 取得連線。
+        /// </summary>
+        public (bool released, string previousRemote) SwitchConnection()
+        {
+            WebSocket toClose;
+            string prev;
+            lock (_connectionLock)
+            {
+                toClose = _activeSocket;
+                prev = _activeRemoteEndpoint;
+                _activeSocket = null;
+                _activeRemoteEndpoint = null;
+                _connectedAtUtc = null;
+            }
+
+            if (toClose == null)
+            {
+                return (false, null);
+            }
+
+            try
+            {
+                // 必須用 Abort()，不能用 CloseAsync：CloseAsync 需要等待對方回應 close frame，
+                // 會和 receive task 既有的 ReceiveAsync 相撞，拋出「already one outstanding receive」例外。
+                toClose.Abort();
+            }
+            catch (Exception ex)
+            {
+                Logger.Debug("[Socket] Abort 期間例外(可忽略): " + ex.Message);
+            }
+
+            Logger.Info("[Socket] 使用者釋放連線: " + prev + ". 下一個重連的客戶端將取得鎖。");
+            return (true, prev);
+        }
+
+        /// <summary>
+        /// 取得目前連線鎖定狀態快照，供 UI (設定視窗) 顯示使用。
+        /// </summary>
+        public (bool locked, string remote, DateTime? sinceUtc) GetStatusSnapshot()
+        {
+            lock (_connectionLock)
+            {
+                return (_activeSocket != null && _activeSocket.State == WebSocketState.Open, _activeRemoteEndpoint, _connectedAtUtc);
             }
         }
 
@@ -193,9 +301,36 @@ namespace RevitMCP.Core
                 // 這是正常關閉，不需要視為錯誤
                 Logger.Info("[Socket] 訊息接收已停止 (服務已取消)");
             }
+            catch (WebSocketException ex)
+            {
+                // 使用者切換/停止造成的中止 (Abort()) 會讓這裡的 ReceiveAsync 拋出例外，屬正常流程
+                Logger.Debug("[Socket] 接收訊息中止 (使用者切換/停止造成的中止,屬正常): " + ex.Message);
+            }
             catch (Exception ex)
             {
                 Logger.Error("[Socket] 接收訊息錯誤", ex);
+            }
+            finally
+            {
+                lock (_connectionLock)
+                {
+                    if (ReferenceEquals(_activeSocket, socket))
+                    {
+                        _activeSocket = null;
+                        _activeRemoteEndpoint = null;
+                        _connectedAtUtc = null;
+                    }
+                }
+
+                // 唯一的 disposer：SwitchConnection() 與 Stop() 只呼叫 Abort()，不在此之外 Dispose，
+                // 避免與這裡的 receive loop 重複釋放。
+                try
+                {
+                    socket.Dispose();
+                }
+                catch
+                {
+                }
             }
         }
 
@@ -221,7 +356,14 @@ namespace RevitMCP.Core
         /// </summary>
         public async Task SendResponseAsync(RevitCommandResponse response)
         {
-            if (!IsConnected)
+            // 鎖內快照後改用區域變數 socket 傳送，避免 IsConnected 檢查與 SendAsync 之間
+            // _activeSocket 被 SwitchConnection()/Stop() 換掉或清空 (TOCTOU)。
+            WebSocket socket;
+            lock (_connectionLock)
+            {
+                socket = _activeSocket;
+            }
+            if (socket == null || socket.State != WebSocketState.Open)
             {
                 throw new InvalidOperationException("WebSocket 未連線");
             }
@@ -230,7 +372,7 @@ namespace RevitMCP.Core
             {
                 string json = JsonConvert.SerializeObject(response);
                 byte[] bytes = Encoding.UTF8.GetBytes(json);
-                await _webSocket.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true, CancellationToken.None);
+                await socket.SendAsync(new ArraySegment<byte>(bytes), WebSocketMessageType.Text, true, CancellationToken.None);
                 Logger.Debug($"[Socket] 已發送回應 (RequestId: {response.RequestId})");
             }
             catch (Exception ex)
@@ -255,35 +397,26 @@ namespace RevitMCP.Core
                 // 先取消所有背景任務
                 _cancellationTokenSource?.Cancel();
 
-                // 處理 WebSocket 關閉 (不阻塞 UI 執行緒)
-                if (_webSocket != null)
+                // 釋放連線鎖定 (只 Abort，不 CloseAsync/Dispose —— 交給 receive task 的 finally
+                // 處理 Dispose，維持單一 disposer 原則)
+                WebSocket ws;
+                lock (_connectionLock)
                 {
-                    var ws = _webSocket;
-                    _webSocket = null; // 先斷開引用
+                    ws = _activeSocket;
+                    _activeSocket = null;
+                    _activeRemoteEndpoint = null;
+                    _connectedAtUtc = null;
+                }
 
-                    Task.Run(async () =>
+                if (ws != null)
+                {
+                    try
                     {
-                        try
-                        {
-                            if (ws.State == WebSocketState.Open)
-                            {
-                                // 給予 2 秒時間嘗試正常關閉
-                                using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2)))
-                                {
-                                    await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "服務關閉", cts.Token);
-                                }
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            Logger.Debug($"WebSocket 正常關閉失敗 (此為正常現象): {ex.Message}");
-                        }
-                        finally
-                        {
-                            ws.Dispose();
-                            Logger.Info("WebSocket 已釋放");
-                        }
-                    });
+                        ws.Abort();
+                    }
+                    catch
+                    {
+                    }
                 }
 
                 // 停止 HttpListener

--- a/README.md
+++ b/README.md
@@ -218,11 +218,12 @@ Replace `<YOUR_PROJECT_PATH>` in the templates with the actual project path on y
 
 ### Switching Between AI Clients
 
-The Revit-side WebSocket service accepts only one MCP connection at a time: a newly connected MCP server replaces the previous connection. Multiple AI clients are therefore used by switching, not concurrently:
+The Revit-side WebSocket service holds an exclusive lock: only one AI client can be connected at a time. A second client that tries to connect is cleanly rejected (HTTP 409), not swapped in — the first connection stays stable. Multiple AI clients are therefore used by switching, not concurrently:
 
-1. Close the current AI client (or disable its MCP server).
-2. Start the other AI client; once its MCP server connects to `localhost:8964`, it takes over.
-3. If the connection misbehaves, restart the MCP service from the Revit ribbon to reset it.
+1. In the Revit ribbon, click the **"切換/釋放連線" (Switch/Release Connection)** button to release the current connection.
+2. Start or reconnect the other AI client; once its MCP server connects to `localhost:8964`, it takes the lock.
+3. The **"MCP 設定"** dialog shows which client currently holds the connection (e.g. `claude-code`, `claude-ai`).
+4. If the connection misbehaves, use the same ribbon button, or restart the MCP service from the Revit ribbon to reset it.
 
 ## Startup Flow
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -218,11 +218,12 @@ VS Code 設定在 `.vscode/mcp.json`：
 
 ### AI Client 切換與並用限制
 
-Revit 端的 WebSocket 服務一次只接受一條 MCP 連線：後連上的 MCP Server 會取代先前的連線。因此多個 AI Client 是「切換使用」而不是「同時並用」：
+Revit 端的 WebSocket 服務採「獨占鎖」機制：同一時間只有一個 AI Client 能保持連線。第二個嘗試連線的 Client 會被直接拒絕（HTTP 409），而不是取代掉原本的連線——第一個連線因此維持穩定。因此多個 AI Client 是「切換使用」而不是「同時並用」：
 
-1. 關閉目前使用的 AI Client（或停用其 MCP server）。
-2. 啟動另一個 AI Client，它的 MCP Server 連上 `localhost:8964` 後即接手。
-3. 若連線狀態異常，於 Revit ribbon 重啟 MCP 服務即可重置。
+1. 在 Revit ribbon 點擊 **「切換/釋放連線」** 按鈕，釋放目前的連線。
+2. 啟動或重新連線另一個 AI Client，它的 MCP Server 連上 `localhost:8964` 後即取得連線。
+3. **「MCP 設定」** 對話框會顯示目前是哪個 Client 持有連線（例如 `claude-code`、`claude-ai`）。
+4. 若連線狀態異常，可使用同一個 ribbon 按鈕，或於 Revit ribbon 重啟 MCP 服務即可重置。
 
 ## 啟動流程
 

--- a/docs/mcp2026-upgrade/ribbon-lock-impl-log.md
+++ b/docs/mcp2026-upgrade/ribbon-lock-impl-log.md
@@ -34,3 +34,23 @@ Confirmed no remaining references to the old `_webSocket` field (only one commen
 ### Round 1 — OPS verdict
 
 pass=true, R24=true, R26=true, issues=[]
+
+## Doc-align round 1 — Sonnet
+
+### Files Changed
+
+- `CLAUDE.md`
+- `README.md`
+- `README.zh-TW.md`
+
+### Summary
+
+Rewrote exclusive-lock documentation across three core files to reflect Design B (HTTP 409 rejection + manual switch button). Counts unchanged (167/75/50), Traditional Chinese text renders correctly with no mojibake. All three files updated, no code touched, no git commands run.
+
+**`CLAUDE.md`** — rewrote the `## Single-Connection Limitation` section (lines ~69-76): replaced "holds one MCP connection... newly connected replaces the previous" with the exclusive-lock/HTTP-409-reject model, added bullets for the "切換/釋放連線" ribbon button (release + let next client take the lock, anonymous-transport caveat), the "MCP 設定" dialog showing the connected client name (via `?client=` from MCP `clientInfo.name`), and `ServiceSettings.ExclusiveLock` (default `true`) as the escape hatch. Reset guidance now mentions the switch button alongside ribbon restart.
+
+**`README.md`** — rewrote the `### Switching Between AI Clients` section (lines ~219-225): describes the exclusive lock / clean HTTP 409 rejection (vs. the old "replaces" language), and rewrote the 3-step procedure to use the "切換/釋放連線" (Switch/Release Connection) ribbon button plus the "MCP 設定" dialog showing the connected client name.
+
+**`README.zh-TW.md`** — parallel edit to `### AI Client 切換與並用限制` (lines ~219-226) in Traditional Chinese, mirroring the same content: 獨占鎖 / HTTP 409 拒絕、切換/釋放連線 按鈕、MCP 設定 對話框顯示連線中的 Client。Verified UTF-8 renders cleanly, no mojibake.
+
+Count numbers (167 tools / 75 domain files / 50 skills) were left untouched in all three files — verified via grep. No code files or git commands were touched.

--- a/docs/mcp2026-upgrade/ribbon-lock-impl-log.md
+++ b/docs/mcp2026-upgrade/ribbon-lock-impl-log.md
@@ -1,0 +1,36 @@
+# Ribbon Exclusive-Lock Impl Log
+
+## Round 1 — Sonnet
+
+### Files Changed
+
+- `MCP/Core/SocketService.cs`
+- `MCP/Configuration/ServiceSettings.cs`
+- `MCP/Commands/MCPCommands.cs`
+- `MCP/Application.cs`
+
+### Summary
+
+Implemented Design B (exclusive lock + manual switch) across the four permitted files:
+
+**`MCP/Core/SocketService.cs`** (main correctness surface)
+- Replaced bare `_webSocket` with lock-guarded state: `_connectionLock`, `_activeSocket`, `_activeRemoteEndpoint`, `_connectedAtUtc`, `_lastRejectLogUtc`.
+- `IsConnected` now reads under lock; added `IsLocked_NoLock()` helper.
+- Rewrote `AcceptConnectionsAsync`: checks lock state before `AcceptWebSocketAsync`; rejects with HTTP 409 + `RateLimitedRejectLog` (30s throttle) when locked; otherwise accepts, sets the three lock-guarded fields inside the lock, logs `"[Socket] MCP Server 已連線 (locked) - "+endpoint`, and starts `ReceiveMessagesAsync` via `Task.Run`.
+- Added `SwitchConnection()` — clears state under lock, then calls `Abort()` (not `CloseAsync`, to avoid the "already one outstanding receive" race), returns `(released, previousRemote)`.
+- `ReceiveMessagesAsync` now has a `finally` that compare-and-clears (`ReferenceEquals`) the active socket and is the **single disposer** (`socket.Dispose()`); added a `WebSocketException` catch logged at Debug (not Error) for user-triggered aborts.
+- `Stop()` now acquires the socket under lock, calls `Abort()` only (no `CloseAsync`/`Dispose`), leaving disposal to the receive task's `finally`; the synchronous `_httpListener.Stop()/Close()` block is unchanged.
+- Added `GetStatusSnapshot()` returning `(locked, remote, sinceUtc)`.
+- `SendResponseAsync` renamed to use `_activeSocket`, unchanged logic/guard.
+
+**`MCP/Configuration/ServiceSettings.cs`** — added `public bool ExclusiveLock { get; set; } = true;`. `ConfigVersion`/`ValidateAndFix()` untouched.
+
+**`MCP/Commands/MCPCommands.cs`** — added `SwitchConnectionCommand : IExternalCommand` (same `[Transaction(TransactionMode.Manual)]` pattern, calls `SwitchConnection()`, shows TaskDialog feedback). `SettingsCommand.Execute` now appends a connection-status block (locked/idle, remote client, connect time) via `GetStatusSnapshot()` when the service is running.
+
+**`MCP/Application.cs`** — added the 4th ribbon button `"MCPSwitch"` ("切換/\n釋放連線") wired to `RevitMCP.Commands.SwitchConnectionCommand`, placed right after the settings button.
+
+Confirmed no remaining references to the old `_webSocket` field (only one comment mentions it descriptively), and that `MCP-Server/`, the wire protocol, and port 8964 were not touched. No `git` commands were run.
+
+### Round 1 — OPS verdict
+
+pass=true, R24=true, R26=true, issues=[]


### PR DESCRIPTION
## 背景 / Context

Revit add-in 的 WebSocket server(`localhost:8964`,單一連線)過去 accept loop **每個新連線都直接覆蓋 `_webSocket`**,回覆只送給最後連上的;加上 Node 端每 5s 自動重連,**Claude Code(CLI)與 Claude Desktop 一直互搶連線**(實測:CLI 在跑時 Desktop 一直逾時)。

## 變更 / Changes(Design B + 具名)

| 面向 | 內容 |
|---|---|
| **獨佔鎖** | `SocketService.cs`:`_connectionLock` 保護的連線狀態;已鎖時新連線在 `AcceptWebSocketAsync` **之前**回 **HTTP 409**(不再 clobber),拒絕 log 30s 限流。第一個連上者穩定持有,後來者乾淨被拒。 |
| **手動切換** | ribbon 新增 **「切換/釋放連線」** 鈕 → `SwitchConnection()` 用 **`Abort()`**(非 CloseAsync)釋放,下一個重連者取得鎖。 |
| **顯示佔用工具** | Node 把 MCP `clientInfo.name` 以 `?client=<name>` 帶給 add-in;「MCP 設定」顯示 **目前客戶端: `claude-code` / `claude-ai` (endpoint)**,匿名/舊 client fallback `unknown`。 |
| **開/關按鈕修正** | 改看 `IsRunning`(非 `IsConnected`,修正無 client 時再按誤判);跳 **🟢 已啟動 / 🔴 已關閉** 對話框。 |
| **逃生旗標** | `ServiceSettings.ExclusiveLock`(預設 `true`);關閉即回退舊 clobber 行為。無 `ConfigVersion` bump,舊 config 自動得安全預設。 |

## 執行緒正確性(自審 + Opus 逐條)
單一非-null 寫入者不變式;所有 `_activeSocket` 存取在 `lock` 內;`SwitchConnection`/`Stop` 只 `Abort()`;唯一 `Dispose()` 在 receive `finally` + `ReferenceEquals` compare-and-clear(single-disposer);`Stop()` 保留**同步** `_httpListener.Stop()+Close()`(port 釋放不變);`SendResponseAsync` 鎖內快照(消除 TOCTOU)。`ExternalEventManager`/單一 active socket 假設維持成立,故不動。

## 相容 / Fork 影響
Server 端(C#/Node)only;**不改 wire、不改 port 8964、不改 client 設定**。現有單 client 使用者無感(連線更穩)。文件(CLAUDE.md Single-Connection 段 + README ×2)已同步。計數 167/75/50 未變。

## 驗證 / Verification
- **build 全 5 版**:`Release.R22/R23/R24/R25/R26` 皆 **0 errors**(涵蓋 int/long ElementId 邊界);node `tsc` 0。
- `verify-qaqc.ps1 -SkipBuild -SkipDeploy` = **59 PASS / 0 FAIL / 0 WARN**。
- **Live-Revit(2024)已驗**:(a) A 鎖定 ✅;(b) 第二 client 收 **409、沒偷走** ✅;(c) 切換鈕交接 ✅;具名顯示 ✅;Desktop 成功連上 ✅。
- **Port/lifecycle**:`OnShutdown`/`ProcessExit`/`StartAsync` 的三層 port 釋放/自癒**未被本次改動觸及**;(e) 鎖定關閉→port 釋放、(f) 2024→2026 換版本不卡磚 —— 維護者 live 確認中。

## 延後
- **保證切到指定 client**(具名交接):目前切換為「先重連者得鎖」;若要指名交接需 client-id gating(完整 Design C)。

---
🤖 多代理編排(Sonnet 實作 / Opus 逐條執行緒審查 + R24/R26 build / Haiku 記錄 / Fable 統籌),Opus 親自逐行覆審 concurrency diff + 補 TOCTOU 加固。