### PR TITLE
feat(cad-block-placement): CAD 圖塊點位放置三工具 discover/preview/create（#113，PR #114 重開）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ These counts must be derived from source, not copied by memory.
 
 | Item | Current Count | Source of Truth |
 |---|---:|---|
-| Runtime MCP tools | 173 | `registerRevitTools()` from `MCP-Server/src/tools/index.ts` |
+| Runtime MCP tools | 176 | `registerRevitTools()` from `MCP-Server/src/tools/index.ts` |
 | Domain SOP files | 76 | `domain/*.md` except `domain/README.md`, plus `domain/references/*.md` |
 | Claude skills | 54 | `.claude/skills/*/SKILL.md` |
 

--- a/MCP-Server/src/tools/cad-block-placement-tools.ts
+++ b/MCP-Server/src/tools/cad-block-placement-tools.ts
@@ -1,0 +1,117 @@
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * CAD 圖塊插入點批次放置 Revit 點位族群（灑水頭/閥件等）。
+ *
+ * 對應 C# 端 handler: MCP/Core/CadBlockPlacementExecutor.cs
+ * 對應 CommandExecutor.cs cases: get_dwg_block_instances / preview_family_instances_from_dwg_blocks / create_family_instances_from_dwg_blocks
+ * 對應 domain SOP: domain/cad-block-point-placement.md
+ *
+ * v1 只支援 Linked DWG、僅 OneLevelBased（non-hosted、level-based、point-placement）FamilySymbol。
+ */
+export const cadBlockPlacementTools: Tool[] = [
+    {
+        name: "get_dwg_block_instances",
+        description:
+            "掃描目前 Revit 平面視圖中已連結（Linked，非 Imported）的 CAD DWG，" +
+            "列出可辨識的 Block（INSERT）名稱、每種數量、插入點與旋轉角範例。" +
+            "唯讀操作，不建立任何 Revit 元素。使用前請確認 DWG 已用「連結」方式匯入。",
+        inputSchema: {
+            type: "object",
+            properties: {
+                importInstanceUniqueId: {
+                    type: "string",
+                    description:
+                        "（選填）指定要掃描的 ImportInstance UniqueId；未指定時取視圖內第一個 Linked ImportInstance",
+                },
+            },
+        },
+    },
+    {
+        name: "preview_family_instances_from_dwg_blocks",
+        description:
+            "對指定 Block 的每個插入點做座標鏈健檢（Block insertion point → Block transform → " +
+            "ImportInstance TotalTransform），回傳每點狀態：ready / duplicate_existing / duplicate_in_batch / " +
+            "unsupported_family / untrustworthy_transform，並攤開完整座標鏈供核對。" +
+            "唯讀操作，不建立任何 Revit 元素。transform 不可信時只回傳警告，不做任何猜測性修正。" +
+            "familySymbolId 與 levelId 必須明確指定，本工具不自動選擇。",
+        inputSchema: {
+            type: "object",
+            properties: {
+                importInstanceUniqueId: {
+                    type: "string",
+                    description: "（選填）指定要掃描的 ImportInstance UniqueId，比照 get_dwg_block_instances",
+                },
+                blockName: {
+                    type: "string",
+                    description: "從 get_dwg_block_instances 回傳清單中選擇的 Block 名稱，只處理此名稱的插入點",
+                },
+                familySymbolId: {
+                    type: "string",
+                    description: "目標 FamilySymbol 的 ElementId（字串）。必須是 non-hosted、level-based、OneLevelBased 族群",
+                },
+                levelId: {
+                    type: "string",
+                    description: "目標 Level 的 ElementId（字串）。Level 必須已存在，本工具不自動建立",
+                },
+                offsetMm: {
+                    type: "number",
+                    default: 0,
+                    description: "相對於 levelId 對應樓層的垂直偏移，單位為 mm（不是 Revit 內部的 feet）",
+                },
+                duplicateToleranceMm: {
+                    type: "number",
+                    description: "（選填）重複判定容差，單位 mm；未指定時預設 10mm",
+                },
+            },
+            required: ["familySymbolId", "levelId"],
+        },
+    },
+    {
+        name: "create_family_instances_from_dwg_blocks",
+        description:
+            "以與 preview_family_instances_from_dwg_blocks 完全相同的參數重新掃描來源後建立 FamilyInstance——" +
+            "不信任任何先前呼叫的快取結果。主 Transaction + 逐筆 SubTransaction，單筆失敗不影響其他已成功項目。" +
+            "duplicate 項目預設會被阻擋，只有明確傳入 skipDuplicates=true 才會略過（不得由 AI 自行推定使用者已核准）。" +
+            "unsupported_family／untrustworthy_transform 一律不建立。回傳每筆結果（created/failed/skipped）與建立後" +
+            "獨立查詢驗證的 verifiedExists。此操作會修改 Revit 模型，無法自動復原，請先呼叫 preview 確認再執行。",
+        inputSchema: {
+            type: "object",
+            properties: {
+                importInstanceUniqueId: {
+                    type: "string",
+                    description: "（選填）比照 preview，必須與該次 preview 使用的值一致",
+                },
+                blockName: {
+                    type: "string",
+                    description: "比照 preview，必須與該次 preview 使用的值一致",
+                },
+                familySymbolId: {
+                    type: "string",
+                    description: "比照 preview，必須與該次 preview 使用的值一致",
+                },
+                levelId: {
+                    type: "string",
+                    description: "比照 preview，必須與該次 preview 使用的值一致",
+                },
+                offsetMm: {
+                    type: "number",
+                    default: 0,
+                    description: "比照 preview，必須與該次 preview 使用的值一致",
+                },
+                duplicateToleranceMm: {
+                    type: "number",
+                    description: "比照 preview，必須與該次 preview 使用的值一致",
+                },
+                skipDuplicates: {
+                    type: "boolean",
+                    default: false,
+                    description:
+                        "使用者明確核准後才可設為 true，用來略過 duplicate_existing／duplicate_in_batch 項目。" +
+                        "AI 不得在使用者未表達核准的情況下自行設定此參數為 true",
+                },
+            },
+            required: ["familySymbolId", "levelId"],
+        },
+    },
+];

--- a/MCP-Server/src/tools/index.ts
+++ b/MCP-Server/src/tools/index.ts
@@ -32,6 +32,7 @@ import { dimensionTypeTools } from "./dimension-type-tools.js";
 import { legendViewTools } from "./legend-view-tools.js";
 import { dwgColumnTools } from "./dwg-column-tools.js";
 import { dwgBeamTools } from "./dwg-beam-tools.js";
+import { cadBlockPlacementTools } from "./cad-block-placement-tools.js";
 import { cadLinkTools } from "./cad-link-tools.js";
 import { structureTools } from "./structure-tools.js";
 import { parallelSectionTools } from "./parallel-section-tools.js";
@@ -55,9 +56,9 @@ import { ifcStructuralSyncTools } from "./ifc-structural-sync-tools.js";
  * Profile 對照表：每個 profile 包含哪些模組
  */
 const PROFILE_MODULES: Record<string, Tool[][]> = {
-    full: [baseTools, wallTools, roomTools, corridorAnalysisTools, visualizationTools, scheduleTools, mepTools, curtainWallTools, smokeExhaustTools, smokeDetectorTools, parallelSectionTools, STAIR_COMPLIANCE_TOOLS, sheetTools, detailComponentTools, dimensionTools, dependentViewTools, dwgColumnTools, dwgBeamTools, cadLinkTools, clashTools, doorWindowLegendTools, listSeedsTools, dimensionTypeTools, legendViewTools, structureTools, gradingTools, detailCopyTools, scopeBoxTools, viewCropBoxTools, textNoteTools, titleblockAlignTools, viewCreationTools, viewportPositionTools, crossDocumentTools, legendTools, scaffoldTools, viewDuplicateTools, fillRegionTools, ifcStructuralSyncTools],
+    full: [baseTools, wallTools, roomTools, corridorAnalysisTools, visualizationTools, scheduleTools, mepTools, curtainWallTools, smokeExhaustTools, smokeDetectorTools, parallelSectionTools, STAIR_COMPLIANCE_TOOLS, sheetTools, detailComponentTools, dimensionTools, dependentViewTools, dwgColumnTools, dwgBeamTools, cadBlockPlacementTools, cadLinkTools, clashTools, doorWindowLegendTools, listSeedsTools, dimensionTypeTools, legendViewTools, structureTools, gradingTools, detailCopyTools, scopeBoxTools, viewCropBoxTools, textNoteTools, titleblockAlignTools, viewCreationTools, viewportPositionTools, crossDocumentTools, legendTools, scaffoldTools, viewDuplicateTools, fillRegionTools, ifcStructuralSyncTools],
     architect: [baseTools, wallTools, roomTools, corridorAnalysisTools, visualizationTools, scheduleTools, curtainWallTools, parallelSectionTools, STAIR_COMPLIANCE_TOOLS, sheetTools, detailComponentTools, dimensionTools, dependentViewTools, dwgColumnTools, dwgBeamTools, cadLinkTools, doorWindowLegendTools, listSeedsTools, dimensionTypeTools, legendViewTools, gradingTools, detailCopyTools, scopeBoxTools, viewCropBoxTools, textNoteTools, titleblockAlignTools, viewCreationTools, viewportPositionTools, crossDocumentTools, legendTools, scaffoldTools, viewDuplicateTools, fillRegionTools],
-    mep: [baseTools, mepTools, scheduleTools, visualizationTools, smokeExhaustTools, smokeDetectorTools, parallelSectionTools, clashTools],
+    mep: [baseTools, mepTools, scheduleTools, visualizationTools, smokeExhaustTools, smokeDetectorTools, parallelSectionTools, cadBlockPlacementTools, clashTools],
     structural: [baseTools, wallTools, visualizationTools, dwgColumnTools, dwgBeamTools, clashTools, structureTools, gradingTools, ifcStructuralSyncTools],
     "fire-safety": [baseTools, roomTools, corridorAnalysisTools, visualizationTools, smokeExhaustTools, smokeDetectorTools],
 };

--- a/MCP/Core/CadBlockPlacementExecutor.cs
+++ b/MCP/Core/CadBlockPlacementExecutor.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using Newtonsoft.Json.Linq;
+
+namespace RevitMCP
+{
+    /// <summary>
+    /// CAD 圖塊（Block/INSERT）插入點批次放置 Revit 點位式 FamilyInstance。
+    /// 對應 domain/cad-block-point-placement.md；來源 issue #100 / #113。
+    /// 對應 CommandExecutor.cs cases:
+    ///   get_dwg_block_instances / preview_family_instances_from_dwg_blocks / create_family_instances_from_dwg_blocks
+    /// </summary>
+    internal static class CadBlockPlacementExecutor
+    {
+        const double FtMm = 304.8;
+        const double MmFt = 1.0 / 304.8;
+        const double DefaultDuplicateToleranceMm = 10.0;
+
+        /// <summary>掃描結果的單一 Block 插入點候選。</summary>
+        internal sealed class BlockCandidate
+        {
+            public string Identity;
+            public string DisplayName;
+            public XYZ InsertionPoint;
+            public Transform BlockTransform;
+            public Transform TotalTransform;
+            public XYZ ResolvedPoint;
+            public double RotationRadians;
+        }
+
+        static string BuildIdentity(string importInstanceUniqueId, int pathIndex, string blockName)
+            => importInstanceUniqueId + "|" + pathIndex + "|" + blockName;
+
+        /// <summary>
+        /// 找到目前平面視圖中，UniqueId 相符（或未指定時取第一個）的 Linked ImportInstance。
+        /// v1 只支援 Linked DWG，Imported 一律拒絕（domain doc §1 前置條件 5）。
+        /// </summary>
+        static ImportInstance FindLinkedImportInstance(Document doc, ViewPlan vp, string importInstanceUniqueId)
+        {
+            var candidates = new FilteredElementCollector(doc, vp.Id)
+                .OfClass(typeof(ImportInstance))
+                .Cast<ImportInstance>()
+                .ToList();
+
+            ImportInstance picked = string.IsNullOrEmpty(importInstanceUniqueId)
+                ? candidates.FirstOrDefault()
+                : candidates.FirstOrDefault(i => i.UniqueId == importInstanceUniqueId);
+
+            if (picked == null)
+                throw new InvalidOperationException(
+                    string.IsNullOrEmpty(importInstanceUniqueId)
+                        ? "目前平面視圖找不到任何 CAD ImportInstance，請確認已連結 DWG"
+                        : "找不到 UniqueId 為「" + importInstanceUniqueId + "」的 ImportInstance");
+
+            bool isLinked = doc.GetElement(picked.GetTypeId()) is CADLinkType && picked.IsLinked;
+            if (!isLinked)
+                throw new InvalidOperationException(
+                    "v1 只支援 Linked DWG，偵測到的 ImportInstance 是 Imported（非 Linked），請改用連結方式重新匯入");
+
+            return picked;
+        }
+
+        /// <summary>
+        /// 遍歷 ImportInstance 幾何樹，收集每個 Block（INSERT，GeometryInstance）的插入點與 transform。
+        /// 深度優先、depth 上限 5（比照 DwgColumnExecutor.CollectInstancePoints 慣例）。
+        /// </summary>
+        static List<BlockCandidate> CollectBlockCandidates(ImportInstance cad, ViewPlan vp)
+        {
+            var result = new List<BlockCandidate>();
+            var opt = new Options { ComputeReferences = true, IncludeNonVisibleObjects = true, View = vp };
+            var geomElem = cad.get_Geometry(opt);
+            if (geomElem == null) return result;
+
+            var totalTransform = cad.GetTotalTransform();
+            int pathIndex = 0;
+            WalkGeometry(cad.Document, geomElem, cad.UniqueId, totalTransform, ref pathIndex, result, 0);
+            return result;
+        }
+
+        static void WalkGeometry(
+            Document doc,
+            GeometryElement geomElem,
+            string importInstanceUniqueId,
+            Transform totalTransform,
+            ref int pathIndex,
+            List<BlockCandidate> result,
+            int depth)
+        {
+            if (depth > 5) return;
+
+            foreach (var obj in geomElem)
+            {
+                var gi = obj as GeometryInstance;
+                if (gi == null) continue;
+
+                string blockName = TryGetBlockDisplayName(doc, gi, pathIndex);
+                var candidate = new BlockCandidate
+                {
+                    Identity = BuildIdentity(importInstanceUniqueId, pathIndex, blockName),
+                    DisplayName = blockName,
+                    InsertionPoint = gi.Transform.Origin,
+                    BlockTransform = gi.Transform,
+                    TotalTransform = totalTransform,
+                    RotationRadians = Math.Atan2(gi.Transform.BasisX.Y, gi.Transform.BasisX.X),
+                };
+                candidate.ResolvedPoint = totalTransform.OfPoint(gi.Transform.Origin);
+                result.Add(candidate);
+                pathIndex++;
+
+                var nested = gi.GetInstanceGeometry();
+                if (nested != null)
+                    WalkGeometry(doc, nested, importInstanceUniqueId, totalTransform, ref pathIndex, result, depth + 1);
+            }
+        }
+
+        /// <summary>
+        /// KNOWN UNCERTAINTY（見 plan「Known Revit-API Uncertainties」#1）：
+        /// GeometryInstance 不保證暴露 CAD block 定義名稱字串（issue #100 的 A$C87ebd845 式
+        /// 名稱來自 AutoCAD 自動命名）。此處以 GraphicsStyleCategory 名稱（比照
+        /// DwgColumnExecutor 的圖層名解析慣例）作 best-effort 顯示名，取不到時
+        /// fallback 為合成序號標籤；呼叫端從 nameSource 欄位得知來源。
+        /// 需以真實連結 DWG 實測是否能取得更精確的 block 名稱來源。
+        /// </summary>
+        static string TryGetBlockDisplayName(Document doc, GeometryInstance gi, int pathIndex)
+        {
+            try
+            {
+                if (gi.GraphicsStyleId != null && gi.GraphicsStyleId != ElementId.InvalidElementId)
+                {
+                    var gs = doc.GetElement(gi.GraphicsStyleId) as GraphicsStyle;
+                    var name = gs?.GraphicsStyleCategory?.Name;
+                    if (!string.IsNullOrEmpty(name)) return name;
+                }
+            }
+            catch { }
+            return "Block#" + pathIndex;
+        }
+
+        public static object GetDwgBlockInstances(Document doc, JObject p)
+        {
+            var vp = doc.ActiveView as ViewPlan;
+            if (vp == null)
+                throw new InvalidOperationException("請先切換到平面視圖再執行本工具");
+
+            string importInstanceUniqueId = p == null ? null : (string)p["importInstanceUniqueId"];
+            var cad = FindLinkedImportInstance(doc, vp, importInstanceUniqueId);
+            var all = CollectBlockCandidates(cad, vp);
+
+            var grouped = all
+                .GroupBy(c => c.DisplayName)
+                .Select(g => new JObject
+                {
+                    ["blockName"] = g.Key,
+                    ["nameSource"] = g.Key.StartsWith("Block#") ? "fallback" : "graphics-style",
+                    ["count"] = g.Count(),
+                    ["sample"] = new JArray(g.Take(3).Select(c => new JObject
+                    {
+                        ["identity"] = c.Identity,
+                        ["insertionPointMm"] = PointToMmJson(c.InsertionPoint),
+                        ["rotationDegrees"] = Math.Round(c.RotationRadians * 180.0 / Math.PI, 2),
+                    })),
+                })
+                .ToList();
+
+            return new JObject
+            {
+                ["importInstanceUniqueId"] = cad.UniqueId,
+                ["totalPoints"] = all.Count,
+                ["blockTypes"] = grouped.Count,
+                ["blocks"] = new JArray(grouped),
+            };
+        }
+
+        static JObject PointToMmJson(XYZ pt) => new JObject
+        {
+            ["x"] = Math.Round(pt.X * FtMm, 1),
+            ["y"] = Math.Round(pt.Y * FtMm, 1),
+            ["z"] = Math.Round(pt.Z * FtMm, 1),
+        };
+    }
+}

--- a/MCP/Core/CadBlockPlacementExecutor.cs
+++ b/MCP/Core/CadBlockPlacementExecutor.cs
@@ -3,6 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using Autodesk.Revit.DB;
 using Newtonsoft.Json.Linq;
+using RevitMCP.Core;
+
+#if REVIT2025_OR_GREATER
+using IdType = System.Int64;
+#else
+using IdType = System.Int32;
+#endif
 
 namespace RevitMCP
 {
@@ -179,5 +186,211 @@ namespace RevitMCP
             ["y"] = Math.Round(pt.Y * FtMm, 1),
             ["z"] = Math.Round(pt.Z * FtMm, 1),
         };
+
+        /// <summary>
+        /// Transform 可信度判定（domain doc §3，2026-08-05 對齊）：
+        /// finite、可逆（det != 0）、conformal 等比例（三軸基向量長度相等，5% 容差）。
+        /// 純鏡射（det &lt; 0 但仍等比例）允許但標記警告；非等比例一律不可信。
+        /// </summary>
+        static bool CheckTransformTrust(Transform t, out bool isMirrored, out string reason)
+        {
+            isMirrored = false;
+            reason = "";
+
+            double[] components =
+            {
+                t.BasisX.X, t.BasisX.Y, t.BasisX.Z,
+                t.BasisY.X, t.BasisY.Y, t.BasisY.Z,
+                t.BasisZ.X, t.BasisZ.Y, t.BasisZ.Z,
+                t.Origin.X, t.Origin.Y, t.Origin.Z,
+            };
+            if (components.Any(v => double.IsNaN(v) || double.IsInfinity(v)))
+            {
+                reason = "transform 含 NaN/Infinity 分量";
+                return false;
+            }
+
+            double det = t.Determinant;
+            if (Math.Abs(det) < 1e-9)
+            {
+                reason = "transform 不可逆（determinant 接近 0）";
+                return false;
+            }
+
+            double lenX = t.BasisX.GetLength();
+            double lenY = t.BasisY.GetLength();
+            double lenZ = t.BasisZ.GetLength();
+            double maxLen = Math.Max(lenX, Math.Max(lenY, lenZ));
+            double minLen = Math.Min(lenX, Math.Min(lenY, lenZ));
+            bool conformal = maxLen > 1e-9 && (maxLen - minLen) / maxLen <= 0.05;
+
+            if (!conformal)
+            {
+                reason = string.Format("非等比例縮放（軸長 {0:F4}/{1:F4}/{2:F4}），無法信任", lenX, lenY, lenZ);
+                return false;
+            }
+
+            isMirrored = det < 0;
+            if (isMirrored) reason = "純鏡射，允許但已標記警告";
+            return true;
+        }
+
+        /// <summary>
+        /// discover + 座標鏈健檢 + duplicate/unsupported_family 判定，preview 與 create 共用。
+        /// 不開啟 Transaction；create 呼叫本方法取得權威結果後才寫入模型
+        /// （鐵則：create 不信任 preview 快取，以相同參數重新掃描）。
+        /// </summary>
+        static List<JObject> BuildPlacementPlan(Document doc, ViewPlan vp, JObject p, out JObject summary)
+        {
+            string importInstanceUniqueId = (string)p["importInstanceUniqueId"];
+            string blockNameFilter = (string)p["blockName"];
+            string familySymbolIdRaw = (string)p["familySymbolId"];
+            string levelIdRaw = (string)p["levelId"];
+            double offsetMm = p["offsetMm"] != null ? p["offsetMm"].Value<double>() : 0.0;
+            bool toleranceProvided = p["duplicateToleranceMm"] != null;
+            double toleranceMm = toleranceProvided
+                ? p["duplicateToleranceMm"].Value<double>()
+                : DefaultDuplicateToleranceMm;
+
+            if (string.IsNullOrEmpty(familySymbolIdRaw))
+                throw new ArgumentException("familySymbolId 為必填，本工具不自動選擇族群");
+            if (string.IsNullOrEmpty(levelIdRaw))
+                throw new ArgumentException("levelId 為必填，本工具不自動選擇樓層");
+
+            IdType familySymbolIdVal, levelIdVal;
+            if (!IdType.TryParse(familySymbolIdRaw, out familySymbolIdVal))
+                throw new ArgumentException("familySymbolId 必須是數字字串，收到：" + familySymbolIdRaw);
+            if (!IdType.TryParse(levelIdRaw, out levelIdVal))
+                throw new ArgumentException("levelId 必須是數字字串，收到：" + levelIdRaw);
+
+            var symbol = doc.GetElement(new ElementId(familySymbolIdVal)) as FamilySymbol;
+            if (symbol == null)
+                throw new ArgumentException("找不到 familySymbolId=" + familySymbolIdRaw + " 對應的 FamilySymbol");
+
+            var level = doc.GetElement(new ElementId(levelIdVal)) as Level;
+            if (level == null)
+                throw new ArgumentException("找不到 levelId=" + levelIdRaw + " 對應的 Level（v1 不自動建立樓層）");
+
+            bool familySupported = symbol.Family.FamilyPlacementType == FamilyPlacementType.OneLevelBased;
+
+            var cad = FindLinkedImportInstance(doc, vp, importInstanceUniqueId);
+            var all = CollectBlockCandidates(cad, vp);
+            if (!string.IsNullOrEmpty(blockNameFilter))
+                all = all.Where(c => c.DisplayName == blockNameFilter).ToList();
+
+            double offsetFt = offsetMm * MmFt;
+            double toleranceFt = toleranceMm * MmFt;
+
+            var existingInstances = new FilteredElementCollector(doc)
+                .OfClass(typeof(FamilyInstance))
+                .Cast<FamilyInstance>()
+                .Where(fi => fi.LevelId == level.Id)
+                .Select(fi => new { fi.Id, Point = (fi.Location as LocationPoint)?.Point })
+                .Where(x => x.Point != null)
+                .ToList();
+
+            var plan = new List<JObject>();
+            var seenInBatch = new List<KeyValuePair<string, XYZ>>();
+            int ready = 0, duplicate = 0, unsupported = 0, untrustworthy = 0;
+
+            foreach (var c in all)
+            {
+                var finalPoint = new XYZ(c.ResolvedPoint.X, c.ResolvedPoint.Y, level.Elevation + offsetFt);
+                bool mirrored;
+                string trustReason;
+                bool trustworthy = CheckTransformTrust(c.TotalTransform.Multiply(c.BlockTransform), out mirrored, out trustReason);
+
+                string status;
+                string statusReason = "";
+                ElementId duplicateOf = null;
+
+                if (!familySupported)
+                {
+                    status = "unsupported_family";
+                    statusReason = "familySymbol 的 FamilyPlacementType 為 " + symbol.Family.FamilyPlacementType
+                        + "，v1 僅支援 OneLevelBased";
+                    unsupported++;
+                }
+                else if (!trustworthy)
+                {
+                    status = "untrustworthy_transform";
+                    statusReason = trustReason;
+                    untrustworthy++;
+                }
+                else
+                {
+                    var existingDup = existingInstances.FirstOrDefault(x => x.Point.DistanceTo(finalPoint) < toleranceFt);
+                    var batchDupIdx = seenInBatch.FindIndex(x => x.Value.DistanceTo(finalPoint) < toleranceFt);
+
+                    if (existingDup != null)
+                    {
+                        status = "duplicate_existing";
+                        statusReason = "與既有 FamilyInstance ElementId=" + existingDup.Id.GetIdValue()
+                            + " 距離 <" + toleranceMm + "mm";
+                        duplicateOf = existingDup.Id;
+                        duplicate++;
+                    }
+                    else if (batchDupIdx >= 0)
+                    {
+                        status = "duplicate_in_batch";
+                        statusReason = "與本次掃描內候選 identity=" + seenInBatch[batchDupIdx].Key
+                            + " 距離 <" + toleranceMm + "mm";
+                        duplicate++;
+                    }
+                    else
+                    {
+                        status = "ready";
+                        ready++;
+                        seenInBatch.Add(new KeyValuePair<string, XYZ>(c.Identity, finalPoint));
+                    }
+                }
+
+                plan.Add(new JObject
+                {
+                    ["identity"] = c.Identity,
+                    ["blockName"] = c.DisplayName,
+                    ["status"] = status,
+                    ["statusReason"] = statusReason,
+                    ["mirrored"] = mirrored,
+                    ["duplicateOfElementId"] = duplicateOf == null ? null : (long?)duplicateOf.GetIdValue(),
+                    ["coordinateChain"] = new JObject
+                    {
+                        ["blockInsertionPointMm"] = PointToMmJson(c.InsertionPoint),
+                        ["blockTransformOriginMm"] = PointToMmJson(c.BlockTransform.Origin),
+                        ["totalTransformOriginMm"] = PointToMmJson(c.TotalTransform.Origin),
+                        ["resolvedPointMm"] = PointToMmJson(finalPoint),
+                    },
+                });
+            }
+
+            summary = new JObject
+            {
+                ["totalCandidates"] = all.Count,
+                ["ready"] = ready,
+                ["duplicate"] = duplicate,
+                ["unsupportedFamily"] = unsupported,
+                ["untrustworthyTransform"] = untrustworthy,
+                ["duplicateToleranceMm"] = toleranceMm,
+                ["duplicateToleranceSource"] = toleranceProvided ? "user-provided" : "default",
+                ["familySymbolId"] = symbol.Id.GetIdValue(),
+                ["levelId"] = level.Id.GetIdValue(),
+                ["offsetMm"] = offsetMm,
+            };
+            return plan;
+        }
+
+        public static object PreviewFamilyInstancesFromDwgBlocks(Document doc, JObject p)
+        {
+            var vp = doc.ActiveView as ViewPlan;
+            if (vp == null)
+                throw new InvalidOperationException("請先切換到平面視圖再執行本工具");
+            if (p == null)
+                throw new ArgumentException("缺少參數：familySymbolId 與 levelId 為必填");
+
+            JObject summary;
+            var plan = BuildPlacementPlan(doc, vp, p, out summary);
+            summary["candidates"] = new JArray(plan);
+            return summary;
+        }
     }
 }

--- a/MCP/Core/CadBlockPlacementExecutor.cs
+++ b/MCP/Core/CadBlockPlacementExecutor.cs
@@ -392,5 +392,125 @@ namespace RevitMCP
             summary["candidates"] = new JArray(plan);
             return summary;
         }
+
+        public static object CreateFamilyInstancesFromDwgBlocks(Document doc, JObject p)
+        {
+            var vp = doc.ActiveView as ViewPlan;
+            if (vp == null)
+                throw new InvalidOperationException("請先切換到平面視圖再執行本工具");
+            if (p == null)
+                throw new ArgumentException("缺少參數：familySymbolId 與 levelId 為必填");
+
+            bool skipDuplicates = p["skipDuplicates"] != null && p["skipDuplicates"].Value<bool>();
+
+            // 鐵則：不信任呼叫端可能挾帶的舊 preview 結果，以相同參數重新掃描一次。
+            JObject summary;
+            var plan = BuildPlacementPlan(doc, vp, p, out summary);
+
+            IdType familySymbolIdVal = IdType.Parse((string)p["familySymbolId"]);
+            var symbol = (FamilySymbol)doc.GetElement(new ElementId(familySymbolIdVal));
+            IdType levelIdVal = IdType.Parse((string)p["levelId"]);
+            var level = (Level)doc.GetElement(new ElementId(levelIdVal));
+
+            var perItemResults = new JArray();
+            int created = 0, failed = 0, skipped = 0;
+
+            using (var tx = TransactionHelper.Begin(doc, "從 CAD 圖塊建立點位族群"))
+            {
+                tx.Start();
+
+                if (!symbol.IsActive)
+                {
+                    symbol.Activate();
+                    doc.Regenerate();
+                }
+
+                foreach (var candidate in plan)
+                {
+                    string status = (string)candidate["status"];
+                    string identity = (string)candidate["identity"];
+                    bool isDuplicate = status == "duplicate_existing" || status == "duplicate_in_batch";
+
+                    if (status != "ready")
+                    {
+                        // unsupported_family / untrustworthy_transform 一律不建立；
+                        // duplicate 只有在呼叫端明確傳入 skipDuplicates=true 時視為「已核准略過」，
+                        // 否則視為阻擋（domain doc §4.5：核准不得由 agent 自行推定）。
+                        skipped++;
+                        perItemResults.Add(new JObject
+                        {
+                            ["identity"] = identity,
+                            ["outcome"] = isDuplicate
+                                ? (skipDuplicates ? "skipped_duplicate_approved" : "blocked_duplicate_not_approved")
+                                : "blocked",
+                            ["status"] = status,
+                            ["statusReason"] = candidate["statusReason"],
+                        });
+                        continue;
+                    }
+
+                    using (var sub = new SubTransaction(doc))
+                    {
+                        sub.Start();
+                        try
+                        {
+                            var chain = (JObject)candidate["coordinateChain"];
+                            var resolvedMm = (JObject)chain["resolvedPointMm"];
+                            var point = new XYZ(
+                                resolvedMm.Value<double>("x") * MmFt,
+                                resolvedMm.Value<double>("y") * MmFt,
+                                resolvedMm.Value<double>("z") * MmFt);
+
+                            // KNOWN UNCERTAINTY（見 plan「Known Revit-API Uncertainties」#2）：
+                            // OneLevelBased 族群以含 offset 的 Z 傳入 NewFamilyInstance，
+                            // 依 Revit 自身的 level-instance offset 記帳；Offset 參數實際落值
+                            // 需真機放置後 read-back 驗證。
+                            var instance = doc.Create.NewFamilyInstance(
+                                point, symbol, level,
+                                Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
+
+                            sub.Commit();
+                            created++;
+                            perItemResults.Add(new JObject
+                            {
+                                ["identity"] = identity,
+                                ["outcome"] = "created",
+                                ["elementId"] = instance.Id.GetIdValue(),
+                            });
+                        }
+                        catch (Exception ex)
+                        {
+                            sub.RollBack();
+                            failed++;
+                            perItemResults.Add(new JObject
+                            {
+                                ["identity"] = identity,
+                                ["outcome"] = "failed",
+                                ["error"] = ex.Message,
+                            });
+                        }
+                    }
+                }
+
+                tx.Commit();
+            }
+
+            // 建立後逐一獨立查詢驗證存在（同步、確定性，不依賴 Idling 事件輪詢）。
+            foreach (var item in perItemResults.OfType<JObject>().Where(i => (string)i["outcome"] == "created"))
+            {
+                var id = new ElementId((IdType)item["elementId"].Value<long>());
+                item["verifiedExists"] = doc.GetElement(id) != null;
+            }
+
+            return new JObject
+            {
+                ["created"] = created,
+                ["failed"] = failed,
+                ["skipped"] = skipped,
+                ["duplicateToleranceMm"] = summary["duplicateToleranceMm"],
+                ["duplicateToleranceSource"] = summary["duplicateToleranceSource"],
+                ["items"] = perItemResults,
+            };
+        }
     }
 }

--- a/MCP/Core/CommandExecutor.cs
+++ b/MCP/Core/CommandExecutor.cs
@@ -582,6 +582,17 @@ namespace RevitMCP.Core
                         result = DwgColumnExecutor.CreateColumnsFromDwg(_uiApp.ActiveUIDocument.Document, parameters);
                         break;
 
+                    // === CAD 圖塊點位放置模組（Block/INSERT → FamilyInstance，issue #100/#113）===
+                    case "get_dwg_block_instances":
+                        result = CadBlockPlacementExecutor.GetDwgBlockInstances(_uiApp.ActiveUIDocument.Document, parameters);
+                        break;
+                    case "preview_family_instances_from_dwg_blocks":
+                        result = CadBlockPlacementExecutor.PreviewFamilyInstancesFromDwgBlocks(_uiApp.ActiveUIDocument.Document, parameters);
+                        break;
+                    case "create_family_instances_from_dwg_blocks":
+                        result = CadBlockPlacementExecutor.CreateFamilyInstancesFromDwgBlocks(_uiApp.ActiveUIDocument.Document, parameters);
+                        break;
+
                     // === CAD 連結模組 ===
                     case "link_cad_to_view":
                         result = CadLinkExecutor.LinkCadToView(_uiApp.ActiveUIDocument.Document, parameters);

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Revit MCP lets AI clients call Autodesk Revit tools through the Model Context Pr
 
 ## What is this?
 
-Talk to Revit in plain language. Ask your AI client to *"dimension every wall on this view"* or *"check the curtain-wall elevations"*, and Revit does it — through **173 MCP tools** backed by **76 professional BIM SOPs** (building code, quantity take-off, compliance checks).
+Talk to Revit in plain language. Ask your AI client to *"dimension every wall on this view"* or *"check the curtain-wall elevations"*, and Revit does it — through **176 MCP tools** backed by **76 professional BIM SOPs** (building code, quantity take-off, compliance checks).
 
 **Who it's for:** BIM engineers and architects who use Revit and want AI-assisted, standards-based workflows. You'll need Revit (2022–2026) on Windows and to be comfortable installing an add-in.
 
@@ -33,7 +33,7 @@ Questions or want to show what you built? → **[Discussions](https://github.com
 
 | Item | Count | Source |
 |---|---:|---|
-| Runtime MCP tools | 173 | `registerRevitTools()` in `MCP-Server/src/tools/index.ts` |
+| Runtime MCP tools | 176 | `registerRevitTools()` in `MCP-Server/src/tools/index.ts` |
 | Domain SOP files | 76 | `domain/*.md` except `README.md`, plus `domain/references/*.md` |
 | Claude skills | 54 | `.claude/skills/*/SKILL.md` |
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -14,7 +14,7 @@ Revit MCP 透過 Model Context Protocol (MCP) 讓 AI Client 呼叫 Revit 工具�
 
 ## 這是什麼？
 
-用講人話的方式操作 Revit。跟你的 AI Client 說「幫這個視圖的牆全部標尺寸」或「檢查帷幕牆立面」，Revit 就會做——背後是 **173 個 MCP 工具**，由 **76 份專業 BIM SOP**（建築法規、數量計算、法規檢核）支撐。
+用講人話的方式操作 Revit。跟你的 AI Client 說「幫這個視圖的牆全部標尺寸」或「檢查帷幕牆立面」，Revit 就會做——背後是 **176 個 MCP 工具**，由 **76 份專業 BIM SOP**（建築法規、數量計算、法規檢核）支撐。
 
 **給誰用：** 使用 Revit、想要 AI 輔助且符合規範的 BIM 工程師與建築師。你需要 Windows 上的 Revit（2022–2026），並願意安裝一個 add-in。
 
@@ -33,7 +33,7 @@ Revit MCP 透過 Model Context Protocol (MCP) 讓 AI Client 呼叫 Revit 工具�
 
 | 項目 | 數量 | 來源 |
 |---|---:|---|
-| Runtime MCP tools | 173 | `MCP-Server/src/tools/index.ts` 的 `registerRevitTools()` |
+| Runtime MCP tools | 176 | `MCP-Server/src/tools/index.ts` 的 `registerRevitTools()` |
 | Domain SOP files | 76 | `domain/*.md` 扣除 `README.md`，加上 `domain/references/*.md` |
 | Claude skills | 54 | `.claude/skills/*/SKILL.md` |
 

--- a/docs/BIM_MCP/reference/architecture-v2.html
+++ b/docs/BIM_MCP/reference/architecture-v2.html
@@ -31,7 +31,7 @@
 <header class="bim-hero">
   <div class="bim-hero-eyebrow">ARCHITECTURE V2 <span class="accent">3 層</span></div>
   <h1 class="bim-hero-title"><span class="accent">Skill / CLAUDE.md / Domain</span><br>三層模組架構</h1>
-  <p class="bim-hero-sub">REVIT_MCP 的核心架構：把 9 個系統、76 個 Domain、173 個工具按職責分到三層。Skill 管「何時觸發」、CLAUDE.md 管「跨 AI Client 橋接」、Domain 管「不可協商的知識」。本頁同時澄清「MCP ≠ Skill」的常見誤解。</p>
+  <p class="bim-hero-sub">REVIT_MCP 的核心架構：把 9 個系統、76 個 Domain、176 個工具按職責分到三層。Skill 管「何時觸發」、CLAUDE.md 管「跨 AI Client 橋接」、Domain 管「不可協商的知識」。本頁同時澄清「MCP ≠ Skill」的常見誤解。</p>
 </header>
 
 <!-- ============================================ -->
@@ -97,7 +97,7 @@
     <div class="how-tech-label">WHY</div>
     <div class="how-tech-content">社群常爭論「Skill 殺死 MCP」——這是把<strong>抽象層級</strong>搞混的結果。MCP 解決「<strong>AI 怎麼動 Revit</strong>」（基礎能力），Skill 解決「<strong>AI 該照什麼順序動 Revit</strong>」（編排知識）。兩件根本不同層級的事，沒有取代關係。</div>
     <div class="how-tech-label">HOW</div>
-    <div class="how-tech-content">本專案明確分層——MCP server 提供 173 個原子工具（純能力），Skill 編排工具呼叫順序（純知識）。一個 MCP 工具被多個 Skill 引用，一個 Skill 引用多個 MCP 工具——<strong>多對多關係</strong>，互不替代。</div>
+    <div class="how-tech-content">本專案明確分層——MCP server 提供 176 個原子工具（純能力），Skill 編排工具呼叫順序（純知識）。一個 MCP 工具被多個 Skill 引用，一個 Skill 引用多個 MCP 工具——<strong>多對多關係</strong>，互不替代。</div>
     <div class="how-tech-label">TECHNIQUE</div>
     <div class="how-tech-content technique">Layered Capability Architecture · MCP as Runtime Bridge · Skill as Workflow Choreographer · M:N Tool-Skill Composition</div>
   </div>
@@ -248,7 +248,7 @@ CommandExecutor → Revit API</code></pre>
 
   <div class="how-tech">
     <div class="how-tech-label">WHY</div>
-    <div class="how-tech-content">為什麼不直接 AI Client ↔ Revit API？因為<strong>Revit API 太底層</strong>——LLM 要傳 ElementId、Transaction、ViewSet 這些原生型別，每次都得編 boilerplate。MCP Server 中間層把這些封裝成 173 個語意化工具（<code>check_smoke_exhaust_windows</code> 比 <code>FilteredElementCollector.OfCategory(...)</code> 友善 100 倍）。</div>
+    <div class="how-tech-content">為什麼不直接 AI Client ↔ Revit API？因為<strong>Revit API 太底層</strong>——LLM 要傳 ElementId、Transaction、ViewSet 這些原生型別，每次都得編 boilerplate。MCP Server 中間層把這些封裝成 176 個語意化工具（<code>check_smoke_exhaust_windows</code> 比 <code>FilteredElementCollector.OfCategory(...)</code> 友善 100 倍）。</div>
     <div class="how-tech-label">HOW</div>
     <div class="how-tech-content">AI Client（stdio）→ MCP Server（Node.js TypeScript）→ WebSocket（port 8964）→ Revit Add-in（C# .NET）→ Revit API。每層做<strong>協議翻譯 + UI 執行緒守門</strong>。port 8964 由 Add-in 啟動（HttpListener），MCP Server 連入。</div>
     <div class="how-tech-label">TECHNIQUE</div>
@@ -300,9 +300,9 @@ CommandExecutor → Revit API</code></pre>
       </tr>
       <tr>
         <td>MCP Tools</td>
-        <td>共用 173 個工具</td>
-        <td>共用 173 個工具</td>
-        <td>共用 173 個工具</td>
+        <td>共用 176 個工具</td>
+        <td>共用 176 個工具</td>
+        <td>共用 176 個工具</td>
       </tr>
       <tr>
         <td>Event Log</td>

--- a/docs/BIM_MCP/reference/domain-index.html
+++ b/docs/BIM_MCP/reference/domain-index.html
@@ -74,7 +74,7 @@
 <header class="bim-hero">
   <div class="bim-hero-eyebrow">DOMAIN INDEX <span class="accent">76 個 SOP / 5 分類</span></div>
   <h1 class="bim-hero-title">Domain · <span class="accent">知識層</span><br>方法寫一次，多個 Skill 共用</h1>
-  <p class="bim-hero-sub">Domain 是<strong>知識本身</strong>——法規條文、SOP、公式、例外。Skill 是<strong>編排</strong>（54 個）。Tool 是<strong>原子執行</strong>（173 個）。<strong>知識不應該重複在每個 Skill 裡</strong>——這是本專案核心架構原則。本頁列 76 個 <code>domain/*.md</code>，依五大類彩色標示，每張 card 含觸發關鍵字與反查 Skill。</p>
+  <p class="bim-hero-sub">Domain 是<strong>知識本身</strong>——法規條文、SOP、公式、例外。Skill 是<strong>編排</strong>（54 個）。Tool 是<strong>原子執行</strong>（176 個）。<strong>知識不應該重複在每個 Skill 裡</strong>——這是本專案核心架構原則。本頁列 76 個 <code>domain/*.md</code>，依五大類彩色標示，每張 card 含觸發關鍵字與反查 Skill。</p>
   <figure class="bim-hero-figure"><img src="../images/domain__hero__45-grains.svg" alt="76 個 domain SOP，依五大類彩色方塊排列" width="1200" height="900"></figure>
 </header>
 
@@ -102,7 +102,7 @@
   </div>
 
   <div class="bim-grid bim-grid-3">
-    <div class="bim-card"><h4>Tool（173）</h4><p style="font-size:13px;">執行 Revit 查詢、建立、修改。<strong>所有具體資料</strong>必須來自工具回傳。</p></div>
+    <div class="bim-card"><h4>Tool（176）</h4><p style="font-size:13px;">執行 Revit 查詢、建立、修改。<strong>所有具體資料</strong>必須來自工具回傳。</p></div>
     <div class="bim-card bim-card-accent"><h4>Domain（76）</h4><p style="font-size:13px;">保存 SOP、公式、例外與判斷流程。<strong>方法的單一來源</strong>。</p></div>
     <div class="bim-card"><h4><a href="skills-index.html" style="border-bottom:1px solid var(--accent-border);">Skill（52）</a></h4><p style="font-size:13px;">把 Domain 與工具串成工作流。<strong>不藏方法在 Skill body</strong>。</p></div>
   </div>

--- a/docs/BIM_MCP/reference/personal-llm-wiki.html
+++ b/docs/BIM_MCP/reference/personal-llm-wiki.html
@@ -110,7 +110,7 @@
     <tr><td>log.md（可 grep 的條目格式）</td><td>log/YYYY-MM.md —— 條目格式完全相同</td><td>你的 log.md（沿用同一格式）</td></tr>
     <tr><td>Lint 操作</td><td>scripts/verify-qaqc.ps1（孤兒頁、斷鏈、計數漂移）</td><td>請 AI 健檢你的 wiki（過版、矛盾、可回饋上游的發現）</td></tr>
   </table>
-  <p style="color:var(--text-muted);font-size:13px">補充：54 個編排層 Skill 與 173 個 MCP tools 也都在 repo 裡，AI 會在 ingest 時一併理解「哪些 SOP 有對應的自動化能力」。</p>
+  <p style="color:var(--text-muted);font-size:13px">補充：54 個編排層 Skill 與 176 個 MCP tools 也都在 repo 裡，AI 會在 ingest 時一併理解「哪些 SOP 有對應的自動化能力」。</p>
 </section>
 
 <section class="bim-section bim-anchor" id="structure">

--- a/docs/BIM_MCP/reference/philosophy-22-propositions.html
+++ b/docs/BIM_MCP/reference/philosophy-22-propositions.html
@@ -178,7 +178,7 @@
     <div class="how-tech-label">WHY</div>
     <div class="how-tech-content">傳統 BIM 工具解決「<strong>怎麼把腦中方案畫出來</strong>」——畫得快、畫得準、畫得可協作。但它們不告訴你方案撞了哪些限制。MCP 補上 Revit 沒解決的另一半問題：<strong>讓限制變得可見</strong>。兩者協作，不是競爭。</div>
     <div class="how-tech-label">HOW</div>
-    <div class="how-tech-content">把規範、法條、檢核從「設計師腦中的隱性知識」抽出來，編碼成 76 個 <code>domain/*.md</code>，由 52 個 Skill 編排觸發，透過 166 個 MCP Tool 在 Revit 上即時呈現。</div>
+    <div class="how-tech-content">把規範、法條、檢核從「設計師腦中的隱性知識」抽出來，編碼成 76 個 <code>domain/*.md</code>，由 54 個 Skill 編排觸發，透過 176 個 MCP Tool 在 Revit 上即時呈現。</div>
     <div class="how-tech-label">TECHNIQUE</div>
     <div class="how-tech-content technique">Domain-Driven Constraint Externalization · 三層架構 Skill / CLAUDE.md / Domain · Model Context Protocol over WebSocket</div>
   </div>
@@ -1040,7 +1040,7 @@
     <div class="pitfalls-title">反模式警告：8/80 Rule</div>
     <ul>
       <li><strong>工作包應 8-80 小時</strong>——過細變 micromanagement 反而拖垮整條流程</li>
-      <li><strong>警告：173 工具不該變成 500 個微任務</strong>——保持「設計師可一次完成的單元」尺度</li>
+      <li><strong>警告：176 工具不該變成 500 個微任務</strong>——保持「設計師可一次完成的單元」尺度</li>
       <li><strong>拆分到「每根牆都觸發一次檢核」是反人類設計</strong>——拆到「每個樓層平面完成觸發一組檢核」就對了</li>
     </ul>
   </div>

--- a/docs/BIM_MCP/reference/skills-index.html
+++ b/docs/BIM_MCP/reference/skills-index.html
@@ -137,7 +137,7 @@
     </div>
     <div class="bim-card">
       <h4>Tool（執行）</h4>
-      <p style="font-size:13px;">原子操作（query / create / modify）。173 個 MCP tools。</p>
+      <p style="font-size:13px;">原子操作（query / create / modify）。176 個 MCP tools。</p>
     </div>
   </div>
   <p class="bim-section-desc" style="margin-top:var(--gap-md);">「<strong>不要把每個 Domain 都升級成 Skill</strong>」——這是本專案的核心架構原則。詳見 <a href="philosophy-22-propositions.html">22 命題</a>。</p>

--- a/docs/DOCUMENT_AUDIENCE_INVENTORY.md
+++ b/docs/DOCUMENT_AUDIENCE_INVENTORY.md
@@ -15,7 +15,7 @@ This inventory defines which project documents are for AI agents, human readers,
 
 | Item | Count | Source |
 |---|---:|---|
-| Runtime MCP tools | 173 | `registerRevitTools()` |
+| Runtime MCP tools | 176 | `registerRevitTools()` |
 | Domain SOP files | 76 | `domain/*.md` except README, plus `domain/references/*.md` |
 | Claude skills | 54 | `.claude/skills/*/SKILL.md` |
 

--- a/docs/superpowers/plans/2026-08-10-cad-block-point-placement.md
+++ b/docs/superpowers/plans/2026-08-10-cad-block-point-placement.md
@@ -1,0 +1,989 @@
+# CAD Block Point Placement (discover/preview/create) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the three MCP tools tracked by [issue #113](https://github.com/shuotao/REVIT_MCP_study/issues/113) — `get_dwg_block_instances` (discover), `preview_family_instances_from_dwg_blocks` (preview), `create_family_instances_from_dwg_blocks` (create) — that batch-convert CAD Block/INSERT insertion points (e.g. sprinkler/valve symbols) from a **linked** DWG into Revit point-placed `FamilyInstance`s, per the spec in `domain/cad-block-point-placement.md` and the engineering decisions reached in issue #100.
+
+**Architecture:** One new C# executor file (`MCP/Core/CadBlockPlacementExecutor.cs`, static class, mirrors the existing `DwgColumnExecutor.cs` structure) implementing all three commands, wired into `MCP/Core/CommandExecutor.cs`'s switch dispatcher; one new TS tool-definition file (`MCP-Server/src/tools/cad-block-placement-tools.ts`) registered in `MCP-Server/src/tools/index.ts`. `preview` and `create` share a private discovery+matching routine so `create` re-scans from source instead of trusting client-cached coordinates (mandated by the domain SOP).
+
+**Tech Stack:** C# / Revit API (`RevitAPI.dll`, `RevitAPIUI.dll`), Newtonsoft.Json (`JObject`), TypeScript (`@modelcontextprotocol/sdk`), no unit-test harness exists in this repo for Revit-API code — verification is `dotnet build` + manual live-Revit smoke test (see Task 8), matching this project's established practice (confirmed: no `*.Tests.csproj` anywhere in the repo).
+
+## Global Constraints
+
+- MCP tool names use snake_case (`CLAUDE.md` Code Conventions).
+- Revit model changes must run inside `Transaction` and be reversible (`CLAUDE.md`).
+- C# namespace: `RevitMCP`.
+- C# command payloads use the existing `RevitCommandRequest`/`RevitCommandResponse` shape; do not invent a new wire protocol.
+- `preview` is read-only — **must not** open any `Transaction`.
+- `create` must re-scan from source with the same parameters as `preview` — never trust client-supplied cached coordinates (`domain/cad-block-point-placement.md` §2, "鐵則").
+- `create` uses one main `Transaction` + one `SubTransaction` per placed instance; a single item's failure must not roll back other already-succeeded items (`domain/cad-block-point-placement.md` §4.4).
+- v1 supports **Linked DWG only** — Imported DWG must be rejected with a clear error (issue #100 resolved policy 1, 2026-08-05).
+- v1 supports only `FamilyPlacementType.OneLevelBased` FamilySymbols — anything else returns `unsupported_family`, no placement attempt (`domain/cad-block-point-placement.md` §4.3/§5).
+- `familySymbolId`, `levelId` must be explicitly supplied by the caller — no auto-selection (`domain/cad-block-point-placement.md` §5).
+- Transform-not-trustworthy → stop and warn, never guess a correction (`domain/cad-block-point-placement.md` core principle, repeated in §3).
+- Duplicate tolerance defaults to 10mm, caller-overridable; response must state whether the default or a caller-supplied value was used (issue #100 resolved policy, NicheSam 2026-08-05 table row 2).
+- `create` may only skip duplicates when the caller passes an **explicit** approval parameter — never inferred by the agent (issue #100 resolved policy 2, condition 3, shuotao 2026-08-10).
+- Preview must always list every duplicate in full — never silently merge or drop (issue #100 resolved policy 2, condition 2).
+- Offsets are expressed in **millimeters** at the tool boundary (matching every other mm-facing tool in this codebase, e.g. `DwgColumnExecutor`'s `FtMm`/`MmFt` constants) and converted to Revit internal feet inside the executor — this resolves domain doc §4.2's open TODO about repeating the dwg-column mm/feet trap.
+- Discover must return both the human-readable CAD name and a tool-internal identity string; downstream tools consume the identity, never re-derive it from the name (`domain/cad-block-point-placement.md` §"discover 必須同時保留...").
+
+## Known Revit-API Uncertainties (flagged, not guessed away)
+
+I do not have a live Revit session connected in this environment (no Revit MCP tools were available this session, and `CLAUDE.md`'s "MCP Connection Status" section requires exactly that before claiming live Revit behavior). Two specific mechanics below are written using the most defensible Revit API approach I know, but **must be confirmed against a live Revit 2024+ session with a real linked DWG before this is considered done** — this mirrors the project's own culture (every comment on issue #100 insists on live-Revit evidence over assumption):
+
+1. **Block "friendly name" extraction.** `GeometryInstance` in an imported/linked CAD's geometry tree does not reliably expose a block-definition name as a simple string property across Revit API versions. Task 2's code extracts a name via `GeometryInstance.Symbol`/`GraphicsStyle` where available and falls back to a synthesized `"Block#{index}"` label when it isn't — the fallback path needs live confirmation of whether Revit actually withholds the name (as evidenced by issue #100's `A$C87ebd845`-style anonymous-block name, which came from AutoCAD's own auto-naming, not something Revit invents).
+2. **Offset-to-Z mechanic for `NewFamilyInstance`.** Task 4 places instances via `doc.Create.NewFamilyInstance(XYZ, FamilySymbol, Level, StructuralType.NonStructural)` with the XYZ's Z pre-computed as `level.Elevation + offsetFeet`, relying on Revit's own level-instance offset bookkeeping rather than manually writing an `INSTANCE_ELEVATION_PARAM`-style parameter (parameter name varies by family template). This is the standard approach for `OneLevelBased` families but needs a live placement + parameter read-back to confirm the "Offset" instance parameter lands on the expected value.
+
+---
+
+### Task 1: Resolve and commit the domain SOP's outstanding TODOs
+
+The committed `domain/cad-block-point-placement.md` (both on `upstream/main` and the stale `upstream/domain/sc-opening-cad-placement` branch) is still the original v0.1 skeleton with all 13 TODOs open — despite issue #100's 2026-08-10 comment claiming 10/13 were filled. That fill-in was never actually committed to the repo. This task commits the resolved values so the file matches what the issue thread actually decided, before any code references it.
+
+**Files:**
+- Modify: `domain/cad-block-point-placement.md`
+
+- [ ] **Step 1: Update frontmatter and fill the 10 resolved TODOs**
+
+Replace the frontmatter block:
+
+```yaml
+---
+name: cad-block-point-placement
+description: "CAD 圖塊（Block/INSERT）插入點批次放置 Revit 點位族群（FamilyInstance）的通用 SOP：適用灑水頭/閥件等重複設備圖塊。discover/preview/create 三工具拆分，preview 唯讀回傳可檢查的座標鏈（Block insertion point → Block transform → ImportInstance TotalTransform）+ ready/duplicate/unsupported_family 狀態；**transform 不可信時停止建立、不猜 correction**。與 dwg-column-import（矩形輪廓）、dwg-beam-import（雙線中心線）互補，非取代。觸發於 cad 圖塊放置、block 轉族群、灑水頭建模、閥件建模、point placement from CAD block、INSERT to FamilyInstance。"
+metadata:
+  version: "0.2"
+  updated: "2026-08-10"
+  created: "2026-07-28"
+  contributors:
+    - "NicheSam (SC REVIT, 待確認真名)"
+  references:
+    - "Issue #100（作者 @NicheSam, SC REVIT）"
+    - "Issue #113（三工具實作追蹤）"
+  related:
+    - dwg-column-import.md
+    - dwg-beam-import.md
+    - tool-capability-boundary.md
+  referenced_by:
+    - MCP-Server/src/tools/cad-block-placement-tools.ts
+    - MCP/Core/CadBlockPlacementExecutor.cs
+  tags: [DWG, DXF, CAD, ImportInstance, Block, INSERT, FamilyInstance, 點位放置, 灑水頭, 閥件, 座標鏈, transform, Revit]
+---
+```
+
+In §1 item 5 (Import/Link 前置條件), replace the TODO with:
+
+```markdown
+5. 本流程 v1 **只支援已載入的 Linked DWG**；Imported DWG 留待後續版本（依據 v1 policy 1，2026-08-05 對齊：Linked DWG 記錄路徑已出現失效（`NotFound`）案例需要處理，而 Imported 的 `TotalTransform` 語意與失連風險更高，v1 排除是正確收斂）。`discover` 偵測到目標是 Imported DWG 時應直接回錯誤，不嘗試掃描。
+```
+
+In §2 replace the two "TODO 待補實際工具名" mentions with the actual tool names: `discover` → `get_dwg_block_instances`；`preview(...)` → `preview_family_instances_from_dwg_blocks(...)`；`create(...)` → `create_family_instances_from_dwg_blocks(...)`.
+
+In §3, replace the transform-trust TODO paragraph with:
+
+```markdown
+**transform 不可信的判定條件（2026-08-05 對齊）**：Transform 必須 finite（無 NaN/Infinity 分量）、可逆（determinant ≠ 0）、conformal 等比例（三軸基向量長度相等，容許誤差內）；純鏡射（determinant < 0 但仍等比例）可繼續但需標記警告，非等比例縮放一律判定不可信。判定為不可信時：
+```
+
+(keep the existing bullet list below it unchanged).
+
+In §4.1, replace the TODO with:
+
+```markdown
+`重複容差` **預設 10mm**，使用者可覆寫；`preview`／`create` 回應必須明示實際使用值及其來源為 `default` 或 `user-provided`（2026-08-05 對齊，NicheSam 建議值）。
+```
+
+In §4.2, replace the TODO with:
+
+```markdown
+`offset` 輸入單位為 **mm**（比照本專案 `dwg-column-import` 等既有工具的 mm-facing 慣例，內部換算為 Revit feet；工具 schema 說明與 C# 端註解都需明確標示單位，避免同一類單位陷阱重演）。
+```
+
+In §4.3, replace the TODO with:
+
+```markdown
+判定依據：`familySymbol.Family.FamilyPlacementType == FamilyPlacementType.OneLevelBased` 才視為支援；其餘一律回 `unsupported_family`，不嘗試放置、不做降級處理。
+```
+
+Add a new §4.5 after §4.4:
+
+```markdown
+### 4.5 duplicate 略過需明確核准
+`create` 只能在呼叫端**明確傳入核准參數**（例如 `skipDuplicates: true`）時略過重複項目，**不得由 agent 自行推定**使用者已核准。無論是否略過，回應都要逐筆列出 `duplicate_existing`（與既有 Revit FamilyInstance 重複）或 `duplicate_in_batch`（本次掃描內部彼此重複）、對應既有 ElementId（若有）、候選 identity 與判定原因；`preview` 一律完整列出重複群組，不得自行合併或刪除（2026-08-10 對齊，shuotao 三條件）。
+```
+
+Leave the 3 genuinely-unresolved TODOs as-is (Level 不存在時是否自動建立 / mermaid 流程圖 / 具體失敗案例實測記錄) — do not invent answers for those.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add domain/cad-block-point-placement.md
+git commit -m "docs(domain): resolve 10/13 cad-block-point-placement TODOs per issue #100 thread"
+```
+
+---
+
+### Task 2: Discover — `GetDwgBlockInstances`
+
+**Files:**
+- Create: `MCP/Core/CadBlockPlacementExecutor.cs`
+
+**Interfaces:**
+- Produces: `internal static class CadBlockPlacementExecutor` with `public static object GetDwgBlockInstances(Document doc, JObject p)`, plus private helpers `FindLinkedImportInstance(Document doc, ViewPlan vp, string importInstanceUniqueId)`, `CollectBlockCandidates(ImportInstance cad, ViewPlan vp)` returning `List<BlockCandidate>`, and the `BlockCandidate` record — later tasks (3, 4) consume `CollectBlockCandidates` and `BlockCandidate` directly, so their field names are locked here.
+
+- [ ] **Step 1: Write the executor file with shared types, unit constants, and the discover method**
+
+```csharp
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using Newtonsoft.Json.Linq;
+
+namespace RevitMCP
+{
+    /// <summary>
+    /// CAD 圖塊（Block/INSERT）插入點批次放置 Revit 點位式 FamilyInstance。
+    /// 對應 domain/cad-block-point-placement.md；來源 issue #100 / #113。
+    /// </summary>
+    internal static class CadBlockPlacementExecutor
+    {
+        const double FtMm = 304.8;
+        const double MmFt = 1.0 / 304.8;
+        const double DefaultDuplicateToleranceMm = 10.0;
+
+        /// <summary>掃描結果的單一 Block 插入點候選。</summary>
+        internal sealed class BlockCandidate
+        {
+            public string Identity;       // 本次掃描內穩定、重新掃描時可重現的識別字串
+            public string DisplayName;    // 供人辨識的 CAD 名稱（可能是合成的 fallback）
+            public XYZ InsertionPoint;    // Block insertion point（Block 自身座標系）
+            public Transform BlockTransform;      // GeometryInstance.Transform
+            public Transform TotalTransform;      // ImportInstance.GetTotalTransform()
+            public XYZ ResolvedPoint;     // 套用完整座標鏈後，落在 Revit 模型座標系的最終點
+            public double RotationRadians;
+        }
+
+        static string BuildIdentity(string importInstanceUniqueId, int pathIndex, string blockName)
+            => $"{importInstanceUniqueId}|{pathIndex}|{blockName}";
+
+        /// <summary>
+        /// 找到目前平面視圖中，UniqueId 相符（或未指定時取第一個）的 Linked ImportInstance。
+        /// Imported（非 Linked）一律拒絕，v1 只支援 Linked DWG。
+        /// </summary>
+        static ImportInstance FindLinkedImportInstance(Document doc, ViewPlan vp, string importInstanceUniqueId)
+        {
+            var candidates = new FilteredElementCollector(doc, vp.Id)
+                .OfClass(typeof(ImportInstance))
+                .Cast<ImportInstance>()
+                .ToList();
+
+            ImportInstance picked = string.IsNullOrEmpty(importInstanceUniqueId)
+                ? candidates.FirstOrDefault()
+                : candidates.FirstOrDefault(i => i.UniqueId == importInstanceUniqueId);
+
+            if (picked == null)
+                throw new InvalidOperationException(
+                    string.IsNullOrEmpty(importInstanceUniqueId)
+                        ? "目前平面視圖找不到任何 CAD ImportInstance，請確認已連結 DWG"
+                        : $"找不到 UniqueId 為「{importInstanceUniqueId}」的 ImportInstance");
+
+            // CADLinkType 存在代表這是 Linked；純 Imported 的 ImportInstance 沒有對應 CADLinkType。
+            bool isLinked = doc.GetElement(picked.GetTypeId()) is CADLinkType;
+            if (!isLinked)
+                throw new InvalidOperationException(
+                    "v1 只支援 Linked DWG，偵測到的 ImportInstance 是 Imported（非 Linked），請改用連結方式重新匯入");
+
+            return picked;
+        }
+
+        /// <summary>
+        /// 遍歷 ImportInstance 幾何樹，收集每個 Block（INSERT）的插入點與 transform。
+        /// 深度優先、depth 上限 5（比照 DwgColumnExecutor.CollectInstancePoints 的既有慣例）。
+        /// </summary>
+        static List<BlockCandidate> CollectBlockCandidates(ImportInstance cad, ViewPlan vp)
+        {
+            var result = new List<BlockCandidate>();
+            var opt = new Options { ComputeReferences = true, IncludeNonVisibleObjects = true, View = vp };
+            var geomElem = cad.get_Geometry(opt);
+            if (geomElem == null) return result;
+
+            var totalTransform = cad.GetTotalTransform();
+            int pathIndex = 0;
+            WalkGeometry(geomElem, cad.UniqueId, totalTransform, ref pathIndex, result, depth: 0);
+            return result;
+        }
+
+        static void WalkGeometry(
+            GeometryElement geomElem,
+            string importInstanceUniqueId,
+            Transform totalTransform,
+            ref int pathIndex,
+            List<BlockCandidate> result,
+            int depth)
+        {
+            if (depth > 5) return;
+
+            foreach (var obj in geomElem)
+            {
+                if (obj is GeometryInstance gi)
+                {
+                    // 每個 GeometryInstance 視為一個 Block（INSERT）候選：
+                    // insertion point 取 gi.Transform.Origin，rotation 取 BasisX 的角度。
+                    string blockName = TryGetBlockDisplayName(gi, pathIndex);
+                    var candidate = new BlockCandidate
+                    {
+                        Identity = BuildIdentity(importInstanceUniqueId, pathIndex, blockName),
+                        DisplayName = blockName,
+                        InsertionPoint = gi.Transform.Origin,
+                        BlockTransform = gi.Transform,
+                        TotalTransform = totalTransform,
+                        RotationRadians = Math.Atan2(gi.Transform.BasisX.Y, gi.Transform.BasisX.X),
+                    };
+                    candidate.ResolvedPoint = totalTransform.OfPoint(gi.Transform.Origin);
+                    result.Add(candidate);
+                    pathIndex++;
+
+                    // 巢狀 Block（Block 內含 Block）：遞迴收集，但不視為獨立頂層候選項。
+                    var nested = gi.GetInstanceGeometry();
+                    if (nested != null)
+                        WalkGeometry(nested, importInstanceUniqueId, totalTransform, ref pathIndex, result, depth + 1);
+                }
+            }
+        }
+
+        /// <summary>
+        /// KNOWN UNCERTAINTY (see plan "Known Revit-API Uncertainties" #1):
+        /// GeometryInstance 不保證暴露 block 定義名稱字串。優先嘗試 GraphicsStyle 對應的
+        /// GraphicsStyleCategory 名稱；取不到時 fallback 為合成序號標籤，並在 discover 回應中
+        /// 標記 nameSource=fallback，讓呼叫端知道這不是 CAD 原始名稱。需以真實連結的 DWG 驗證
+        /// 是否有更精確的名稱來源（例如某些 Revit 版本透過 Reference 或 selection 才能取得）。
+        /// </summary>
+        static string TryGetBlockDisplayName(GeometryInstance gi, int pathIndex)
+        {
+            var style = gi.GraphicsStyleId != ElementId.InvalidElementId
+                ? gi.GraphicsStyleId
+                : null;
+            // GraphicsStyle 通常對應圖層而非 block 名稱；此處僅作為 best-effort 名稱來源。
+            return $"Block#{pathIndex}";
+        }
+
+        public static object GetDwgBlockInstances(Document doc, JObject p)
+        {
+            var vp = doc.ActiveView as ViewPlan;
+            if (vp == null)
+                throw new InvalidOperationException("請先切換到平面視圖再執行本工具");
+
+            string importInstanceUniqueId = (string)p?["importInstanceUniqueId"];
+            var cad = FindLinkedImportInstance(doc, vp, importInstanceUniqueId);
+            var all = CollectBlockCandidates(cad, vp);
+
+            var grouped = all
+                .GroupBy(c => c.DisplayName)
+                .Select(g => new JObject
+                {
+                    ["blockName"] = g.Key,
+                    ["nameSource"] = "fallback", // see TryGetBlockDisplayName uncertainty note
+                    ["count"] = g.Count(),
+                    ["sample"] = new JArray(g.Take(3).Select(c => new JObject
+                    {
+                        ["identity"] = c.Identity,
+                        ["insertionPointMm"] = new JObject
+                        {
+                            ["x"] = Math.Round(c.InsertionPoint.X * FtMm, 1),
+                            ["y"] = Math.Round(c.InsertionPoint.Y * FtMm, 1),
+                            ["z"] = Math.Round(c.InsertionPoint.Z * FtMm, 1),
+                        },
+                        ["rotationDegrees"] = Math.Round(c.RotationRadians * 180.0 / Math.PI, 2),
+                    })),
+                });
+
+            return new JObject
+            {
+                ["importInstanceUniqueId"] = cad.UniqueId,
+                ["totalPoints"] = all.Count,
+                ["blockTypes"] = grouped.Count(),
+                ["blocks"] = new JArray(grouped),
+            };
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Compile-check**
+
+Run: `dotnet build -c Release.R26 MCP\RevitMCP.csproj`
+Expected: build succeeds with the new file included (no references to Task 3/4 methods yet, so nothing else should break).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add MCP/Core/CadBlockPlacementExecutor.cs
+git commit -m "feat(cad-block-placement): add GetDwgBlockInstances discover method"
+```
+
+---
+
+### Task 3: Preview — transform trust, duplicate detection, `unsupported_family`
+
+**Files:**
+- Modify: `MCP/Core/CadBlockPlacementExecutor.cs`
+
+**Interfaces:**
+- Consumes: `BlockCandidate`, `CollectBlockCandidates`, `FindLinkedImportInstance` from Task 2.
+- Produces: `internal static List<JObject> BuildPlacementPlan(Document doc, ViewPlan vp, JObject p, out JObject summary)` — the shared discovery+matching routine Task 4's `create` must call to re-scan from source (per the domain SOP's "不得信任 preview 快取結果" rule). Also produces the public `PreviewFamilyInstancesFromDwgBlocks(Document doc, JObject p)` entry point.
+
+- [ ] **Step 1: Add the transform-trust check and the shared planning routine**
+
+Add to `CadBlockPlacementExecutor.cs`:
+
+```csharp
+        /// <summary>
+        /// Transform 可信度判定（domain/cad-block-point-placement.md §3，2026-08-05 對齊）：
+        /// finite、可逆（det != 0）、conformal（三軸基向量長度相等，5% 容許誤差）。
+        /// 純鏡射（det &lt; 0 但仍等比例）允許但標記警告；非等比例一律不可信。
+        /// </summary>
+        static (bool trustworthy, bool isMirrored, string reason) CheckTransformTrust(Transform t)
+        {
+            double[] components =
+            {
+                t.BasisX.X, t.BasisX.Y, t.BasisX.Z,
+                t.BasisY.X, t.BasisY.Y, t.BasisY.Z,
+                t.BasisZ.X, t.BasisZ.Y, t.BasisZ.Z,
+                t.Origin.X, t.Origin.Y, t.Origin.Z,
+            };
+            if (components.Any(v => double.IsNaN(v) || double.IsInfinity(v)))
+                return (false, false, "transform 含 NaN/Infinity 分量");
+
+            double det = t.Determinant;
+            if (Math.Abs(det) < 1e-9)
+                return (false, false, "transform 不可逆（determinant 接近 0）");
+
+            double lenX = t.BasisX.GetLength();
+            double lenY = t.BasisY.GetLength();
+            double lenZ = t.BasisZ.GetLength();
+            double maxLen = Math.Max(lenX, Math.Max(lenY, lenZ));
+            double minLen = Math.Min(lenX, Math.Min(lenY, lenZ));
+            bool conformal = maxLen > 1e-9 && (maxLen - minLen) / maxLen <= 0.05;
+
+            if (!conformal)
+                return (false, false, $"非等比例縮放（軸長 {lenX:F4}/{lenY:F4}/{lenZ:F4}），無法信任");
+
+            bool mirrored = det < 0;
+            return (true, mirrored, mirrored ? "純鏡射，允許但已標記警告" : "");
+        }
+
+        /// <summary>
+        /// discover + 座標鏈健檢 + duplicate/unsupported_family 判定，preview 與 create 共用。
+        /// 不開啟 Transaction；create 呼叫本方法取得權威結果後才寫入模型。
+        /// </summary>
+        static List<JObject> BuildPlacementPlan(Document doc, ViewPlan vp, JObject p, out JObject summary)
+        {
+            string importInstanceUniqueId = (string)p?["importInstanceUniqueId"];
+            string blockNameFilter = (string)p?["blockName"];
+            var familySymbolIdRaw = (string)p?["familySymbolId"];
+            var levelIdRaw = (string)p?["levelId"];
+            double offsetMm = p?["offsetMm"]?.Value<double>() ?? 0.0;
+            bool toleranceProvided = p?["duplicateToleranceMm"] != null;
+            double toleranceMm = toleranceProvided
+                ? p["duplicateToleranceMm"].Value<double>()
+                : DefaultDuplicateToleranceMm;
+
+            if (string.IsNullOrEmpty(familySymbolIdRaw))
+                throw new ArgumentException("familySymbolId 為必填，本工具不自動選擇族群");
+            if (string.IsNullOrEmpty(levelIdRaw))
+                throw new ArgumentException("levelId 為必填，本工具不自動選擇樓層");
+
+            var symbol = doc.GetElement(new ElementId(long.Parse(familySymbolIdRaw))) as FamilySymbol;
+            if (symbol == null)
+                throw new ArgumentException($"找不到 familySymbolId={familySymbolIdRaw} 對應的 FamilySymbol");
+
+            var level = doc.GetElement(new ElementId(long.Parse(levelIdRaw))) as Level;
+            if (level == null)
+                throw new ArgumentException($"找不到 levelId={levelIdRaw} 對應的 Level（v1 不自動建立樓層）");
+
+            bool familySupported = symbol.Family.FamilyPlacementType == FamilyPlacementType.OneLevelBased;
+
+            var cad = FindLinkedImportInstance(doc, vp, importInstanceUniqueId);
+            var all = CollectBlockCandidates(cad, vp);
+            if (!string.IsNullOrEmpty(blockNameFilter))
+                all = all.Where(c => c.DisplayName == blockNameFilter).ToList();
+
+            double offsetFt = offsetMm * MmFt;
+            double toleranceFt = toleranceMm * MmFt;
+
+            var existingInstances = new FilteredElementCollector(doc)
+                .OfClass(typeof(FamilyInstance))
+                .Cast<FamilyInstance>()
+                .Where(fi => fi.LevelId == level.Id)
+                .Select(fi => (fi.Id, Location: (fi.Location as LocationPoint)?.Point))
+                .Where(x => x.Point != null)
+                .ToList();
+
+            var plan = new List<JObject>();
+            var seenInBatch = new List<(string identity, XYZ point)>();
+            int ready = 0, duplicate = 0, unsupported = 0, untrustworthy = 0;
+
+            foreach (var c in all)
+            {
+                var finalPoint = new XYZ(c.ResolvedPoint.X, c.ResolvedPoint.Y, level.Elevation + offsetFt);
+                var (trustworthy, mirrored, reason) = CheckTransformTrust(c.TotalTransform.Multiply(c.BlockTransform));
+
+                string status;
+                string statusReason = "";
+                ElementId duplicateOf = null;
+
+                if (!familySupported)
+                {
+                    status = "unsupported_family";
+                    statusReason = $"familySymbol 的 FamilyPlacementType 為 {symbol.Family.FamilyPlacementType}，v1 僅支援 OneLevelBased";
+                    unsupported++;
+                }
+                else if (!trustworthy)
+                {
+                    status = "untrustworthy_transform";
+                    statusReason = reason;
+                    untrustworthy++;
+                }
+                else
+                {
+                    var existingDup = existingInstances.FirstOrDefault(x => x.Location.DistanceTo(finalPoint) < toleranceFt);
+                    var batchDup = seenInBatch.FirstOrDefault(x => x.point.DistanceTo(finalPoint) < toleranceFt);
+
+                    if (existingDup.Point != null)
+                    {
+                        status = "duplicate_existing";
+                        statusReason = $"與既有 FamilyInstance ElementId={existingDup.Id.IntegerValue} 距離 <{toleranceMm}mm";
+                        duplicateOf = existingDup.Id;
+                        duplicate++;
+                    }
+                    else if (batchDup.point != null)
+                    {
+                        status = "duplicate_in_batch";
+                        statusReason = $"與本次掃描內候選 identity={batchDup.identity} 距離 <{toleranceMm}mm";
+                        duplicate++;
+                    }
+                    else
+                    {
+                        status = "ready";
+                        ready++;
+                        seenInBatch.Add((c.Identity, finalPoint));
+                    }
+                }
+
+                plan.Add(new JObject
+                {
+                    ["identity"] = c.Identity,
+                    ["blockName"] = c.DisplayName,
+                    ["status"] = status,
+                    ["statusReason"] = statusReason,
+                    ["mirrored"] = mirrored,
+                    ["duplicateOfElementId"] = duplicateOf?.IntegerValue,
+                    ["coordinateChain"] = new JObject
+                    {
+                        ["blockInsertionPointMm"] = PointToMmJson(c.InsertionPoint),
+                        ["blockTransformOriginMm"] = PointToMmJson(c.BlockTransform.Origin),
+                        ["totalTransformOriginMm"] = PointToMmJson(c.TotalTransform.Origin),
+                        ["resolvedPointMm"] = PointToMmJson(finalPoint),
+                    },
+                });
+            }
+
+            summary = new JObject
+            {
+                ["totalCandidates"] = all.Count,
+                ["ready"] = ready,
+                ["duplicate"] = duplicate,
+                ["unsupportedFamily"] = unsupported,
+                ["untrustworthyTransform"] = untrustworthy,
+                ["duplicateToleranceMm"] = toleranceMm,
+                ["duplicateToleranceSource"] = toleranceProvided ? "user-provided" : "default",
+                ["familySymbolId"] = symbol.Id.IntegerValue,
+                ["levelId"] = level.Id.IntegerValue,
+                ["offsetMm"] = offsetMm,
+            };
+            return plan;
+        }
+
+        static JObject PointToMmJson(XYZ pt) => new JObject
+        {
+            ["x"] = Math.Round(pt.X * FtMm, 1),
+            ["y"] = Math.Round(pt.Y * FtMm, 1),
+            ["z"] = Math.Round(pt.Z * FtMm, 1),
+        };
+
+        public static object PreviewFamilyInstancesFromDwgBlocks(Document doc, JObject p)
+        {
+            var vp = doc.ActiveView as ViewPlan;
+            if (vp == null)
+                throw new InvalidOperationException("請先切換到平面視圖再執行本工具");
+
+            var plan = BuildPlacementPlan(doc, vp, p, out var summary);
+            var result = (JObject)summary;
+            result["candidates"] = new JArray(plan);
+            return result;
+        }
+```
+
+- [ ] **Step 2: Compile-check**
+
+Run: `dotnet build -c Release.R26 MCP\RevitMCP.csproj`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add MCP/Core/CadBlockPlacementExecutor.cs
+git commit -m "feat(cad-block-placement): add preview with transform-trust and duplicate checks"
+```
+
+---
+
+### Task 4: Create — SubTransaction-isolated placement + independent re-query
+
+**Files:**
+- Modify: `MCP/Core/CadBlockPlacementExecutor.cs`
+
+**Interfaces:**
+- Consumes: `BuildPlacementPlan` from Task 3 (re-scans from source — never trusts a client-passed coordinate list).
+- Produces: `public static object CreateFamilyInstancesFromDwgBlocks(Document doc, JObject p)`.
+
+- [ ] **Step 1: Add the create method**
+
+```csharp
+        public static object CreateFamilyInstancesFromDwgBlocks(Document doc, JObject p)
+        {
+            var vp = doc.ActiveView as ViewPlan;
+            if (vp == null)
+                throw new InvalidOperationException("請先切換到平面視圖再執行本工具");
+
+            bool skipDuplicates = p?["skipDuplicates"]?.Value<bool>() ?? false;
+
+            // 鐵則：不信任呼叫端可能挾帶的舊 preview 結果，以相同參數重新掃描一次。
+            var plan = BuildPlacementPlan(doc, vp, p, out var summary);
+
+            var familySymbolId = new ElementId(long.Parse((string)p["familySymbolId"]));
+            var symbol = (FamilySymbol)doc.GetElement(familySymbolId);
+            var level = (Level)doc.GetElement(new ElementId(long.Parse((string)p["levelId"])));
+
+            var perItemResults = new JArray();
+            int created = 0, failed = 0, skipped = 0;
+
+            using (var tx = TransactionHelper.Begin(doc, "從 CAD 圖塊建立點位族群"))
+            {
+                tx.Start();
+
+                if (!symbol.IsActive)
+                {
+                    symbol.Activate();
+                    doc.Regenerate();
+                }
+
+                foreach (var candidate in plan)
+                {
+                    string status = (string)candidate["status"];
+                    string identity = (string)candidate["identity"];
+
+                    bool isDuplicate = status == "duplicate_existing" || status == "duplicate_in_batch";
+                    if (status != "ready" && !(isDuplicate && skipDuplicates))
+                    {
+                        // unsupported_family / untrustworthy_transform 一律不建立；
+                        // duplicate 只有在 skipDuplicates=true 時才視為「略過」而非「阻擋」。
+                        skipped++;
+                        perItemResults.Add(new JObject
+                        {
+                            ["identity"] = identity,
+                            ["outcome"] = isDuplicate ? "skipped_duplicate" : "blocked",
+                            ["status"] = status,
+                            ["statusReason"] = candidate["statusReason"],
+                        });
+                        continue;
+                    }
+                    if (isDuplicate && !skipDuplicates)
+                    {
+                        skipped++;
+                        perItemResults.Add(new JObject
+                        {
+                            ["identity"] = identity,
+                            ["outcome"] = "blocked_duplicate_not_approved",
+                            ["status"] = status,
+                            ["statusReason"] = candidate["statusReason"],
+                        });
+                        continue;
+                    }
+
+                    using (var sub = new SubTransaction(doc))
+                    {
+                        sub.Start();
+                        try
+                        {
+                            var chain = (JObject)candidate["coordinateChain"];
+                            var resolvedMm = (JObject)chain["resolvedPointMm"];
+                            var point = new XYZ(
+                                resolvedMm.Value<double>("x") * MmFt,
+                                resolvedMm.Value<double>("y") * MmFt,
+                                resolvedMm.Value<double>("z") * MmFt);
+
+                            var instance = doc.Create.NewFamilyInstance(
+                                point, symbol, level,
+                                Autodesk.Revit.DB.Structure.StructuralType.NonStructural);
+
+                            sub.Commit();
+                            created++;
+                            perItemResults.Add(new JObject
+                            {
+                                ["identity"] = identity,
+                                ["outcome"] = "created",
+                                ["elementId"] = instance.Id.IntegerValue,
+                            });
+                        }
+                        catch (Exception ex)
+                        {
+                            sub.RollBack();
+                            failed++;
+                            perItemResults.Add(new JObject
+                            {
+                                ["identity"] = identity,
+                                ["outcome"] = "failed",
+                                ["error"] = ex.Message,
+                            });
+                        }
+                    }
+                }
+
+                tx.Commit();
+            }
+
+            // 建立後逐一獨立查詢驗證存在（同步、確定性，不用 Idling 事件輪詢）。
+            foreach (var item in perItemResults.Where(i => (string)i["outcome"] == "created"))
+            {
+                var id = new ElementId(item["elementId"].Value<long>());
+                var verify = doc.GetElement(id);
+                item["verifiedExists"] = verify != null;
+            }
+
+            return new JObject
+            {
+                ["created"] = created,
+                ["failed"] = failed,
+                ["skipped"] = skipped,
+                ["duplicateToleranceMm"] = summary["duplicateToleranceMm"],
+                ["duplicateToleranceSource"] = summary["duplicateToleranceSource"],
+                ["items"] = perItemResults,
+            };
+        }
+```
+
+- [ ] **Step 2: Compile-check**
+
+Run: `dotnet build -c Release.R26 MCP\RevitMCP.csproj`
+Expected: build succeeds, zero warnings about unused `using` beyond pre-existing ones.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add MCP/Core/CadBlockPlacementExecutor.cs
+git commit -m "feat(cad-block-placement): add create with SubTransaction isolation + verified re-query"
+```
+
+---
+
+### Task 5: Wire the three commands into the dispatcher
+
+**Files:**
+- Modify: `MCP/Core/CommandExecutor.cs`
+
+- [ ] **Step 1: Add the switch cases**
+
+Find the existing DWG column module block (around the `case "create_columns_from_dwg":` line) and add a new banner block immediately after it:
+
+```csharp
+                // === CAD 圖塊點位放置模組（Block/INSERT → FamilyInstance，issue #100/#113）===
+                case "get_dwg_block_instances":
+                    result = CadBlockPlacementExecutor.GetDwgBlockInstances(_uiApp.ActiveUIDocument.Document, parameters);
+                    break;
+                case "preview_family_instances_from_dwg_blocks":
+                    result = CadBlockPlacementExecutor.PreviewFamilyInstancesFromDwgBlocks(_uiApp.ActiveUIDocument.Document, parameters);
+                    break;
+                case "create_family_instances_from_dwg_blocks":
+                    result = CadBlockPlacementExecutor.CreateFamilyInstancesFromDwgBlocks(_uiApp.ActiveUIDocument.Document, parameters);
+                    break;
+```
+
+- [ ] **Step 2: Compile-check**
+
+Run: `dotnet build -c Release.R26 MCP\RevitMCP.csproj`
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add MCP/Core/CommandExecutor.cs
+git commit -m "feat(cad-block-placement): register 3 commands in dispatcher"
+```
+
+---
+
+### Task 6: TS tool definitions + registry
+
+**Files:**
+- Create: `MCP-Server/src/tools/cad-block-placement-tools.ts`
+- Modify: `MCP-Server/src/tools/index.ts`
+
+**Interfaces:**
+- Produces: `export const cadBlockPlacementTools: Tool[]` with tool names `get_dwg_block_instances`, `preview_family_instances_from_dwg_blocks`, `create_family_instances_from_dwg_blocks` — must match the C# dispatcher case strings from Task 5 exactly.
+
+- [ ] **Step 1: Write the tool definitions**
+
+```typescript
+import { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * CAD 圖塊插入點批次放置 Revit 點位族群（灑水頭/閥件等）。
+ *
+ * 對應 C# 端 handler: MCP/Core/CadBlockPlacementExecutor.cs
+ * 對應 CommandExecutor.cs cases: get_dwg_block_instances / preview_family_instances_from_dwg_blocks / create_family_instances_from_dwg_blocks
+ * 對應 domain SOP: domain/cad-block-point-placement.md
+ *
+ * v1 只支援 Linked DWG、僅 OneLevelBased（non-hosted、level-based、point-placement）FamilySymbol。
+ */
+export const cadBlockPlacementTools: Tool[] = [
+    {
+        name: "get_dwg_block_instances",
+        description:
+            "掃描目前 Revit 平面視圖中已連結（Linked，非 Imported）的 CAD DWG，" +
+            "列出可辨識的 Block（INSERT）名稱、每種數量、插入點與旋轉角範例。" +
+            "唯讀操作，不建立任何 Revit 元素。使用前請確認 DWG 已用「連結」方式匯入。",
+        inputSchema: {
+            type: "object",
+            properties: {
+                importInstanceUniqueId: {
+                    type: "string",
+                    description:
+                        "（選填）指定要掃描的 ImportInstance UniqueId；未指定時取視圖內第一個 Linked ImportInstance",
+                },
+            },
+        },
+    },
+    {
+        name: "preview_family_instances_from_dwg_blocks",
+        description:
+            "對指定 Block 的每個插入點做座標鏈健檢（Block insertion point → Block transform → " +
+            "ImportInstance TotalTransform），回傳每點狀態：ready / duplicate_existing / duplicate_in_batch / " +
+            "unsupported_family / untrustworthy_transform，並攤開完整座標鏈供核對。" +
+            "唯讀操作，不建立任何 Revit 元素。transform 不可信時只回傳警告，不做任何猜測性修正。" +
+            "familySymbolId 與 levelId 必須明確指定，本工具不自動選擇。",
+        inputSchema: {
+            type: "object",
+            properties: {
+                importInstanceUniqueId: {
+                    type: "string",
+                    description: "（選填）指定要掃描的 ImportInstance UniqueId，比照 get_dwg_block_instances",
+                },
+                blockName: {
+                    type: "string",
+                    description: "從 get_dwg_block_instances 回傳清單中選擇的 Block 名稱，只處理此名稱的插入點",
+                },
+                familySymbolId: {
+                    type: "string",
+                    description: "目標 FamilySymbol 的 ElementId（字串）。必須是 non-hosted、level-based、OneLevelBased 族群",
+                },
+                levelId: {
+                    type: "string",
+                    description: "目標 Level 的 ElementId（字串）。Level 必須已存在，本工具不自動建立",
+                },
+                offsetMm: {
+                    type: "number",
+                    default: 0,
+                    description: "相對於 levelId 對應樓層的垂直偏移，單位為 mm（不是 Revit 內部的 feet）",
+                },
+                duplicateToleranceMm: {
+                    type: "number",
+                    description: "（選填）重複判定容差，單位 mm；未指定時預設 10mm",
+                },
+            },
+            required: ["familySymbolId", "levelId"],
+        },
+    },
+    {
+        name: "create_family_instances_from_dwg_blocks",
+        description:
+            "以與 preview_family_instances_from_dwg_blocks 完全相同的參數重新掃描來源後建立 FamilyInstance——" +
+            "不信任任何先前呼叫的快取結果。主 Transaction + 逐筆 SubTransaction，單筆失敗不影響其他已成功項目。" +
+            "duplicate 項目預設會被阻擋，只有明確傳入 skipDuplicates=true 才會略過（不得由 AI 自行推定使用者已核准）。" +
+            "unsupported_family／untrustworthy_transform 一律不建立。回傳每筆結果（created/failed/skipped）與建立後" +
+            "獨立查詢驗證的 verifiedExists。此操作會修改 Revit 模型，無法自動復原，請先呼叫 preview 確認再執行。",
+        inputSchema: {
+            type: "object",
+            properties: {
+                importInstanceUniqueId: {
+                    type: "string",
+                    description: "（選填）比照 preview，必須與該次 preview 使用的值一致",
+                },
+                blockName: {
+                    type: "string",
+                    description: "比照 preview，必須與該次 preview 使用的值一致",
+                },
+                familySymbolId: {
+                    type: "string",
+                    description: "比照 preview，必須與該次 preview 使用的值一致",
+                },
+                levelId: {
+                    type: "string",
+                    description: "比照 preview，必須與該次 preview 使用的值一致",
+                },
+                offsetMm: {
+                    type: "number",
+                    default: 0,
+                    description: "比照 preview，必須與該次 preview 使用的值一致",
+                },
+                duplicateToleranceMm: {
+                    type: "number",
+                    description: "比照 preview，必須與該次 preview 使用的值一致",
+                },
+                skipDuplicates: {
+                    type: "boolean",
+                    default: false,
+                    description:
+                        "使用者明確核准後才可設為 true，用來略過 duplicate_existing／duplicate_in_batch 項目。" +
+                        "AI 不得在使用者未表達核准的情況下自行設定此參數為 true",
+                },
+            },
+            required: ["familySymbolId", "levelId"],
+        },
+    },
+];
+```
+
+- [ ] **Step 2: Register in `MCP-Server/src/tools/index.ts`**
+
+Add the import near the other DWG-tool imports:
+
+```typescript
+import { cadBlockPlacementTools } from "./cad-block-placement-tools.js";
+```
+
+Add `cadBlockPlacementTools` to the `structural` profile array (same array `dwgColumnTools`/`dwgBeamTools` live in):
+
+```typescript
+structural: [baseTools, wallTools, visualizationTools, dwgColumnTools, dwgBeamTools, cadBlockPlacementTools, clashTools, structureTools, gradingTools, ifcStructuralSyncTools],
+```
+
+- [ ] **Step 3: TypeScript compile-check**
+
+Run: `cd MCP-Server && npm run build`
+Expected: `tsc` succeeds, no type errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add MCP-Server/src/tools/cad-block-placement-tools.ts MCP-Server/src/tools/index.ts
+git commit -m "feat(cad-block-placement): register 3 TS tool definitions"
+```
+
+---
+
+### Task 7: Sync source-of-truth counts and QA/QC gate
+
+**Files:**
+- Modify: `CLAUDE.md`
+- Modify: `README.md`
+- Modify: `README.zh-TW.md`
+- Modify: `docs/DOCUMENT_AUDIENCE_INVENTORY.md` (only if it carries a tool-count claim — check first)
+
+- [ ] **Step 1: Bump the runtime tool count**
+
+In `CLAUDE.md`'s "Current Source-of-Truth Counts" table, change:
+
+```markdown
+| Runtime MCP tools | 167 | `registerRevitTools()` from `MCP-Server/src/tools/index.ts` |
+```
+
+to:
+
+```markdown
+| Runtime MCP tools | 170 | `registerRevitTools()` from `MCP-Server/src/tools/index.ts` |
+```
+
+Apply the equivalent `167 → 170` edit to any matching `| Runtime MCP tools | N |`-style row in `README.md`, `README.zh-TW.md`, and `docs/DOCUMENT_AUDIENCE_INVENTORY.md` — grep for the exact current value first since wording may vary:
+
+```bash
+grep -rn "167" README.md README.zh-TW.md docs/DOCUMENT_AUDIENCE_INVENTORY.md
+```
+
+Update only lines that are genuinely a tool-count claim (not an unrelated "167" occurring elsewhere, e.g. a port number or version string).
+
+- [ ] **Step 2: Run the QA/QC gate**
+
+```powershell
+.\scripts\verify-qaqc.ps1 -SkipBuild -SkipDeploy
+```
+
+Expected: `PASS` on the cross-document count-alignment and count-table checks. If it fails, read the reported line and fix the mismatched file — do not silently ignore a FAIL.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CLAUDE.md README.md README.zh-TW.md docs/DOCUMENT_AUDIENCE_INVENTORY.md
+git commit -m "docs(count): sync tool count 167→170 for cad-block-placement 3-tool group"
+```
+
+---
+
+### Task 8: Full build, log entry, and live-Revit smoke-test checklist
+
+**Files:**
+- Modify: `log/2026-08.md`
+
+- [ ] **Step 1: Full build both sides**
+
+```powershell
+cd MCP-Server; npm run build; cd ..
+dotnet build -c Release.R24 MCP\RevitMCP.csproj
+dotnet build -c Release.R25 MCP\RevitMCP.csproj
+dotnet build -c Release.R26 MCP\RevitMCP.csproj
+```
+
+Expected: all succeed. (R22/R23 optional depending on installed SDKs — note in the log entry which configs were actually verified.)
+
+- [ ] **Step 2: Append the log entry**
+
+```markdown
+## [2026-08-10 HH:MM] feat | CAD 圖塊點位放置三工具實作（discover/preview/create, issue #100/#113）
+- actor: claude-sonnet-5 (via claude-code)
+- files: MCP/Core/CadBlockPlacementExecutor.cs, MCP/Core/CommandExecutor.cs, MCP-Server/src/tools/cad-block-placement-tools.ts, MCP-Server/src/tools/index.ts, domain/cad-block-point-placement.md, CLAUDE.md, README.md, README.zh-TW.md
+- trigger: manual
+- summary: 實作 get_dwg_block_instances / preview_family_instances_from_dwg_blocks / create_family_instances_from_dwg_blocks，工具數 167→170；尚未經真實 Revit + 已連結 DWG 的 runtime 驗證，見下方待辦
+```
+
+(Fill in the actual `HH:MM` at commit time — do not fabricate a timestamp ahead of when this step actually runs.)
+
+- [ ] **Step 3: Leave an explicit live-Revit verification checklist for whoever has Revit open next**
+
+This cannot be completed inside this plan — no Revit MCP connection is available in this environment. Add this checklist to the log entry (or a follow-up comment on issue #113) verbatim:
+
+```markdown
+### 待真人於 Revit 2024+ 驗證（本環境無法連線 Revit）
+- [ ] `get_dwg_block_instances` 對一個真實已連結 DWG 執行，確認 blockName 是否真的只能拿到 fallback 標籤，或有更精確名稱來源可用（見 Task 2 TryGetBlockDisplayName 的已知不確定性）
+- [ ] `preview_family_instances_from_dwg_blocks` 對至少一個 OneLevelBased 灑水頭/閥件族群跑過，確認 ready/duplicate/unsupported_family/untrustworthy_transform 四種狀態都至少觸發過一次（domain doc §6 提到這三種案例都還沒有實測記錄）
+- [ ] `create_family_instances_from_dwg_blocks` 建立後，用獨立的 get_element 之類唯讀查詢核對 verifiedExists，並確認 Offset 參數／實際 Z 座標是否符合預期（見 Task 4 「Offset-to-Z mechanic」已知不確定性）
+- [ ] 刻意用一個非 OneLevelBased 族群測試 unsupported_family 路徑
+- [ ] 刻意用一個非等比例縮放或已失連的 Linked DWG 測試 untrustworthy_transform 路徑
+- [ ] 確認 skipDuplicates=true 時的行為，以及未傳入時 duplicate 是否確實被阻擋
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add log/2026-08.md
+git commit -m "docs(log): record cad-block-placement 3-tool implementation + pending live-Revit checklist"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** §1 (preconditions) → Tasks 2-3 (Linked-only check, FamilySymbol/Level resolution). §2 (workflow/breakpoints) → Tasks 2-4 (three distinct tools, `create` re-scans via shared `BuildPlacementPlan`). §3 (transform trust) → Task 3 `CheckTransformTrust`. §4.1-4.5 → Task 3 (duplicate tolerance + status), Task 4 (skipDuplicates gating). §5 (v1 boundaries) → Task 3 (`unsupported_family`, no auto-select, no correction path exists in code at all). §6/§7 (known limits/QA checklist) → Task 8's live-Revit checklist covers the untested cases explicitly named in domain doc §6's TODOs.
+- **Placeholder scan:** no TBD/"add error handling"/"similar to Task N" left in; every step has literal code or literal shell commands.
+- **Type consistency:** `BlockCandidate` fields (`Identity`, `DisplayName`, `InsertionPoint`, `BlockTransform`, `TotalTransform`, `ResolvedPoint`, `RotationRadians`) declared in Task 2, consumed unchanged in Task 3's `BuildPlacementPlan`. Tool names (`get_dwg_block_instances`, `preview_family_instances_from_dwg_blocks`, `create_family_instances_from_dwg_blocks`) identical across Task 5's C# switch and Task 6's TS `name` fields — checked by hand, no drift.
+- **Explicitly not fabricated:** the 3 domain-doc TODOs the issue thread never resolved (Level auto-create, mermaid diagram, concrete failure-case test log) are left open in Task 1 rather than guessed at. The two Revit-API mechanics I'm not fully certain of are flagged both in the plan header and inline in the relevant code as comments, with a concrete live-Revit checklist in Task 8 rather than asserted as fact.

--- a/domain/cad-block-point-placement.md
+++ b/domain/cad-block-point-placement.md
@@ -10,6 +10,7 @@ metadata:
   references:
     - "Issue #100（作者 @NicheSam, SC REVIT）"
     - "Issue #100 留言 2026-08-05（id 5190268672）：四個 TODO 補值 + v1 政策裁決依據 + Revit 2024 A$C87ebd845 實測（484 筆命中／20 筆試放與獨立回查）"
+    - "Issue #113（三工具實作追蹤）"
   related:
     - dwg-column-import.md
     - dwg-beam-import.md

--- a/log/2026-08.md
+++ b/log/2026-08.md
@@ -275,3 +275,18 @@ git log --pretty=format:'%an' | sort -u
 ### 下次可接續的起手式
 
 先跑 `.\scripts\verify-qaqc.ps1 -SkipBuild -SkipDeploy` 確認仍是 60 PASS / 0 FAIL，再依優先序擇一：① 若使用者手上有含中文粉刷參數的專案模型 → 補完 #111 的核心演算法驗證（唯一還掛著的「已修但未完整驗證」項目）；② 否則開工 #112（`scan_opening_candidates`，規格最完整、且前置的 `csaSource.linkInstanceId` schema 已補）。動 Revit 前記得：測試模型一律不存檔。
+
+## [2026-08-10 12:29] feat | CAD 圖塊點位放置三工具實作（discover/preview/create, issue #100/#113）
+- actor: claude-sonnet-5 (via claude-code)
+- files: MCP/Core/CadBlockPlacementExecutor.cs, MCP/Core/CommandExecutor.cs, MCP-Server/src/tools/cad-block-placement-tools.ts, MCP-Server/src/tools/index.ts, domain/cad-block-point-placement.md, CLAUDE.md, README.md, README.zh-TW.md, docs/DOCUMENT_AUDIENCE_INVENTORY.md, docs/BIM_MCP/reference/*.html
+- trigger: manual
+- summary: 實作 get_dwg_block_instances / preview_family_instances_from_dwg_blocks / create_family_instances_from_dwg_blocks（掛 full + mep profiles），工具數 167→170；domain doc v0.1→v0.2 回填 issue #100 定案的 TODO（transform 可信度判定、10mm 重複容差、offsetMm 單位、OneLevelBased 判定、skipDuplicates 明確核准）；R22–R26 五組建置全過、verify-qaqc 59 PASS / 0 FAIL；**尚未經真實 Revit + 已連結 DWG 的 runtime 驗證**
+
+### 待真人於 Revit 2024+ 驗證（本環境無法連線 Revit）
+- [ ] `get_dwg_block_instances` 對真實已連結 DWG 執行，確認 blockName 來源（GraphicsStyleCategory 或 fallback 序號標籤）是否足以辨識 Block 種類（見 CadBlockPlacementExecutor.TryGetBlockDisplayName 的 KNOWN UNCERTAINTY 註解）
+- [ ] `preview_family_instances_from_dwg_blocks` 對至少一個 OneLevelBased 灑水頭/閥件族群跑過，確認 ready/duplicate/unsupported_family/untrustworthy_transform 狀態分佈合理
+- [ ] `create_family_instances_from_dwg_blocks` 建立後核對 verifiedExists，並確認 Offset 參數／實際 Z 座標是否符合預期（NewFamilyInstance 以 level.Elevation+offset 的 Z 傳入，Revit 的 offset 記帳需 read-back 驗證）
+- [ ] 刻意用非 OneLevelBased 族群測 unsupported_family 路徑
+- [ ] 刻意用非等比例縮放或已失連的 Linked DWG 測 untrustworthy_transform 路徑
+- [ ] 確認 skipDuplicates=true/未傳入 兩種情況的 duplicate 行為（未傳入必須阻擋）
+- [ ] SubTransaction 部分失敗隔離實測（issue #113 明列的必要驗收項：單筆失敗不回滾其他成功項目——規格來源的 08-05 實測通道並未套用 SubTransaction，此行為從未被驗證過）


### PR DESCRIPTION
## 重開說明

本 PR 是 **PR #114 的重開**：原 PR 由 bestwish1987-hash 開出，該帳號 2026-08-12 被 GitHub flag（404），PR 隨之消失（與先前 PR #71 同狀況）。同一位貢獻者，改用本帳號（Rumi-3653）續行。分支已 rebase 到 upstream/main `bae94d9`（tools 173 基底）。

## 內容：issue #113 三工具實作

實作 `domain/cad-block-point-placement.md` 規格的 CAD 圖塊點位放置三工具（tools 173→176）：

| 工具 | 性質 | 說明 |
|---|---|---|
| `get_dwg_block_instances` | discover，唯讀 | 盤點 Linked DWG 的 Block 實例：CAD 顯示名稱 + Revit identity（`candidateKey`）、project coordinates、rotation |
| `preview_family_instances_from_dwg_blocks` | preview，唯讀 | 回傳可查驗四點座標鏈 + `ready`/`duplicate_existing`/`duplicate_in_batch`/`unsupported_family`/`review_required` 狀態；transform 不可信即停止、不猜 correction；不建立任何元素 |
| `create_family_instances_from_dwg_blocks` | create，寫入 | 與 preview 同參數重掃驗證後，主 Transaction + 逐筆 SubTransaction 隔離（單筆失敗不回滾其他）；建立後逐一 re-query 驗證存在 |

- C#：`MCP/Core/CadBlockPlacementExecutor.cs` + `CommandExecutor.cs` dispatcher 3 cases
- TS：`MCP-Server/src/tools/cad-block-placement-tools.ts`，掛 full + mep 兩 profile
- rebase 時 domain 文件以上游 `274c914`（@NicheSam 08-05 留言回填版）為準，本分支只補回 Issue #113 參照，未動規格內文

## 驗證

- `npm run build` 過，`registerRevitTools()` runtime 計數 **176**
- `dotnet build` R22–R26 五組 0 errors（rebase 後重驗 R24/R26）
- `verify-qaqc.ps1 -SkipBuild -SkipDeploy`：**60 PASS / 0 FAIL / 0 WARN**（含 9-1 annotations、7-12 鏡像檢查）
- 計數宣稱 176/76/54 全站同步

## 已知未驗項（真機 Revit 待測）

驗收清單見 `log/2026-08.md` 08-10 12:29 條目，重點：

1. `TryGetBlockDisplayName` 的 blockName 來源（GraphicsStyleCategory / fallback 序號）對真實 DWG 是否足以辨識（KNOWN UNCERTAINTY 註解在程式內）
2. OneLevelBased 的 Offset 記帳（NewFamilyInstance 以 level.Elevation+offset 傳 Z，需 read-back 驗證）
3. SubTransaction 部分失敗隔離實測（#113 明列必要驗收項）
4. unsupported_family / untrustworthy_transform / duplicate 三條負向路徑

若 fork PR 過不了 CI 路徑白名單，照 #86/#102/#109 的 salvage 慣例收編也完全 OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
