### PR TITLE
docs(archicad): adapter 知識層 + 以 0.5.3 重評 Wave 2

### DIFF
--- a/.claude/skills/archicad-skill-adapter/SKILL.md
+++ b/.claude/skills/archicad-skill-adapter/SKILL.md
@@ -32,7 +32,9 @@ For every other Skill, consult `docs/integrations/archicad-skill-portability.md`
 - Treat writes as unverified until a follow-up read confirms the result.
 - Stop when no discovered command supports a required capability. Report the gap instead of inventing a payload.
 
-Read [references/revit-archicad-terminology.md](references/revit-archicad-terminology.md) before translating object names, properties, views, documentation objects, units, or identifiers.
+Read [references/revit-archicad-terminology.md](references/revit-archicad-terminology.md) before translating object names, properties, views, documentation objects, units, or identifiers. Numeric values in particular are not safe to pass through untouched: that file's unit contract explains why a returned number's unit depends on project settings and on which command produced it.
+
+Read [references/archicad-runtime-facts.md](references/archicad-runtime-facts.md) before concluding that a capability is missing. It records which commands are currently defective or absent per wrapper version, so that a wrapper defect is not filed as an Archicad limitation.
 
 ## Workflow
 
@@ -100,6 +102,7 @@ For an existing element-query workflow and the user request `查出 Archicad 目
 ## Reference
 
 - [Revit to Archicad terminology](references/revit-archicad-terminology.md)
+- [Archicad MCP runtime facts](references/archicad-runtime-facts.md)
 - [Element query pilot](references/pilot-element-query.md)
 - [Room and Zone numbering pilot](references/pilot-room-numbering.md)
 - [Quantity takeoff Excel pilot](references/pilot-quantity-takeoff-excel.md)

--- a/.claude/skills/archicad-skill-adapter/references/archicad-runtime-facts.md
+++ b/.claude/skills/archicad-skill-adapter/references/archicad-runtime-facts.md
@@ -154,6 +154,52 @@ invalidates an earlier "capability gap" conclusion, so check here before recordi
 | `mep_get_mep_preference_tables` | Circular cross-section preference tables for Piping and Ventilation — the closest Archicad analogue to a Revit pipe segment size catalog |
 | `elements_filter_elements`, `elements_get_collisions` | Both referenced by the Wave 2 plan; confirmed present |
 
+## Verified response shapes
+
+Dispatched on `0.5.3` against the test project, so these are observed rather than inferred from
+schemas. Re-verify before relying on them; the schema is the contract, this is only what one
+project actually returned.
+
+### `elements_get_relations_of_elements` on Zones
+
+Returns `zoneRelations` per input element:
+
+```text
+elementsGroupedByType : [{elementType, elements[]}]   Wall, Beam, Column, Door, Window observed
+wallParts             : [{elementId, roomEdgeIndex, begDistance, endDistance}]
+beamParts             : [{elementId, begDistance, endDistance}]
+curtainWallSegmentParts : []
+```
+
+`wallParts` is the important one. It states which segment of which wall forms which edge of the
+Zone polygon, which is the Archicad counterpart of a Revit room boundary segment. Two consequences:
+
+- A room-side test does not need ray casting. "Does this wall segment have a Zone on one side" is
+  answerable directly, and it does not depend on `elements_get_details_of_elements`, which is
+  currently broken.
+- A perimeter-based takeoff can source its evidence chain here: which walls bound a room, and over
+  what length of each.
+
+Distances are geometry-layer values, so metres, and `begDistance` can be negative where the wall
+runs past the start of the Zone edge.
+
+**Not every Zone returns relations.** Of seven Zones on the active story, six returned full
+relations and one returned an empty structure; `elements_get_zone_boundaries` was also empty for
+that Zone. An empty result must be reported as distinct from a Zone that genuinely has no
+boundaries, not silently dropped.
+
+### `project_get_hotlinks`
+
+Returns only `[{location}]` — a file path per hotlink node. No module name, and **no GUID
+ownership**, so it cannot answer which elements came from which hotlink. Any workflow that needs to
+separate host content from hotlinked content cannot get that from this command.
+
+Worth knowing when reading counts from any Archicad project: the test project used here reports 13
+hotlink nodes, all pointing at its own file. Element counts therefore include hotlinked content
+unless something else excludes it, and an unscoped `Wall` enumeration in this project showed a
+visible change of GUID format partway through, consistent with crossing from host elements into
+module elements. **State whether a count includes hotlinked content.**
+
 ## Element types decompose further than Revit categories
 
 `elements_get_elements_by_type` takes an `ElementType` enum with roughly seventy values. The trap

--- a/.claude/skills/archicad-skill-adapter/references/archicad-runtime-facts.md
+++ b/.claude/skills/archicad-skill-adapter/references/archicad-runtime-facts.md
@@ -1,0 +1,189 @@
+# Archicad MCP Runtime Facts
+
+## What this file is, and when to distrust it
+
+This records what the Archicad MCP runtime actually did when driven from this repository, as
+opposed to what its schemas and descriptions claim. Everything here has a shelf life: the
+wrapper, the Tapir Add-On and Archicad itself ship independently, so a fact that held for one
+combination can be wrong for the next.
+
+| Verified against | Value |
+|---|---|
+| Wrapper | `tapir-archicad-mcp` `0.4.3` and `0.5.3` (both observed; differences called out) |
+| Archicad | 28 |
+| Tapir Add-On | 1.5.8 |
+| Date | 2026-08-19 |
+| Project | one solo project, metric calculation units |
+
+`docs/integrations/archicad-mcp.md` currently pins `0.4.3`. `0.5.3` was tested separately and is
+**not** the pinned version; the sections below say which one they describe.
+
+Treat every command name here as a search hint, never as a contract. Re-discover before dispatch,
+exactly as `SKILL.md` requires. Nothing in this file removes that obligation.
+
+## Discovery works differently on each version
+
+**`0.5.x` — two-step, no search.**
+
+| Tool | Behaviour |
+|---|---|
+| `archicad_list_commands` | Takes no arguments. Returns the full command inventory with one-line descriptions. |
+| `archicad_get_command_schema` | Takes `command_name`. Returns that command's exact input schema. |
+| `archicad_call_tool` | Dispatch. Its own description now requires `archicad_get_command_schema` first. |
+
+Because there is no query, there are no false negatives. List everything, then read the schema of
+the command you picked.
+
+**`0.4.3` — one-step, and the search is not what it claims.**
+
+`archicad_discover_tools` took a query string and its description advertised semantic search. It
+behaved as a **case-insensitive literal substring match over command description text**:
+
+- `get the currently selected elements` — the tool's own documented example — returned `[]`.
+- `all elements` matched `CreateWalls` and `ModifyWalls`, because their descriptions contain
+  `Wall elements`, i.e. the substring `all elements`.
+- Broad single words appeared to cap at 10 results ordered by command name.
+
+On that version, query short noun phrases likely to appear verbatim in a description
+(`given type`, `property names`, `details of`), and never read an empty result as evidence that a
+capability is absent.
+
+`archicad_discover_tools` **does not exist on `0.5.3`**. `SKILL.md` step 4 and its tool table still
+name it; that instruction cannot be followed on the newer wrapper.
+
+## Discovery silently conflates two different failures
+
+`discovery_list_active_archicads` returns a bare `{"result": []}` when the Tapir Add-On is not
+loaded — the same response as when no Archicad is running at all. Observed with Archicad running
+and port 19723 listening: an unloaded Add-On still produced an empty array with no diagnostic.
+
+**Before concluding that no instance is available, confirm the Tapir Add-On is loaded.** Tracked
+upstream as [SzamosiMate/tapir-archicad-MCP#11](https://github.com/SzamosiMate/tapir-archicad-MCP/issues/11).
+
+## Known defect: `elements_get_details_of_elements` is unusable
+
+A single Wall GUID fails validation on both versions tested:
+
+| Wrapper | Tapir Add-On | Result |
+|---|---|---|
+| `0.4.3` | 1.5.8 | 431 validation errors |
+| `0.5.3` | 1.5.8 | 522 validation errors |
+
+The generated response models mark every per-type detail variant `additionalProperties: false`, so
+fields the Add-On has since added are rejected rather than ignored. Because the result is a union,
+each unmatched field is reported once per variant, so the error count tracks the number of
+supported variants rather than how far behind the schema is — `0.5.3` reports *more* errors while
+being *less* out of date.
+
+`0.5.3` did narrow the gap: `flipped` and `floorPlanPolygons` are accepted where `0.4.3` rejected
+them. Tapir 1.5.8 then added the next batch, currently rejected: `referenceLineLocation`,
+`profileType`, `slantAlpha`, `slantBeta`, `topOffset`, `relativeTopStory`, `zoneRel`, `visibility`,
+`isAutoOnStoryVisibility`, `referenceMaterial`, `oppositeMaterial`, `sideMaterial`, `cutFillPen`,
+`cutFillBackgroundPen`.
+
+Tracked upstream as
+[SzamosiMate/tapir-archicad-MCP#24](https://github.com/SzamosiMate/tapir-archicad-MCP/issues/24).
+
+**Consequence for planning.** Archicad does return `flipped` and `referenceLineLocation` — the
+wrapper discards them. Any assessment that concluded "Archicad exposes no equivalent of Revit's
+`Wall.Flipped`" was reading a wrapper defect as an API gap. The data exists; it is currently
+unreachable through this command. Do not plan a wall-orientation workflow around
+`elements_get_details_of_elements` until the upstream issue closes, and do not record the absence
+of exterior-side evidence as a permanent Archicad limitation.
+
+## Pagination
+
+- Page size is 100. `next_page_token` is base64 of the integer offset (`MTAw` = 100).
+- Absence of `next_page_token` is the only end-of-list signal, so a complete count is
+  `offset_of_final_page + len(final page)`.
+- On `0.4.3`, an unscoped `Wall` walk succeeded for 16 consecutive pages (1600 GUIDs) and then
+  returned `Pagination session expired. Please start a new request.` Tokens also failed when
+  reused a few minutes later in a separate turn with no intervening pages, which points at a
+  **time-based session TTL rather than a page-count limit**.
+- On `0.5.3`, a token survived a large intervening call. The walk was **not** run to completion, so
+  whether the TTL still exists is unresolved.
+
+**Working rule regardless of version:** bound the scope with a server-side filter first, then
+exhaust pagination inside that scope, and report the scope alongside the count. A count without its
+scope is not evidence.
+
+## Command inventory
+
+`archicad_list_commands` on `0.5.3` returned roughly 250 commands. Do not copy that list into a
+Skill — run the command. The families below exist so an application-neutral intent can be pointed
+at the right area quickly.
+
+| Family | Covers |
+|---|---|
+| `app_*` | Active window, Add-On version, special folders, alerts |
+| `attributes_*` | Layer, Line, Fill, Composite, Surface, Profile, Pen Table, Zone Category, MEP System, Building Material; folders; physical properties |
+| `classifications_*` | Systems, items, per-element classification, availability |
+| `components_*` | Element components and their property values |
+| `design_options_*` | Design options, sets, combinations (Archicad 29+) |
+| `elements_*` | Query, create, modify, delete, relations, collisions, bounding boxes, GDL parameters, highlight, selection |
+| `favorites_*` | Create, apply, rename, import/export Favorites |
+| `grouping_*` | Groups and Suspend Groups mode |
+| `ifc_*` | IFC ids, types, properties, file operations |
+| `issues_*` | Issues and BCF import/export |
+| `keynotes_*` | Keynote tree, items, folders, labels (Archicad 28+) |
+| `layout_*`, `navigator_*` | Layout Book, views, drawings, sections, publisher sets |
+| `library_*` | Loaded libraries, available library parts, embedded library |
+| `mep_*` | MEP elements, routing, ports, distribution systems, preference tables (Archicad 28+) |
+| `project_*` | Stories, calculation units, geo location, project info, open/save/close |
+| `properties_*` | Property definitions, groups, ids, values, availability |
+| `revisions_*` | Document revisions, changes, issues |
+| `solid_ops_*` | Solid element operation links |
+| `teamwork_*` | Reserve, release, send, receive |
+
+### Commands that change existing assessments
+
+These exist on `0.5.3` and did not on `0.4.3`, or were not found by its discovery. Each one
+invalidates an earlier "capability gap" conclusion, so check here before recording a new one.
+
+| Command | Why it matters |
+|---|---|
+| `elements_get_zone_boundaries` | Zone boundaries including connected elements and neighbour zones — the evidence a Zone-based takeoff needs |
+| `elements_get_relations_of_elements` | Wall/beam endpoint and reference-line connections, zone boundaries, the zones either side of a window or door, roofs and shells |
+| `elements_get_elements_related_to_zones` | Elements grouped by type per Zone |
+| `elements_get_subelements_of_hierarchical_elements` | Decomposes Stair and Railing into their subelements |
+| `properties_get_all_properties` | All user-defined and built-in properties in one call |
+| `properties_get_all_property_ids_of_elements` | Which properties are actually available on given elements |
+| `properties_get_property_definition_availability` | Which classification items a property is available for |
+| `classifications_get_classification_item_availability` | Which properties a classification item exposes |
+| `elements_get_gdl_parameters_of_elements` | Library Part parameters, the nearest thing to Revit type/instance parameters on objects |
+| `mep_get_mep_preference_tables` | Circular cross-section preference tables for Piping and Ventilation — the closest Archicad analogue to a Revit pipe segment size catalog |
+| `elements_filter_elements`, `elements_get_collisions` | Both referenced by the Wave 2 plan; confirmed present |
+
+## Element types decompose further than Revit categories
+
+`elements_get_elements_by_type` takes an `ElementType` enum with roughly seventy values. The trap
+is not the size of the list, it is that several Revit "single elements" are several Archicad
+elements:
+
+- A stair is `Stair` plus `Riser`, `Tread` and `StairStructure`.
+- A railing is `Railing` plus a dozen part types (`RailingPost`, `RailingBaluster`, `RailingPanel`,
+  `RailingSegment`, and so on).
+- A curtain wall is `CurtainWall` plus `CurtainWallSegment`, `Frame`, `Panel`, `Junction`,
+  `Accessory`.
+- Beams and columns also expose `BeamSegment` and `ColumnSegment`.
+
+Before any count or quantity, decide and state which granularity is being measured, and use
+`elements_get_subelements_of_hierarchical_elements` rather than guessing at the parent/child split.
+Counting parents and subelements together double-counts; counting only parents loses the parts a
+takeoff usually needs.
+
+`ElementFilter` (`IsEditable`, `OnActualFloor`, `IsVisibleByLayer`, `IsVisibleIn3D`, ...) filters by
+visibility and editability state. It is **not** a type filter — type selection comes only from the
+separate `elementType` argument.
+
+## Re-verification triggers
+
+Re-run the checks in this file when any of these change: the pinned wrapper version, the Tapir
+Add-On version, the Archicad major version, or the project's calculation units. Record the new
+combination in the table at the top rather than editing the old observations away.
+
+## Reference
+
+- [Terminology and boundary map](revit-archicad-terminology.md)
+- [Element query pilot](pilot-element-query.md)
+- `domain/tool-capability-boundary.md`

--- a/.claude/skills/archicad-skill-adapter/references/revit-archicad-terminology.md
+++ b/.claude/skills/archicad-skill-adapter/references/revit-archicad-terminology.md
@@ -6,9 +6,11 @@
 2. Core model terms
 3. Documentation and organization terms
 4. Data and collaboration terms
-5. Tool orchestration mapping
-6. Stop conditions
-7. Official terminology sources
+5. Which Archicad system owns this term
+6. Units and the numeric contract
+7. Tool orchestration mapping
+8. Stop conditions
+9. Official terminology sources
 
 ## Mapping rules
 
@@ -69,18 +71,88 @@
 | Workset | Teamwork reservation/workspace concepts | No 1:1 | Do not automate ownership changes without explicit scope. |
 | Design Option | Design Options | Approximate | Confirm current API/Add-On support. |
 | Shared Coordinates | Project Location / Survey Point / Project Origin concepts | No 1:1 | Require a coordinate-specific workflow and explicit unit verification. |
-| Internal feet | Tool-schema-defined Archicad units | No 1:1 | Never apply Revit unit conversion automatically. |
+| Internal feet | Two different Archicad layers, see [Units and the numeric contract](#units-and-the-numeric-contract) | No 1:1 | Never apply Revit unit conversion automatically, and never assume a returned number's unit. |
+
+## Which Archicad system owns this term
+
+Revit collapses almost all element data into "parameters". Archicad splits the same ground across
+three systems that are queried by different commands and follow different rules. Deciding which one
+owns the user's term is the first step of any translation; guessing produces empty results that
+look like missing data.
+
+| System | What it holds | How it is reached |
+|---|---|---|
+| **Property** | Per-element data values, both built-in and user-defined | Resolve name to id, then read values |
+| **Classification** | A separate semantic taxonomy the element is filed under | Classification systems and items |
+| **Attribute** | Project-wide named resources: Layer, Line, Fill, Composite, Surface, Profile, Pen Table, Zone Category, MEP System, Building Material | Attribute commands, by attribute type |
+| **Library Part parameter** | GDL parameters of Objects, Doors, Windows, Lamps | GDL parameter commands |
+
+Rules that have no Revit analogue:
+
+- **Property availability is driven by classification.** A property can exist in the project and
+  still be unavailable on a given element because of how that element is classified. An empty
+  property value is therefore ambiguous: it can mean "no value" or "not available here". Resolve
+  which, rather than reporting a blank.
+- **Built-in and user-defined properties are identified differently.** A built-in property is
+  identified by a single non-localized name. A user-defined property is identified by a two-part
+  localized name: the group name and the property name. A one-part name will not resolve a
+  user-defined property.
+- **Never type a property name by hand.** List the available properties, resolve the name to its
+  identifier, then read values by identifier. This is the Archicad form of the
+  `domain/element-query-workflow.md` rule that forbids guessing parameter names.
+- **An attribute is not a property.** Building Material and Surface are attributes, so questions
+  about materials are answered from the attribute side, not by looking for a material property.
+
+## Units and the numeric contract
+
+Archicad returns numbers through two layers that do not agree with each other. This is Archicad's
+own design, not an artifact of any wrapper version.
+
+| Layer | What it returns | Follows |
+|---|---|---|
+| **Property layer** | Display *strings*, which may embed a unit symbol | The project's **calculation units** |
+| **Geometry layer** | Typed numbers | Raw SI: metres, square metres, cubic metres, radians |
+
+Observed on one wall in a project whose calculation units were Meter with 2 decimals and
+DecimalDegree for angle:
+
+| | Slant angle | Reference line length | Thickness |
+|---|---|---|---|
+| Property layer | `"90°"` | `"18.96"` | — |
+| Geometry layer | `1.570796327` | — | `0.2` |
+
+`"90°"` and `1.570796327` are the same angle. The property layer had already converted radians to
+degrees and appended the symbol, because the project asked for degrees.
+
+Consequences, all of which produce silently wrong numbers rather than errors:
+
+- **Read the project's calculation units before converting anything.** The same wall returns
+  `"18.96"` in a metre project and `"1896"` in a centimetre one, with no error and no warning.
+- **Do not parse a property string as a bare number.** It can carry a unit symbol, and its decimal
+  places come from a project setting rather than from the value.
+- **Do not mix the two layers in one calculation.** A length from the property layer and a
+  thickness from the geometry layer are not necessarily in the same unit.
+- **Revit-side Domains carry Revit-side units.** The takeoff Domains in `domain/` compute in
+  millimetres. Feeding an Archicad metre value into one of those formulas is a factor-of-1000
+  error that every downstream total will inherit without complaint.
+- **Archicad working units are a third setting again.** They govern the drafting interface, no
+  command to read them was found, and nothing observed here follows them. A user saying "my project
+  is in centimetres" is usually describing working units, which is not what the API answers with.
+
+Report the unit basis alongside any quantity that leaves this adapter. A number without its unit
+basis is not evidence.
 
 ## Tool orchestration mapping
 
 | Revit-oriented Skill step | Archicad adapter step |
 |---|---|
-| Call a named Revit MCP tool | Search by application-neutral intent with `archicad_discover_tools`. |
+| Call a named Revit MCP tool | Resolve the intent against the current runtime, then dispatch. The discovery mechanism differs by wrapper version — see [archicad-runtime-facts.md](archicad-runtime-facts.md). |
 | Pass an ElementId | Pass a GUID returned by the selected Archicad instance. |
 | Pass a category name | Inspect whether the command expects element type, classification, or another enum. |
 | Use current Revit view | Discover the relevant Navigator/view command and anchor current Archicad state. |
 | Mutate then trust success | Re-read affected GUIDs and verify changed fields. |
 | Reuse a previous model result | Re-anchor project/port and fetch current state in this turn. |
+| Read a numeric parameter value | Establish the unit basis first; property values and geometry values are in different units. |
 
 ## Stop conditions
 

--- a/docs/integrations/archicad-skill-translation-wave2.md
+++ b/docs/integrations/archicad-skill-translation-wave2.md
@@ -6,6 +6,81 @@
 > 上游討論：[`shuotao/REVIT_MCP_study#98`](https://github.com/shuotao/REVIT_MCP_study/issues/98)
 > 本文件只定義下一批轉譯範圍；尚未授權或完成 Skill、Domain、MCP runtime 實作。
 
+## 0. 2026-08-19 實測重評（本節後補，原始內容未刪改）
+
+本文件建立於 2026-07-22，當時的能力判斷基於 `tapir-archicad-mcp==0.4.3`。
+2026-08-19 以 `0.5.3` + Archicad 28 + Tapir Add-On 1.5.8 實機重測後，
+下列判斷需要修正。原始章節保留未動，以便對照。
+
+| 原判斷 | 重測結果 |
+|---|---|
+| `wall-orientation-check` 只能走 capability-gap 人工檢查 | **前提不成立，建議升為 pilot**，見下方 (a) |
+| `detect-clashes` 縮限為 GUID pairs + 兩個 boolean | **維持**，schema 已確認，見下方 (b) |
+| Hotlink 不納入第一版 | **維持**，且已取得反面證據，見下方 (c) |
+| `element-coloring` 走暫時 Highlight | **維持**，但新增單位相關風險，見下方 (d) |
+
+### (a) `wall-orientation-check`：第 6.4 節的兩項「缺少的證據」其實都存在
+
+1. **`Wall.Flipped` 等價值存在。** Archicad 的 `GetDetailsOfElements` 回應中確實含有
+   `flipped` 與 `referenceLineLocation`。目前讀不到的原因是 MCP wrapper 的回應模型過期，
+   把新欄位當成不允許的多餘欄位丟棄（上游
+   [SzamosiMate/tapir-archicad-MCP#24](https://github.com/SzamosiMate/tapir-archicad-MCP/issues/24)，
+   `0.4.3` 與 `0.5.3` 皆失敗）。這是 wrapper 缺陷，不是 Archicad 的 API 缺口。
+
+2. **Revit Room-side 判斷有對應的 command chain。** `elements_get_relations_of_elements`
+   對 Zone 回傳 `zoneRelations`，內含 `wallParts`：
+
+   ```text
+   {elementId, roomEdgeIndex, begDistance, endDistance}
+   ```
+
+   即「這面牆的哪一段構成這個 Zone 的第幾條邊」，等同 Revit 的 room boundary segment。
+   「某牆某段的一側是否有 Zone」因此可直接判定，不需要 ray test，也不需要
+   目前壞掉的 `GetDetailsOfElements`。
+
+   實測：本專案目前樓層 7 個 Zone，其中 6 個回傳完整關係（含 Wall／Beam／Column／Door／
+   Window 分組），1 個回傳空關係。**空結果必須與「確實無邊界」區分後回報，不可省略。**
+
+   建議改寫方向：Archicad route 改走 Zone 關係路線，而非原規劃的 WallDetails 幾何路線；
+   驗收條件仍維持「不自動宣稱 correct／incorrect」，但可從人工檢查表升級為
+   有證據支撐的候選判定。
+
+### (b) `detect-clashes`：schema 已確認，補一個原文未載明的細節
+
+`elements_get_collisions` 的 `settings` 可以整個省略（預設 null），
+但**一旦給定，`volumeTolerance`、`performSurfaceCheck`、`surfaceTolerance` 三者皆為必填**。
+預設值分別為 `0.001`、`false`、`0.001`。其餘輸入與結果欄位與第 5.4 節記載一致。
+
+### (c) Hotlink：維持排除，且現在有反面證據
+
+`project_get_hotlinks` 只回傳 `location` 字串陣列，沒有模組名稱，也沒有任何
+GUID ownership 資訊，無法判斷哪些元素屬於哪個 hotlink。第 5.7 節要求
+「live test 同時證明 GUID ownership、project context 與 collision schema 可用」
+才可納入 —— 其中 GUID ownership 這項仍不成立，因此排除的判斷維持。
+
+附帶提醒：本次測試用的專案本身含 13 個 hotlink 節點，因此任何元素計數都必須
+聲明是否包含 hotlink 內容。未過濾的 `Wall` 列舉中，約位移 570 之後 GUID 格式明顯不同，
+研判即為 hotlink 模組內的元素。
+
+### (d) `element-coloring`：新增一項單位相關風險
+
+第 4.5 節第 5 步要求建立「Property value → GUID count」的分組表。
+Archicad 的 property 值是**依專案計算單位格式化的顯示字串**，可能夾帶單位符號
+（實測回傳 `"90°"`），小數位數也來自專案設定而非數值本身。
+
+因此以 property 值當分組鍵有兩個陷阱：
+
+- 兩個實際不同的數值可能格式化後相同而被併成同一組（例如 2 位小數下的 18.955 與 18.964）
+- 專案計算單位一改，分組鍵全部改變
+
+數值型 property 分組前必須先呼叫 `project_get_calculation_units` 並在報告中聲明單位基準。
+詳見 `.claude/skills/archicad-skill-adapter/references/revit-archicad-terminology.md`
+的「Units and the numeric contract」一節。
+
+另外，property 的可用性由 classification 決定，所以「空值」是有歧義的：
+可能是沒有值，也可能是該元素根本沒有這個 property。第 4.3 節第 3 點
+「不把未查到的元素或值編入結果」在 Archicad 需要進一步區分這兩種情況。
+
 ## 1. 決策摘要
 
 Wave 2 建議處理三個既有 canonical Skills：


### PR DESCRIPTION
補進 `archicad-skill-adapter` 的兩份知識層文件。與 #122 分開送，因為 #122 是單一 pilot 的實測證據，這裡是 adapter 本身的共用知識。

只動 `.claude/skills/archicad-skill-adapter/` 底下三個檔案，沒有碰 Revit 工具、設定、埠或建置。

## 1. 新增 `references/archicad-runtime-facts.md`

記錄 runtime **實際的行為**，而不是它的 schema 與描述所宣稱的行為。開頭掛驗證組合表（wrapper / Archicad / Tapir Add-On / 日期 / 專案），並明講這份文件有保存期限。

涵蓋：

- **discovery 機制在兩個版本完全不同**。`0.4.3` 的 `archicad_discover_tools` 實際是對指令描述做字面子字串比對（它自己文件裡的範例查詢會回空集合）；`0.5.3` 已移除該工具，改為 `archicad_list_commands` + `archicad_get_command_schema` 兩步，沒有查詢就沒有偽陰性。
- **`discovery_list_active_archicads` 會把兩種失敗混為一談**。Tapir Add-On 未載入時回傳的是乾淨的空陣列，與「沒有 Archicad 在跑」完全相同。實測：Archicad 執行中、埠 19723 監聽中，仍得到空陣列且無任何診斷訊息。對應上游 [#11](https://github.com/SzamosiMate/tapir-archicad-MCP/issues/11)。
- **`elements_get_details_of_elements` 目前不可用**，兩個版本皆然（`0.4.3` 431 個錯、`0.5.3` 522 個錯）。上游 [#24](https://github.com/SzamosiMate/tapir-archicad-MCP/issues/24) 追蹤中。
- 分頁語意、指令家族地圖、以及**會推翻既有「能力缺口」結論的那批指令**。

這份文件的目的寫在裡面：**避免把 wrapper 的缺陷登記成 Archicad 的限制**。

具體例子與本 repo 直接相關：`archicad-skill-translation-wave2.md` 第 6.4 節說 `wall-orientation-check` 做不了是因為「缺少 Revit `Wall.Flipped` 等價值」。但 Archicad **確實有回傳** `flipped` 與 `referenceLineLocation`，是 wrapper 的舊 schema 把它們當成多餘欄位丟棄。那不是 API 缺口，是 wrapper 缺陷。

## 2. `references/revit-archicad-terminology.md` 補上兩節

這兩節是 `SKILL.md` 早已聲明、但檔案裡一直沒有的內容——SKILL.md 要求「translating ... **units** ... 前先讀這份」，而它關於單位只有一行「Never apply Revit unit conversion automatically」。

### 「這個名詞歸哪個系統管」

Revit 把幾乎所有元素資料都收進「參數」；Archicad 拆成 Property／Classification／Attribute／Library Part 參數四套，各自用不同指令、遵守不同規則。新增三條沒有 Revit 對應的規則，其中最關鍵：

- **property 可用性由 classification 決定**，所以空值是有歧義的：可能是「沒有值」，也可能是「這個元素根本沒有這個屬性」。必須分辨，不能直接回報空白。
- **built-in 與 user-defined 的識別方式不同**：前者是單段非在地化名稱，後者是「群組名 + 屬性名」兩段式在地化名稱。用一段式名稱查 user-defined 屬性一定查不到。

### 「單位與數值契約」

Archicad 透過**兩層**回答數值，而兩層互相不一致。這是 Archicad 自己的設計，與 wrapper 版本無關。

同一面牆，計算單位為 Meter / 2 位小數 / 角度 DecimalDegree：

| 層 | 傾斜角 | 參考線長度 | 厚度 |
|---|---|---|---|
| 屬性層 | `"90°"` | `"18.96"` | — |
| 幾何層 | `1.570796327` | — | `0.2` |

`"90°"` 與 `1.570796327` 是同一個角度。屬性層已依專案計算單位把弧度轉成度數並附上符號。

會靜默算錯而不是報錯的後果：

- 同一面牆在公尺專案回 `"18.96"`，在公分專案回 `"1896"`，**沒有錯誤也沒有警告**
- 屬性字串可能夾帶單位符號，不可直接當數字 parse
- 兩層的數值不可混入同一次計算
- **`domain/` 的算量 Domain 全部以 mm 計算**，把 Archicad 的公尺值餵進去就是 1000 倍誤差，且會被所有下游總計繼承
- Archicad 的**工作單位**是第三個設定，沒有找到可讀取的指令，且觀察到的行為都不跟隨它——使用者說「我的專案是公分」通常指的是工作單位，那不是 API 回答的東西

## 沒有做的事

- **沒有改 `SKILL.md` 的工作流程步驟。** 它第 4 步仍寫呼叫 `archicad_discover_tools`，而該工具在 `0.5.3` 不存在。但本 repo 目前釘 `0.4.3`，所以它與自己是一致的。是否升級釘選版本是維護者的決定，我只在 runtime 事實檔中把這個矛盾記錄清楚。
- **沒有抄錄完整的指令清單與 ElementType enum。** 那等於自建一份會過期的副本，違背 adapter 自己「內部指令名稱不是穩定契約」的紅線。改為記錄家族地圖與判斷原則，完整清單請跑 `archicad_list_commands`。ElementType 只記錄會出錯的部分：樓梯、欄杆、帷幕牆在 Archicad 會拆成子元素，算量前必須先決定並聲明測量粒度。

## 驗證

`scripts/verify-qaqc.ps1 -SkipBuild -SkipDeploy` 通過（56 PASS / 0 FAIL）。本地 markdown 連結檢查由 48 增為 50 條，全數解析。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 追加（第 2 個 commit）：以 `0.5.3` 實機重評 Wave 2

`docs/integrations/archicad-skill-translation-wave2.md` 建立於 2026-07-22，其能力判斷基於 `0.4.3`。以 `0.5.3` + Archicad 28 + Tapir 1.5.8 重測後新增第 0 節記錄差異，**原有章節一字未改**，方便對照。

### 需要修正的一項：`wall-orientation-check`

第 6.4 節列出兩項「目前缺少的直接證據」，實測後**兩項都不成立**：

1. **`flipped` 存在。** Archicad 有回傳 `flipped` 與 `referenceLineLocation`，是 wrapper 的過期回應模型把它們丟棄。這是 wrapper 缺陷，不是 API 缺口。

2. **Revit room-side 判斷有對應的 command chain。** 對 Zone 派發 `elements_get_relations_of_elements`，回傳的 `wallParts` 形如：

   ```text
   {elementId, roomEdgeIndex, begDistance, endDistance}
   ```

   即「哪一面牆的哪一段構成這個 Zone 的第幾條邊」——等同 Revit 的 room boundary segment。「某牆某段的一側是否有 Zone」可直接判定，不需要 ray cast，也不依賴目前壞掉的 `elements_get_details_of_elements`。

   實測：目前樓層 7 個 Zone，6 個回傳完整關係（Wall／Beam／Column／Door／Window 分組），1 個回傳空結構——空結果必須與「確實無邊界」區分後回報。

   → 建議 `wall-orientation-check` 從「capability-gap 人工檢查」改為**可做的 pilot**，但改走 Zone 關係路線，而非原規劃的 WallDetails 幾何路線。

**這同一份回應對算量 pilot 同樣關鍵**：`wallParts` 就是「某房間周長由哪幾面牆的哪一段組成」的證據鏈。

### 維持不變的三項（但都補了證據）

- **`detect-clashes`** 維持縮限範圍。補一個原文未載明的細節：`settings` 可整個省略，但**一旦給定，三個欄位皆為必填**。
- **Hotlink** 維持排除，且現在有反面證據：`project_get_hotlinks` 只回 location 字串，沒有模組名稱也沒有 GUID ownership，第 5.7 節的前置條件仍不成立。
- **`element-coloring`** 維持暫時 Highlight 的框架，但新增一項單位風險：property 值是依專案計算單位格式化的**顯示字串**，用它當分組鍵會把不同數值併成同一組（2 位小數下 18.955 與 18.964 都是 `"18.96"`），且專案單位一改分組鍵全變。

### 一個影響所有計數的發現

測試專案本身含 **13 個 hotlink 節點**。因此該專案內任何元素計數都包含 hotlink 內容，除非另有排除。未過濾的 `Wall` 列舉中約位移 570 之後 GUID 格式明顯改變，研判即為跨入模組元素。**計數時必須聲明是否含 hotlink 內容。**

## 驗證（含第 2 個 commit）

`scripts/verify-qaqc.ps1 -SkipBuild -SkipDeploy` 通過（56 PASS / 0 FAIL）。

Refs #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)
