### PR TITLE
docs(archicad): 補上 element-query pilot 的 live-test evidence 與兩項 runtime 缺陷

### DIFF
--- a/.claude/skills/archicad-skill-adapter/references/pilot-element-query.md
+++ b/.claude/skills/archicad-skill-adapter/references/pilot-element-query.md
@@ -79,6 +79,7 @@ property_source: BuiltIn property definitions resolved by name via GetPropertyId
   Wall_ReferenceLineLength -> 736276cc-0825-4738-a2e8-cdd740c7f635
   Wall_CenterLength        -> 6651c8de-502e-47f0-9a96-671a3c5255f2
 extract_sample: 4 Wall GUIDs from the final explore page, values returned
+  (values are display strings formatted by the project's calculation units; see finding 3)
   5cc16bbe-1d8a-4eb6-b5ab-0ed0f4b53770 -> 0.85 / 0.78
   ea3dc95e-2569-42a6-a99f-876288a4ff6a -> 4.70 / 4.63
   1d415f56-5909-44dc-93b6-603cce626832 -> 1.95 / 1.95
@@ -89,37 +90,93 @@ verification: read-only; no write command dispatched; no highlight applied,
 unsupported_steps: none required for this read path
 ```
 
-### Runtime findings from this run
+### Follow-up verification 2026-08-19
 
-1. `archicad_discover_tools` in this pinned runtime behaves as a case-insensitive
+Same project and port, read-only, to pin down what the returned numbers actually mean.
+
+```text
+project_get_calculation_units ->
+  length: Meter,       decimals 2
+  area:   SquareMeter, decimals 2
+  volume: CubicMeter,  decimals 2
+  angle:  DecimalDegree, decimals 0
+
+Same wall c69cf43d-cdf4-4870-a1d4-122b53c0eef0, two different layers:
+  property layer  Wall_ReferenceLineLength  = "18.96"
+                  Wall_NetInsideSurfaceArea = "56.87"
+                  Wall_InsideSlantAngle     = "90°"
+  geometry layer  slantAlpha                = 1.570796327
+                  begThickness/endThickness = 0.2
+```
+
+`"90°"` and `1.570796327` are the same angle. See finding 3.
+
+### Runtime findings
+
+> **Version scope.** All of this was observed on the pinned `tapir-archicad-mcp==0.4.3`
+> (released 2026-06-24) against Archicad 28 with Tapir Add-On 1.5.8. That pin is four
+> releases behind: `0.5.0`, `0.5.1`, `0.5.2`, `0.5.3` (2026-08-17) have shipped since.
+> Findings 1 and 2 are runtime behaviour and may already differ on `0.5.x` — treat them as
+> version-specific until re-tested. Findings 3, 4, 6 and 7 describe Archicad's own API
+> semantics and are not expected to change with the wrapper version.
+
+1. **(0.4.3, may be fixed upstream)** `archicad_discover_tools` behaves as a case-insensitive
    **literal substring match over command description text**, not the semantic search its
    own tool description advertises. Long application-neutral sentences return `[]`, including
    the tool's own documented example `get the currently selected elements`. The query
    `all elements` matches `CreateWalls`/`ModifyWalls` only because their description contains
    `Wall elements`, i.e. the substring `all elements`. Single broad words appear to cap at
    10 results ordered by command name.
-   Practical consequence: step 4.1's "describe the application-neutral operation" produces
-   false negatives here. Query short noun phrases that are likely to appear verbatim in a
-   command description (`given type`, `property names`, `all elements`, `details of`), and
+   Practical consequence on this pin: step 4.1's "describe the application-neutral operation"
+   produces systematic false negatives. Query short noun phrases likely to appear verbatim in
+   a command description (`given type`, `property names`, `all elements`, `details of`), and
    never read an empty result as proof that a capability is absent.
+   Note: `0.5.0` advertises a reworked tool-discovery mechanism (upstream issue #28), so this
+   finding should be re-tested before any pilot text is changed on account of it.
 
-2. Pagination sessions expire. An unscoped `elements_get_elements_by_type` walk over
-   `Wall` in this project succeeded for 16 consecutive pages (1600 GUIDs) and then returned
-   `Pagination session expired. Please start a new request.` This triggers the
-   "Pagination cannot be completed" Stop Condition above, so step 2's "follow pagination
-   until complete" is not achievable for large element types. Bound the scope first with a
-   discovered server-side filter (here `filters: ["OnActualFloor"]`), then exhaust pagination
-   within that scope.
+2. **(0.4.3, unverified on 0.5.x)** Pagination sessions expire. An unscoped
+   `elements_get_elements_by_type` walk over `Wall` succeeded for 16 consecutive pages
+   (1600 GUIDs) and then returned `Pagination session expired. Please start a new request.`
+   Page tokens also do not survive across turns. This triggers the "Pagination cannot be
+   completed" Stop Condition above. Bound the scope first with a discovered server-side
+   filter (here `filters: ["OnActualFloor"]`), then exhaust pagination within that scope.
 
-3. `GetPropertyValuesOfElements` returns `propertyValuesForElements` positionally and does
+3. **Units are a two-layer model, and the two layers disagree.** This is Archicad API
+   behaviour, not a wrapper artifact.
+   - The **property layer** (`GetPropertyValuesOfElements`) returns *display strings*
+     formatted by the project's **calculation units**, and those strings may carry a unit
+     symbol: this project returned `"90°"` for `Wall_InsideSlantAngle`.
+   - The **geometry layer** returns raw SI typed numbers: the same wall's `slantAlpha` is
+     `1.570796327` (radians) and its thickness is `0.2` (metres).
+   Consequences for any Domain that carries Revit-side units (the takeoff Domains compute in
+   mm): never assume a unit, never `parseFloat` a property string blindly, and call
+   `project_get_calculation_units` before converting. A project switched to centimetres would
+   return `"1896"` where this one returns `"18.96"`, with no error and no warning.
+   Archicad's *working units* are a separate setting again; no command to read them was found,
+   and nothing observed here follows them.
+
+4. `GetPropertyValuesOfElements` returns `propertyValuesForElements` positionally and does
    **not** echo the element GUID or the property GUID. The caller must preserve the request
    ordering to keep the GUID-to-value evidence chain intact.
 
-4. The `ElementFilter` enum (`IsEditable`, `OnActualFloor`, `IsVisibleByLayer`, ...) filters by
+5. **`elements_get_details_of_elements` is unusable on this pin.** A single Wall GUID returned
+   431 pydantic validation errors: the generated response models mark every per-type detail
+   variant `additionalProperties: false`, so fields the add-on has since added are rejected
+   rather than ignored. This is already tracked upstream as
+   [SzamosiMate/tapir-archicad-MCP#24](https://github.com/SzamosiMate/tapir-archicad-MCP/issues/24)
+   (open since 2026-07-23, reported there for Zone on Tapir 1.5.3 and Wall on 1.5.5).
+   Two points matter for this repository:
+   - The rejected payload **does** contain `flipped`, `referenceLineLocation`, `profileType`,
+     `slantAlpha`/`slantBeta`, the three material overrides and `floorPlanPolygons`. The data
+     exists; the wrapper discards it.
+   - `0.5.3` regenerates schemas against Tapir **1.5.7**, while this environment runs Tapir
+     **1.5.8**, so upgrading the pin may not be sufficient on its own.
+
+6. The `ElementFilter` enum (`IsEditable`, `OnActualFloor`, `IsVisibleByLayer`, ...) filters by
    visibility/editability state, not by element type. Element type selection comes only from
    the separate `elementType` enum.
 
-5. `elements_highlight_elements` carries its own clear path: passing an empty `elements`
+7. `elements_highlight_elements` carries its own clear path: passing an empty `elements`
    array removes all previously set highlights. The clear operation required by step 5 was
    confirmed from the schema without dispatching any highlight.
 

--- a/.claude/skills/archicad-skill-adapter/references/pilot-element-query.md
+++ b/.claude/skills/archicad-skill-adapter/references/pilot-element-query.md
@@ -53,6 +53,76 @@ result_guids: <count, not fabricated values>
 verification: read-only result or highlight cleared
 ```
 
+### Recorded run 2026-08-18
+
+```text
+backend: archicad
+canonical_skill: element-query
+agy_codex_mirror: .agents/skills/element-query/SKILL.md
+domain_method: domain/element-query-workflow.md
+adapter_reference: pilot-element-query.md
+runtime: tapir-archicad-mcp==0.4.3 (uvx), Archicad 28, Tapir Add-On 1.5.8
+project_port: 19723
+project: AC28 空白樣板20260709 (solo)
+discovered_commands:
+  explore: elements_get_elements_by_type, elements_get_all_elements
+  align:   elements_get_details_of_elements, properties_get_all_property_names,
+           properties_get_property_ids
+  extract: properties_get_property_values_of_elements
+  visualize (discovered, NOT dispatched): elements_highlight_elements
+result_guids: 304 Wall GUIDs, scope elementType=Wall + filters=["OnActualFloor"],
+              pagination exhausted (offsets 0/100/200 = 100 each, offset 300 = 4,
+              final page returned no next_page_token)
+              Unscoped project-wide Wall enumeration reached 1600 GUIDs over 16 pages
+              and then failed; see the Stop Conditions section above.
+property_source: BuiltIn property definitions resolved by name via GetPropertyIds
+  Wall_ReferenceLineLength -> 736276cc-0825-4738-a2e8-cdd740c7f635
+  Wall_CenterLength        -> 6651c8de-502e-47f0-9a96-671a3c5255f2
+extract_sample: 4 Wall GUIDs from the final explore page, values returned
+  5cc16bbe-1d8a-4eb6-b5ab-0ed0f4b53770 -> 0.85 / 0.78
+  ea3dc95e-2569-42a6-a99f-876288a4ff6a -> 4.70 / 4.63
+  1d415f56-5909-44dc-93b6-603cce626832 -> 1.95 / 1.95
+  6fd1a710-0de7-4321-9f4d-e741724af798 -> 17.50 / 17.50
+identifiers: Archicad GUID only; no Revit ElementId entered or left this chain
+verification: read-only; no write command dispatched; no highlight applied,
+              so no highlight had to be cleared
+unsupported_steps: none required for this read path
+```
+
+### Runtime findings from this run
+
+1. `archicad_discover_tools` in this pinned runtime behaves as a case-insensitive
+   **literal substring match over command description text**, not the semantic search its
+   own tool description advertises. Long application-neutral sentences return `[]`, including
+   the tool's own documented example `get the currently selected elements`. The query
+   `all elements` matches `CreateWalls`/`ModifyWalls` only because their description contains
+   `Wall elements`, i.e. the substring `all elements`. Single broad words appear to cap at
+   10 results ordered by command name.
+   Practical consequence: step 4.1's "describe the application-neutral operation" produces
+   false negatives here. Query short noun phrases that are likely to appear verbatim in a
+   command description (`given type`, `property names`, `all elements`, `details of`), and
+   never read an empty result as proof that a capability is absent.
+
+2. Pagination sessions expire. An unscoped `elements_get_elements_by_type` walk over
+   `Wall` in this project succeeded for 16 consecutive pages (1600 GUIDs) and then returned
+   `Pagination session expired. Please start a new request.` This triggers the
+   "Pagination cannot be completed" Stop Condition above, so step 2's "follow pagination
+   until complete" is not achievable for large element types. Bound the scope first with a
+   discovered server-side filter (here `filters: ["OnActualFloor"]`), then exhaust pagination
+   within that scope.
+
+3. `GetPropertyValuesOfElements` returns `propertyValuesForElements` positionally and does
+   **not** echo the element GUID or the property GUID. The caller must preserve the request
+   ordering to keep the GUID-to-value evidence chain intact.
+
+4. The `ElementFilter` enum (`IsEditable`, `OnActualFloor`, `IsVisibleByLayer`, ...) filters by
+   visibility/editability state, not by element type. Element type selection comes only from
+   the separate `elementType` enum.
+
+5. `elements_highlight_elements` carries its own clear path: passing an empty `elements`
+   array removes all previously set highlights. The clear operation required by step 5 was
+   confirmed from the schema without dispatching any highlight.
+
 ## Reference
 
 - [Terminology and boundary map](revit-archicad-terminology.md)


### PR DESCRIPTION
補上 issue #98 缺的 `element-query` pilot Live-Test Evidence。

全程只經 `archicad-mcp` 三支 MCP 工具（`discovery_list_active_archicads` / `archicad_discover_tools` / `archicad_call_tool`）跑完 pilot 六步，沒有直接打 JSON API 埠。全程唯讀，沒有派發任何寫入指令。

## 這個 PR 動到什麼

只改 `.claude/skills/archicad-skill-adapter/references/pilot-element-query.md` 一個檔案。原本的 evidence 模板保留未動，新增三個小節：

- `### Recorded run 2026-08-18` — 填上實際值的 evidence trace
- `### Follow-up verification 2026-08-19` — 單位契約的對照實驗
- `### Runtime findings` — 七項實測發現，含明確的版本適用範圍

## Evidence 摘要

| 欄位 | 值 |
|---|---|
| runtime | `tapir-archicad-mcp==0.4.3` / Archicad 28 / Tapir Add-On 1.5.8 |
| project_port | `19723` |
| result_guids | **304**（scope = `elementType:"Wall"` + `filters:["OnActualFloor"]`，分頁走完） |
| identifiers | 全程只有 Archicad GUID，沒有 Revit ElementId 進出 |
| verification | 唯讀；未派發寫入指令；未套用 highlight |

Domain 順序有保住。`domain/element-query-workflow.md` 那條「嚴禁猜測參數名稱」，在 Archicad 端是靠 `GetAllPropertyNames` → `GetPropertyIds` 把屬性名解析成 property GUID 來落實的。

## 最重要的一項：單位是兩層模型，而且兩層對不起來

這是 Archicad API 自己的設計，**與 MCP wrapper 版本無關**。同一面牆同時讀兩條路：

| 層 | 傾斜角 | 長度 | 厚度 |
|---|---|---|---|
| 屬性層 `GetPropertyValuesOfElements` | `"90°"` | `"18.96"` | — |
| 幾何層 | `1.570796327` | — | `0.2` |

- 屬性層回的是**依專案計算單位格式化的顯示字串**，而且**可能夾帶單位符號**
- 幾何層回的是**原始 SI 型別數字**

本專案計算單位是 `Meter` / 2 位小數 / 角度 `DecimalDegree`。若專案改成公分，同一面牆會回 `"1896"` 而非 `"18.96"`，**不會有任何錯誤或警告**。

由於算量 Domain 是以 mm 計算，這是會靜默算錯的風險。規則：換算前必須先呼叫 `project_get_calculation_units`，且不可直接 `parseFloat` 屬性字串。

## 關於另外兩項發現的版本限定（重要）

初版把 discovery 行為與分頁逾時當成「pilot 條文需要修訂」的理由。**這個判斷需要收回**：

repo 釘住的 `0.4.3` 發布於 2026-06-24，目前已落後四個版本（`0.5.3` 於 2026-08-17 發布）。其中 `0.5.0` 的 release notes 明確提到重做了 tool discovery 機制（對應上游已關閉的 issue #28）。

因此檔案裡這兩項已改為**明確標示為 0.4.3 特有、待重測**，不再作為修改 pilot 條文的依據。真正的建議是**升級釘選版本後重跑**。

## `GetDetailsOfElements` 已是上游既有 issue

單一 Wall GUID 回傳 431 個 pydantic validation errors。這已由 [SzamosiMate/tapir-archicad-MCP#24](https://github.com/SzamosiMate/tapir-archicad-MCP/issues/24) 追蹤（2026-07-23 開啟、仍 open）。

兩點對本 repo 有意義：

1. 被拒絕的 payload **確實含有** `flipped`、`referenceLineLocation`、`profileType`、`slantAlpha`/`slantBeta` 與 `floorPlanPolygons`。資料存在，是 wrapper 丟掉的。這與 `archicad-skill-translation-wave2.md` 第 6.4 節「缺少 Revit `Wall.Flipped` 等價值」的敘述不符。
2. `0.5.3` 的 schema 只對齊到 Tapir **1.5.7**，而本環境是 Tapir **1.5.8**——單純升級釘選版本未必足夠。

## 這個 PR 不改規範條文

只補證據與實測發現。版本升級、pilot 條文修訂、Wave 2 第 6 節的更正，都等維護者裁決後再另行處理。

## Revit 端未受影響

沒有呼叫任何 Revit MCP 工具，沒有變更 Revit 原始碼、埠 `8964`、安裝／部署腳本或 `revit-mcp` 設定。`.mcp.json` 與 `.vscode/mcp.json` 未納入本 PR。

Refs #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)
