### PR TITLE
fix(dwg-column-import): 梯形/任意四邊形 PolyLine 於 fallback 分支不再誤建矩形柱（#118）

### DIFF
--- a/MCP/Core/DwgColumnExecutor.cs
+++ b/MCP/Core/DwgColumnExecutor.cs
@@ -393,7 +393,22 @@ namespace RevitMCP.Core
                     var pts = pl.GetCoordinates().ToList();
                     var c = MakeRect(pts);                          // 嚴格矩形優先（向後相容）
                     if (c == null && pts.Count >= 3)                // 退而求其次：通用外接矩形
+                    {
+                        // #118：MakeRect 已判定「非嚴格矩形」。若去重後恰為 4 個獨立頂點，
+                        // 代表梯形／任意四邊形，通用外接矩形法會把它誤建成矩形柱，故略過不建，
+                        // 保留 diag 紀錄讓 preview 端可見（避免靜默漏建卻無跡可循）。
+                        var uniquePts = new List<XYZ>();
+                        foreach (var p in pts)
+                            if (!uniquePts.Any(q => p.DistanceTo(q) < 0.001))
+                                uniquePts.Add(p);
+                        if (uniquePts.Count == 4)
+                        {
+                            if (diag != null)
+                                diag.Add("skip PolyLine(" + pts.Count + "pt) non-rect quad (unique=4) — trapezoid/arbitrary quad, not built");
+                            continue;
+                        }
                         c = BuildColFromPoints(pts, LongestEdgeAngle(pts), diag, "PolyLine(" + pts.Count + "pt)");
+                    }
                     if (c != null) res.Add(c);
                 }
                 else if (obj is GeometryInstance gi)


### PR DESCRIPTION
## 說明

修正 #118：`Extract()` 的 PolyLine 退而求其次分支（`MakeRect` 判定非嚴格矩形後），對梯形／任意四邊形仍以通用外接矩形建柱，導致誤建尺寸不對的矩形柱。

## 修法

依 issue 回報者 @Roy-y111 的本機驗證提案：fallback 分支先以 0.001 ft 距離容差去除重複頂點，若恰餘 4 個獨立頂點（= MakeRect 已排除的非矩形四邊形，即梯形／任意四邊形），跳過不建；並寫入既有 `diag` 紀錄（preview 回應的 debug 欄位可見），避免靜默漏建無跡可循。

- 三角形與其他點數不受影響，仍走原 fallback。
- `MakeRect` 嚴格矩形路徑完全不變。
- 跳過紀錄格式：`skip PolyLine(Npt) non-rect quad (unique=4) — trapezoid/arbitrary quad, not built`。

## 驗證

- 本分支基於 upstream/main（bae94d9），僅含 `MCP/Core/DwgColumnExecutor.cs` 單檔 +15 行。
- `dotnet build -c Release.R24`：0 錯誤（另在本地 main 同內容以 R26 驗證 0 錯誤）。
- `scripts/verify-qaqc.ps1 -SkipBuild -SkipDeploy`：0 FAIL。

Fixes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)