### PR TITLE
Issue #112：實作 scan_opening_candidates 唯讀開孔候選掃描

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ These counts must be derived from source, not copied by memory.
 
 | Item | Current Count | Source of Truth |
 |---|---:|---|
-| Runtime MCP tools | 173 | `registerRevitTools()` from `MCP-Server/src/tools/index.ts` |
+| Runtime MCP tools | 174 | `registerRevitTools()` from `MCP-Server/src/tools/index.ts` |
 | Domain SOP files | 76 | `domain/*.md` except `domain/README.md`, plus `domain/references/*.md` |
 | Claude skills | 54 | `.claude/skills/*/SKILL.md` |
 

--- a/MCP-Server/package.json
+++ b/MCP-Server/package.json
@@ -24,6 +24,7 @@
   },
   "scripts": {
     "build": "tsc && node scripts/build-apps.mjs",
+    "test:opening-candidate-contract": "node scripts/test-opening-candidate-contract.mjs",
     "start": "node build/index.js",
     "dev": "tsc && node build/index.js",
     "watch": "tsc --watch",

--- a/MCP-Server/scripts/test-opening-candidate-contract.mjs
+++ b/MCP-Server/scripts/test-opening-candidate-contract.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import { clashTools } from "../build/tools/clash-tools.js";
+import { withAnnotations } from "../build/tools/annotations.js";
+
+const tool = clashTools.find(({ name }) => name === "scan_opening_candidates");
+
+assert.ok(tool, "scan_opening_candidates must be registered in clashTools");
+assert.deepEqual(
+  tool.inputSchema.required,
+  ["mepSource", "structureSource", "clearanceMm"],
+  "the public contract must require both sources and an explicit clearanceMm",
+);
+assert.equal(tool.inputSchema.properties.clearanceMm.minimum, 0);
+assert.equal(tool.inputSchema.properties.maxCount.minimum, 1);
+assert.ok(tool.inputSchema.properties.levels, "levels must be available as an optional scope filter");
+assert.ok(tool.inputSchema.properties.categories, "categories must be available as an optional scope filter");
+
+const annotated = withAnnotations(tool);
+assert.equal(annotated.annotations?.readOnlyHint, true);
+assert.equal(annotated.annotations?.destructiveHint, false);
+
+console.log("opening candidate MCP contract: PASS");

--- a/MCP-Server/src/tools/clash-tools.ts
+++ b/MCP-Server/src/tools/clash-tools.ts
@@ -120,6 +120,59 @@ export const clashTools: Tool[] = [
         },
     },
     {
+        name: "scan_opening_candidates",
+        title: "Scan MEP Opening Candidates",
+        description: "唯讀掃描 MEP 管線穿越結構的開孔候選。沿用 detect_clashes 的 Curve-to-Solid 幾何核心，依明確的每側 clearanceMm 計算建議孔徑，並以 candidate / review_required 與 warningCodes 保守分流；不建立套管、開孔族群、標記或視圖圖形。",
+        inputSchema: {
+            type: "object",
+            properties: {
+                mepSource: {
+                    type: "object",
+                    description: "MEP 來源；語意同 detect_clashes.mepSource",
+                    properties: {
+                        linkInstanceId: { type: "number", description: "連結模型 ID；為 0 或省略時讀取主模型" },
+                        categories: {
+                            type: "array",
+                            items: { type: "string", enum: ["Pipes", "Ducts", "CableTrays", "Conduits"] },
+                        },
+                        filters: {
+                            type: "array",
+                            items: {
+                                type: "object",
+                                properties: {
+                                    field: { type: "string" },
+                                    operator: { type: "string", enum: ["equals", "contains", "not_equals", "less_than", "greater_than"] },
+                                    value: { type: "string" },
+                                },
+                                required: ["field", "operator", "value"],
+                            },
+                        },
+                    },
+                },
+                structureSource: {
+                    type: "object",
+                    description: "結構來源；語意同 detect_clashes.csaSource",
+                    properties: {
+                        linkInstanceId: { type: "number", description: "連結模型 ID；為 0 或省略時讀取主模型" },
+                        categories: {
+                            type: "array",
+                            items: { type: "string", enum: ["Walls", "Floors", "StructuralFraming", "StructuralColumns"] },
+                        },
+                    },
+                },
+                clearanceMm: { type: "number", minimum: 0, description: "開孔每一側的明確預留量（mm），無預設值" },
+                levels: { type: "array", items: { type: "string" }, description: "主模型樓層名稱篩選（選填）" },
+                categories: {
+                    type: "array",
+                    items: { type: "string", enum: ["Pipes", "Ducts", "CableTrays", "Conduits", "Walls", "Floors", "StructuralFraming", "StructuralColumns"] },
+                    description: "跨來源的品類子集篩選；會依 MEP／結構品類分流套用（選填）",
+                },
+                maxCount: { type: "number", minimum: 1, default: 1000, description: "最大回傳候選數" },
+            },
+            required: ["mepSource", "structureSource", "clearanceMm"],
+        },
+    },
+    {
         name: "colorize_clashes",
         description: "將 detect_clashes 的結果視覺化上色到 CSA 元素。colorScheme 可選 by_csa_category（柱紅/樑橘/板黃/牆藍）、by_system（依 MEP 系統）、by_severity（依貫穿深度嚴重度）。",
         inputSchema: {

--- a/MCP/Core/ClashDetector.cs
+++ b/MCP/Core/ClashDetector.cs
@@ -461,22 +461,6 @@ namespace RevitMCP.Core
                     }));
                 }
 
-                // 套用過濾
-                if (filters != null && filters.Count > 0)
-                {
-                    result = result.Where(ctx =>
-                    {
-                        foreach (var f in filters)
-                        {
-                            string field = f["field"]?.Value<string>();
-                            string op = f["operator"]?.Value<string>();
-                            string val = f["value"]?.Value<string>();
-                            string actual = GetParamValue(ctx.Element, ctx.Doc, field);
-                            if (!MatchFilterValue(actual, op, val)) return false;
-                        }
-                        return true;
-                    }).ToList();
-                }
             }
             else
             {
@@ -496,6 +480,23 @@ namespace RevitMCP.Core
                         Transform = Transform.Identity
                     }));
                 }
+            }
+
+            // Main-model and linked-model sources must honor the same filter contract.
+            if (filters != null && filters.Count > 0)
+            {
+                result = result.Where(ctx =>
+                {
+                    foreach (var f in filters)
+                    {
+                        string field = f["field"]?.Value<string>();
+                        string op = f["operator"]?.Value<string>();
+                        string val = f["value"]?.Value<string>();
+                        string actual = GetParamValue(ctx.Element, ctx.Doc, field);
+                        if (!MatchFilterValue(actual, op, val)) return false;
+                    }
+                    return true;
+                }).ToList();
             }
 
             return result;

--- a/MCP/Core/CommandExecutor.cs
+++ b/MCP/Core/CommandExecutor.cs
@@ -614,6 +614,9 @@ namespace RevitMCP.Core
                     case "detect_clashes":
                         result = DetectClashes(parameters);
                         break;
+                    case "scan_opening_candidates":
+                        result = ScanOpeningCandidates(parameters);
+                        break;
                     case "colorize_clashes":
                         result = ColorizeClashes(parameters);
                         break;
@@ -4373,6 +4376,12 @@ namespace RevitMCP.Core
         {
             var linkHelper = new LinkedModelHelper(_uiApp);
             return new ClashDetector(_uiApp, linkHelper).DetectClashes(parameters);
+        }
+
+        private object ScanOpeningCandidates(JObject parameters)
+        {
+            var linkHelper = new LinkedModelHelper(_uiApp);
+            return new OpeningCandidateScanner(_uiApp, linkHelper).Scan(parameters);
         }
 
         private object ColorizeClashes(JObject parameters)

--- a/MCP/Core/OpeningCandidateScanner.cs
+++ b/MCP/Core/OpeningCandidateScanner.cs
@@ -1,0 +1,412 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Autodesk.Revit.DB;
+using Autodesk.Revit.UI;
+using Newtonsoft.Json.Linq;
+
+#if REVIT2025_OR_GREATER
+using IdType = System.Int64;
+#else
+using IdType = System.Int32;
+#endif
+
+namespace RevitMCP.Core
+{
+    /// <summary>
+    /// Maps the existing ClashDetector result into the conservative, read-only
+    /// opening-candidate contract. It deliberately does not own a second clash engine.
+    /// </summary>
+    internal sealed class OpeningCandidateScanner
+    {
+        private const double MmPerFoot = 304.8;
+        private const double FaceDistanceToleranceFeet = 1.0 / MmPerFoot;
+        private const double OrthogonalityTolerance = 1e-6;
+
+        private readonly UIApplication _uiApp;
+        private readonly LinkedModelHelper _linkHelper;
+
+        public OpeningCandidateScanner(UIApplication uiApp, LinkedModelHelper linkHelper)
+        {
+            _uiApp = uiApp ?? throw new ArgumentNullException(nameof(uiApp));
+            _linkHelper = linkHelper ?? throw new ArgumentNullException(nameof(linkHelper));
+        }
+
+        public object Scan(JObject parameters)
+        {
+            if (!(parameters["mepSource"] is JObject mepSource))
+                throw new Exception("必須提供 mepSource 參數");
+            if (!(parameters["structureSource"] is JObject structureSource))
+                throw new Exception("必須提供 structureSource 參數");
+            if (parameters["clearanceMm"] == null || parameters["clearanceMm"].Type == JTokenType.Null)
+                throw new Exception("必須提供明確的 clearanceMm；本工具不會套用預設預留量");
+
+            double clearanceMm = parameters["clearanceMm"].Value<double>();
+            if (clearanceMm < 0)
+                throw new Exception("clearanceMm 不可小於 0");
+
+            int maxCount = parameters["maxCount"]?.Value<int>() ?? 1000;
+            if (maxCount < 1)
+                throw new Exception("maxCount 必須大於或等於 1");
+
+            JObject scopedMep = (JObject)mepSource.DeepClone();
+            JObject scopedStructure = (JObject)structureSource.DeepClone();
+            if (!(scopedMep["categories"] is JArray) && scopedMep["category"] == null)
+                scopedMep["categories"] = new JArray("Pipes", "Ducts", "CableTrays", "Conduits");
+            ApplyCategoryScope(parameters["categories"] as JArray, scopedMep, scopedStructure);
+
+            var detectParameters = new JObject
+            {
+                ["mepSource"] = scopedMep,
+                ["csaSource"] = scopedStructure,
+                ["options"] = new JObject
+                {
+                    ["useCoarseFilter"] = true,
+                    ["maxResults"] = maxCount
+                }
+            };
+
+            object raw = new ClashDetector(_uiApp, _linkHelper).DetectClashes(detectParameters);
+            JObject clashResult = JObject.FromObject(raw);
+            JArray clashes = clashResult["Clashes"] as JArray ?? new JArray();
+
+            Document projectDoc = _uiApp.ActiveUIDocument.Document;
+            SourceContext mepContext = ResolveSource(projectDoc, scopedMep);
+            SourceContext hostContext = ResolveSource(projectDoc, scopedStructure);
+            var levelNames = new HashSet<string>(
+                (parameters["levels"] as JArray)?.Values<string>() ?? Enumerable.Empty<string>(),
+                StringComparer.OrdinalIgnoreCase);
+            var projectLevels = new FilteredElementCollector(projectDoc)
+                .OfClass(typeof(Level))
+                .Cast<Level>()
+                .OrderBy(level => level.Elevation)
+                .ToList();
+
+            var candidates = new JArray();
+            var failures = new JArray();
+            int sourceIndex = 0;
+
+            foreach (JObject clash in clashes.OfType<JObject>())
+            {
+                sourceIndex++;
+                try
+                {
+                    JObject candidate = MapCandidate(
+                        clash,
+                        sourceIndex,
+                        clearanceMm,
+                        projectLevels,
+                        mepContext,
+                        hostContext);
+
+                    string resolvedLevel = candidate["openingBottom"]?["projectLevelName"]?.Value<string>();
+                    if (levelNames.Count > 0 && (resolvedLevel == null || !levelNames.Contains(resolvedLevel)))
+                        continue;
+
+                    candidates.Add(candidate);
+                }
+                catch (Exception ex)
+                {
+                    failures.Add(new JObject
+                    {
+                        ["sourceClashIndex"] = sourceIndex,
+                        ["reason"] = ex.Message,
+                        ["suggestedAction"] = "確認來源 Link 已載入、元素仍存在且幾何可讀後重新掃描"
+                    });
+                }
+            }
+
+            return new JObject
+            {
+                ["totalCandidates"] = candidates.Count,
+                ["reviewRequiredCount"] = candidates.Count(c => c["status"]?.Value<string>() == "review_required"),
+                ["candidateCount"] = candidates.Count(c => c["status"]?.Value<string>() == "candidate"),
+                ["failedCount"] = failures.Count,
+                ["clearanceMmPerSide"] = clearanceMm,
+                ["mepElementCount"] = clashResult["MepElementCount"] ?? 0,
+                ["structureElementCount"] = clashResult["CsaElementCount"] ?? 0,
+                ["candidates"] = candidates,
+                ["failures"] = failures
+            };
+        }
+
+        private JObject MapCandidate(
+            JObject clash,
+            int index,
+            double clearanceMm,
+            IList<Level> projectLevels,
+            SourceContext mepContext,
+            SourceContext hostContext)
+        {
+            IdType mepId = clash["MepElement"]?["Id"]?.Value<IdType>() ?? 0;
+            IdType hostId = clash["CsaElement"]?["Id"]?.Value<IdType>() ?? 0;
+            Element mep = mepContext.Document.GetElement(new ElementId(mepId));
+            Element host = hostContext.Document.GetElement(new ElementId(hostId));
+            if (mep == null) throw new Exception($"找不到穿管元素 {mepId}");
+            if (host == null) throw new Exception($"找不到結構元素 {hostId}");
+
+            XYZ entry = ReadPoint(clash["Intersection"]?["EntryPoint"]);
+            XYZ exit = ReadPoint(clash["Intersection"]?["ExitPoint"]);
+            XYZ center = (entry + exit) * 0.5;
+            XYZ direction = (exit - entry).Normalize();
+            double lengthMm = clash["Intersection"]?["PenetrationLength"]?.Value<double>() ?? 0;
+
+            string mepCategory = GetCanonicalCategory(mep);
+            string hostCategory = GetCanonicalCategory(host);
+            JObject size = BuildSuggestedSize(mep, mepCategory, clearanceMm);
+            XYZ hostNormal = TryResolveHostNormal(host, hostContext.Transform, entry, exit);
+            double? deviationDegrees = hostNormal == null
+                ? (double?)null
+                : Math.Acos(Math.Min(1.0, Math.Abs(direction.DotProduct(hostNormal)))) * 180.0 / Math.PI;
+
+            var warnings = new JArray();
+            if (hostCategory == "StructuralFraming") warnings.Add("structural_framing_review");
+            if (hostCategory == "StructuralColumns") warnings.Add("structural_column_review");
+            if (hostNormal == null)
+                warnings.Add("host_normal_unresolved");
+            else if (Math.Abs(direction.DotProduct(hostNormal)) < 1.0 - OrthogonalityTolerance)
+                warnings.Add("oblique_penetration");
+            if (lengthMm < 10.0) warnings.Add("short_intersection");
+            if (!HasResolvedSize(size)) warnings.Add("size_data_missing");
+
+            JObject openingBottom = BuildOpeningBottom(center, size, projectLevels);
+            if (openingBottom["projectElevationMm"].Type == JTokenType.Null ||
+                openingBottom["projectLevelName"].Type == JTokenType.Null)
+                warnings.Add("opening_bottom_unresolved");
+
+            return new JObject
+            {
+                ["candidateId"] = $"OC-{index:D3}",
+                ["revitLookup"] = new JObject
+                {
+                    ["penetratingElement"] = BuildLookup(mepId, mepContext),
+                    ["hostElement"] = BuildLookup(hostId, hostContext)
+                },
+                ["entry"] = PointJson(entry),
+                ["exit"] = PointJson(exit),
+                ["center"] = PointJson(center),
+                ["intersectionLengthMm"] = Math.Round(lengthMm, 2),
+                ["orthogonalityDeviationDegrees"] = deviationDegrees.HasValue
+                    ? new JValue(Math.Round(deviationDegrees.Value, 6))
+                    : JValue.CreateNull(),
+                ["mepCategory"] = mepCategory,
+                ["hostCategory"] = hostCategory,
+                ["suggestedOpeningSize"] = size,
+                ["openingBottom"] = openingBottom,
+                ["status"] = warnings.Count == 0 ? "candidate" : "review_required",
+                ["warningCodes"] = warnings
+            };
+        }
+
+        private static void ApplyCategoryScope(JArray categories, JObject mepSource, JObject structureSource)
+        {
+            if (categories == null || categories.Count == 0) return;
+
+            var mep = new HashSet<string>(new[] { "Pipes", "Ducts", "CableTrays", "Conduits" }, StringComparer.OrdinalIgnoreCase);
+            var structure = new HashSet<string>(new[] { "Walls", "Floors", "StructuralFraming", "StructuralColumns" }, StringComparer.OrdinalIgnoreCase);
+            var mepSelection = new JArray(categories.Values<string>().Where(value => mep.Contains(value)));
+            var structureSelection = new JArray(categories.Values<string>().Where(value => structure.Contains(value)));
+            if (mepSelection.Count > 0) mepSource["categories"] = mepSelection;
+            if (structureSelection.Count > 0) structureSource["categories"] = structureSelection;
+        }
+
+        private SourceContext ResolveSource(Document projectDoc, JObject source)
+        {
+            IdType linkInstanceId = source["linkInstanceId"]?.Value<IdType>() ?? 0;
+            if (linkInstanceId == 0)
+                return new SourceContext(projectDoc, Transform.Identity, 0);
+
+            var data = _linkHelper.GetLinkData(linkInstanceId);
+            if (data.Item2 == null)
+                throw new Exception($"Link {linkInstanceId} 未載入");
+            return new SourceContext(data.Item2, data.Item3, linkInstanceId);
+        }
+
+        private static JObject BuildLookup(IdType elementId, SourceContext context)
+        {
+            if (context.LinkInstanceId == 0)
+            {
+                return new JObject
+                {
+                    ["documentKind"] = "main",
+                    ["elementId"] = elementId
+                };
+            }
+
+            return new JObject
+            {
+                ["documentKind"] = "link",
+                ["linkInstanceId"] = context.LinkInstanceId,
+                ["linkedElementId"] = elementId
+            };
+        }
+
+        private static JObject BuildSuggestedSize(Element mep, string category, double clearanceMm)
+        {
+            double? diameterMm = null;
+            double? widthMm = null;
+            double? heightMm = null;
+            string shape;
+
+            if (category == "Pipes" || category == "Conduits")
+            {
+                shape = "round";
+                double? nominal = ReadLengthMm(mep, "Diameter", "直徑", "Nominal Diameter", "標稱直徑");
+                if (nominal.HasValue) diameterMm = nominal.Value + 2.0 * clearanceMm;
+            }
+            else
+            {
+                shape = "rectangular";
+                double? nominalWidth = ReadLengthMm(mep, "Width", "寬度");
+                double? nominalHeight = ReadLengthMm(mep, "Height", "高度");
+                if (nominalWidth.HasValue) widthMm = nominalWidth.Value + 2.0 * clearanceMm;
+                if (nominalHeight.HasValue) heightMm = nominalHeight.Value + 2.0 * clearanceMm;
+            }
+
+            return new JObject
+            {
+                ["shape"] = shape,
+                ["unit"] = "mm",
+                ["diameterMm"] = diameterMm.HasValue ? new JValue(Math.Round(diameterMm.Value, 2)) : JValue.CreateNull(),
+                ["widthMm"] = widthMm.HasValue ? new JValue(Math.Round(widthMm.Value, 2)) : JValue.CreateNull(),
+                ["heightMm"] = heightMm.HasValue ? new JValue(Math.Round(heightMm.Value, 2)) : JValue.CreateNull(),
+                ["clearanceMmPerSide"] = clearanceMm
+            };
+        }
+
+        private static bool HasResolvedSize(JObject size)
+        {
+            return size["shape"]?.Value<string>() == "round"
+                ? size["diameterMm"].Type != JTokenType.Null
+                : size["widthMm"].Type != JTokenType.Null && size["heightMm"].Type != JTokenType.Null;
+        }
+
+        private static double? ReadLengthMm(Element element, params string[] names)
+        {
+            Element type = element.Document.GetElement(element.GetTypeId());
+            foreach (string name in names)
+            {
+                Parameter parameter = element.LookupParameter(name) ?? type?.LookupParameter(name);
+                if (parameter != null && parameter.StorageType == StorageType.Double && parameter.HasValue)
+                {
+                    double value = parameter.AsDouble();
+                    if (value > 0) return value * MmPerFoot;
+                }
+            }
+            return null;
+        }
+
+        private static JObject BuildOpeningBottom(XYZ center, JObject size, IList<Level> levels)
+        {
+            double? openingHeightMm = size["shape"]?.Value<string>() == "round"
+                ? size["diameterMm"]?.Value<double?>()
+                : size["heightMm"]?.Value<double?>();
+
+            double? bottomMm = openingHeightMm.HasValue
+                ? center.Z * MmPerFoot - openingHeightMm.Value / 2.0
+                : (double?)null;
+            Level level = bottomMm.HasValue
+                ? levels.LastOrDefault(item => item.Elevation * MmPerFoot <= bottomMm.Value + 0.01)
+                : null;
+
+            return new JObject
+            {
+                ["basis"] = "opening_bottom_edge",
+                ["projectLevelName"] = level != null ? new JValue(level.Name) : JValue.CreateNull(),
+                ["projectElevationMm"] = bottomMm.HasValue ? new JValue(Math.Round(bottomMm.Value, 2)) : JValue.CreateNull(),
+                ["offsetFromLevelMm"] = bottomMm.HasValue && level != null
+                    ? new JValue(Math.Round(bottomMm.Value - level.Elevation * MmPerFoot, 2))
+                    : JValue.CreateNull()
+            };
+        }
+
+        private static XYZ TryResolveHostNormal(Element host, Transform transform, XYZ entry, XYZ exit)
+        {
+            PlanarFace bestFace = null;
+            double bestDistance = double.MaxValue;
+            foreach (Solid solid in GetTransformedSolids(host, transform))
+            {
+                foreach (Face face in solid.Faces)
+                {
+                    if (!(face is PlanarFace planar)) continue;
+                    foreach (XYZ point in new[] { entry, exit })
+                    {
+                        IntersectionResult projection = face.Project(point);
+                        if (projection != null && projection.Distance <= FaceDistanceToleranceFeet && projection.Distance < bestDistance)
+                        {
+                            bestFace = planar;
+                            bestDistance = projection.Distance;
+                        }
+                    }
+                }
+            }
+            return bestFace?.FaceNormal.Normalize();
+        }
+
+        private static IEnumerable<Solid> GetTransformedSolids(Element element, Transform transform)
+        {
+            var result = new List<Solid>();
+            GeometryElement geometry = element.get_Geometry(new Options { DetailLevel = ViewDetailLevel.Fine });
+            if (geometry == null) return result;
+            foreach (GeometryObject item in geometry)
+            {
+                if (item is Solid solid && solid.Volume > 0)
+                    result.Add(SolidUtils.CreateTransformed(solid, transform));
+                else if (item is GeometryInstance instance)
+                {
+                    foreach (GeometryObject nested in instance.GetInstanceGeometry(transform))
+                        if (nested is Solid nestedSolid && nestedSolid.Volume > 0) result.Add(nestedSolid);
+                }
+            }
+            return result;
+        }
+
+        private static string GetCanonicalCategory(Element element)
+        {
+            IdType id = element.Category?.Id.GetIdValue() ?? 0;
+            if (id == (IdType)BuiltInCategory.OST_PipeCurves) return "Pipes";
+            if (id == (IdType)BuiltInCategory.OST_DuctCurves) return "Ducts";
+            if (id == (IdType)BuiltInCategory.OST_CableTray) return "CableTrays";
+            if (id == (IdType)BuiltInCategory.OST_Conduit) return "Conduits";
+            if (id == (IdType)BuiltInCategory.OST_Walls) return "Walls";
+            if (id == (IdType)BuiltInCategory.OST_Floors) return "Floors";
+            if (id == (IdType)BuiltInCategory.OST_StructuralFraming) return "StructuralFraming";
+            if (id == (IdType)BuiltInCategory.OST_StructuralColumns) return "StructuralColumns";
+            return element.Category?.Name ?? "Unknown";
+        }
+
+        private static XYZ ReadPoint(JToken point)
+        {
+            if (point == null) throw new Exception("碰撞結果缺少交點座標");
+            return new XYZ(
+                (point["X"]?.Value<double>() ?? 0) / MmPerFoot,
+                (point["Y"]?.Value<double>() ?? 0) / MmPerFoot,
+                (point["Z"]?.Value<double>() ?? 0) / MmPerFoot);
+        }
+
+        private static JObject PointJson(XYZ point)
+        {
+            return new JObject
+            {
+                ["x"] = Math.Round(point.X * MmPerFoot, 2),
+                ["y"] = Math.Round(point.Y * MmPerFoot, 2),
+                ["z"] = Math.Round(point.Z * MmPerFoot, 2),
+                ["unit"] = "mm"
+            };
+        }
+
+        private sealed class SourceContext
+        {
+            public SourceContext(Document document, Transform transform, IdType linkInstanceId)
+            {
+                Document = document;
+                Transform = transform;
+                LinkInstanceId = linkInstanceId;
+            }
+
+            public Document Document { get; }
+            public Transform Transform { get; }
+            public IdType LinkInstanceId { get; }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Revit MCP lets AI clients call Autodesk Revit tools through the Model Context Pr
 
 ## What is this?
 
-Talk to Revit in plain language. Ask your AI client to *"dimension every wall on this view"* or *"check the curtain-wall elevations"*, and Revit does it — through **173 MCP tools** backed by **76 professional BIM SOPs** (building code, quantity take-off, compliance checks).
+Talk to Revit in plain language. Ask your AI client to *"dimension every wall on this view"* or *"check the curtain-wall elevations"*, and Revit does it — through **174 MCP tools** backed by **76 professional BIM SOPs** (building code, quantity take-off, compliance checks).
 
 **Who it's for:** BIM engineers and architects who use Revit and want AI-assisted, standards-based workflows. You'll need Revit (2022–2026) on Windows and to be comfortable installing an add-in.
 
@@ -33,7 +33,7 @@ Questions or want to show what you built? → **[Discussions](https://github.com
 
 | Item | Count | Source |
 |---|---:|---|
-| Runtime MCP tools | 173 | `registerRevitTools()` in `MCP-Server/src/tools/index.ts` |
+| Runtime MCP tools | 174 | `registerRevitTools()` in `MCP-Server/src/tools/index.ts` |
 | Domain SOP files | 76 | `domain/*.md` except `README.md`, plus `domain/references/*.md` |
 | Claude skills | 54 | `.claude/skills/*/SKILL.md` |
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -14,7 +14,7 @@ Revit MCP 透過 Model Context Protocol (MCP) 讓 AI Client 呼叫 Revit 工具�
 
 ## 這是什麼？
 
-用講人話的方式操作 Revit。跟你的 AI Client 說「幫這個視圖的牆全部標尺寸」或「檢查帷幕牆立面」，Revit 就會做——背後是 **173 個 MCP 工具**，由 **76 份專業 BIM SOP**（建築法規、數量計算、法規檢核）支撐。
+用講人話的方式操作 Revit。跟你的 AI Client 說「幫這個視圖的牆全部標尺寸」或「檢查帷幕牆立面」，Revit 就會做——背後是 **174 個 MCP 工具**，由 **76 份專業 BIM SOP**（建築法規、數量計算、法規檢核）支撐。
 
 **給誰用：** 使用 Revit、想要 AI 輔助且符合規範的 BIM 工程師與建築師。你需要 Windows 上的 Revit（2022–2026），並願意安裝一個 add-in。
 
@@ -33,7 +33,7 @@ Revit MCP 透過 Model Context Protocol (MCP) 讓 AI Client 呼叫 Revit 工具�
 
 | 項目 | 數量 | 來源 |
 |---|---:|---|
-| Runtime MCP tools | 173 | `MCP-Server/src/tools/index.ts` 的 `registerRevitTools()` |
+| Runtime MCP tools | 174 | `MCP-Server/src/tools/index.ts` 的 `registerRevitTools()` |
 | Domain SOP files | 76 | `domain/*.md` 扣除 `README.md`，加上 `domain/references/*.md` |
 | Claude skills | 54 | `.claude/skills/*/SKILL.md` |
 

--- a/docs/BIM_MCP/reference/architecture-v2.html
+++ b/docs/BIM_MCP/reference/architecture-v2.html
@@ -31,7 +31,7 @@
 <header class="bim-hero">
   <div class="bim-hero-eyebrow">ARCHITECTURE V2 <span class="accent">3 層</span></div>
   <h1 class="bim-hero-title"><span class="accent">Skill / CLAUDE.md / Domain</span><br>三層模組架構</h1>
-  <p class="bim-hero-sub">REVIT_MCP 的核心架構：把 9 個系統、76 個 Domain、173 個工具按職責分到三層。Skill 管「何時觸發」、CLAUDE.md 管「跨 AI Client 橋接」、Domain 管「不可協商的知識」。本頁同時澄清「MCP ≠ Skill」的常見誤解。</p>
+  <p class="bim-hero-sub">REVIT_MCP 的核心架構：把 9 個系統、76 個 Domain、174 個工具按職責分到三層。Skill 管「何時觸發」、CLAUDE.md 管「跨 AI Client 橋接」、Domain 管「不可協商的知識」。本頁同時澄清「MCP ≠ Skill」的常見誤解。</p>
 </header>
 
 <!-- ============================================ -->
@@ -97,7 +97,7 @@
     <div class="how-tech-label">WHY</div>
     <div class="how-tech-content">社群常爭論「Skill 殺死 MCP」——這是把<strong>抽象層級</strong>搞混的結果。MCP 解決「<strong>AI 怎麼動 Revit</strong>」（基礎能力），Skill 解決「<strong>AI 該照什麼順序動 Revit</strong>」（編排知識）。兩件根本不同層級的事，沒有取代關係。</div>
     <div class="how-tech-label">HOW</div>
-    <div class="how-tech-content">本專案明確分層——MCP server 提供 173 個原子工具（純能力），Skill 編排工具呼叫順序（純知識）。一個 MCP 工具被多個 Skill 引用，一個 Skill 引用多個 MCP 工具——<strong>多對多關係</strong>，互不替代。</div>
+    <div class="how-tech-content">本專案明確分層——MCP server 提供 174 個原子工具（純能力），Skill 編排工具呼叫順序（純知識）。一個 MCP 工具被多個 Skill 引用，一個 Skill 引用多個 MCP 工具——<strong>多對多關係</strong>，互不替代。</div>
     <div class="how-tech-label">TECHNIQUE</div>
     <div class="how-tech-content technique">Layered Capability Architecture · MCP as Runtime Bridge · Skill as Workflow Choreographer · M:N Tool-Skill Composition</div>
   </div>
@@ -248,7 +248,7 @@ CommandExecutor → Revit API</code></pre>
 
   <div class="how-tech">
     <div class="how-tech-label">WHY</div>
-    <div class="how-tech-content">為什麼不直接 AI Client ↔ Revit API？因為<strong>Revit API 太底層</strong>——LLM 要傳 ElementId、Transaction、ViewSet 這些原生型別，每次都得編 boilerplate。MCP Server 中間層把這些封裝成 173 個語意化工具（<code>check_smoke_exhaust_windows</code> 比 <code>FilteredElementCollector.OfCategory(...)</code> 友善 100 倍）。</div>
+    <div class="how-tech-content">為什麼不直接 AI Client ↔ Revit API？因為<strong>Revit API 太底層</strong>——LLM 要傳 ElementId、Transaction、ViewSet 這些原生型別，每次都得編 boilerplate。MCP Server 中間層把這些封裝成 174 個語意化工具（<code>check_smoke_exhaust_windows</code> 比 <code>FilteredElementCollector.OfCategory(...)</code> 友善 100 倍）。</div>
     <div class="how-tech-label">HOW</div>
     <div class="how-tech-content">AI Client（stdio）→ MCP Server（Node.js TypeScript）→ WebSocket（port 8964）→ Revit Add-in（C# .NET）→ Revit API。每層做<strong>協議翻譯 + UI 執行緒守門</strong>。port 8964 由 Add-in 啟動（HttpListener），MCP Server 連入。</div>
     <div class="how-tech-label">TECHNIQUE</div>
@@ -300,9 +300,9 @@ CommandExecutor → Revit API</code></pre>
       </tr>
       <tr>
         <td>MCP Tools</td>
-        <td>共用 173 個工具</td>
-        <td>共用 173 個工具</td>
-        <td>共用 173 個工具</td>
+        <td>共用 174 個工具</td>
+        <td>共用 174 個工具</td>
+        <td>共用 174 個工具</td>
       </tr>
       <tr>
         <td>Event Log</td>

--- a/docs/BIM_MCP/reference/domain-index.html
+++ b/docs/BIM_MCP/reference/domain-index.html
@@ -74,7 +74,7 @@
 <header class="bim-hero">
   <div class="bim-hero-eyebrow">DOMAIN INDEX <span class="accent">76 個 SOP / 5 分類</span></div>
   <h1 class="bim-hero-title">Domain · <span class="accent">知識層</span><br>方法寫一次，多個 Skill 共用</h1>
-  <p class="bim-hero-sub">Domain 是<strong>知識本身</strong>——法規條文、SOP、公式、例外。Skill 是<strong>編排</strong>（54 個）。Tool 是<strong>原子執行</strong>（173 個）。<strong>知識不應該重複在每個 Skill 裡</strong>——這是本專案核心架構原則。本頁列 76 個 <code>domain/*.md</code>，依五大類彩色標示，每張 card 含觸發關鍵字與反查 Skill。</p>
+  <p class="bim-hero-sub">Domain 是<strong>知識本身</strong>——法規條文、SOP、公式、例外。Skill 是<strong>編排</strong>（54 個）。Tool 是<strong>原子執行</strong>（174 個）。<strong>知識不應該重複在每個 Skill 裡</strong>——這是本專案核心架構原則。本頁列 76 個 <code>domain/*.md</code>，依五大類彩色標示，每張 card 含觸發關鍵字與反查 Skill。</p>
   <figure class="bim-hero-figure"><img src="../images/domain__hero__45-grains.svg" alt="76 個 domain SOP，依五大類彩色方塊排列" width="1200" height="900"></figure>
 </header>
 
@@ -102,7 +102,7 @@
   </div>
 
   <div class="bim-grid bim-grid-3">
-    <div class="bim-card"><h4>Tool（173）</h4><p style="font-size:13px;">執行 Revit 查詢、建立、修改。<strong>所有具體資料</strong>必須來自工具回傳。</p></div>
+    <div class="bim-card"><h4>Tool（174）</h4><p style="font-size:13px;">執行 Revit 查詢、建立、修改。<strong>所有具體資料</strong>必須來自工具回傳。</p></div>
     <div class="bim-card bim-card-accent"><h4>Domain（76）</h4><p style="font-size:13px;">保存 SOP、公式、例外與判斷流程。<strong>方法的單一來源</strong>。</p></div>
     <div class="bim-card"><h4><a href="skills-index.html" style="border-bottom:1px solid var(--accent-border);">Skill（52）</a></h4><p style="font-size:13px;">把 Domain 與工具串成工作流。<strong>不藏方法在 Skill body</strong>。</p></div>
   </div>

--- a/docs/BIM_MCP/reference/personal-llm-wiki.html
+++ b/docs/BIM_MCP/reference/personal-llm-wiki.html
@@ -110,7 +110,7 @@
     <tr><td>log.md（可 grep 的條目格式）</td><td>log/YYYY-MM.md —— 條目格式完全相同</td><td>你的 log.md（沿用同一格式）</td></tr>
     <tr><td>Lint 操作</td><td>scripts/verify-qaqc.ps1（孤兒頁、斷鏈、計數漂移）</td><td>請 AI 健檢你的 wiki（過版、矛盾、可回饋上游的發現）</td></tr>
   </table>
-  <p style="color:var(--text-muted);font-size:13px">補充：54 個編排層 Skill 與 173 個 MCP tools 也都在 repo 裡，AI 會在 ingest 時一併理解「哪些 SOP 有對應的自動化能力」。</p>
+  <p style="color:var(--text-muted);font-size:13px">補充：54 個編排層 Skill 與 174 個 MCP tools 也都在 repo 裡，AI 會在 ingest 時一併理解「哪些 SOP 有對應的自動化能力」。</p>
 </section>
 
 <section class="bim-section bim-anchor" id="structure">

--- a/docs/BIM_MCP/reference/philosophy-22-propositions.html
+++ b/docs/BIM_MCP/reference/philosophy-22-propositions.html
@@ -1040,7 +1040,7 @@
     <div class="pitfalls-title">反模式警告：8/80 Rule</div>
     <ul>
       <li><strong>工作包應 8-80 小時</strong>——過細變 micromanagement 反而拖垮整條流程</li>
-      <li><strong>警告：173 工具不該變成 500 個微任務</strong>——保持「設計師可一次完成的單元」尺度</li>
+      <li><strong>警告：174 工具不該變成 500 個微任務</strong>——保持「設計師可一次完成的單元」尺度</li>
       <li><strong>拆分到「每根牆都觸發一次檢核」是反人類設計</strong>——拆到「每個樓層平面完成觸發一組檢核」就對了</li>
     </ul>
   </div>

--- a/docs/BIM_MCP/reference/skills-index.html
+++ b/docs/BIM_MCP/reference/skills-index.html
@@ -137,7 +137,7 @@
     </div>
     <div class="bim-card">
       <h4>Tool（執行）</h4>
-      <p style="font-size:13px;">原子操作（query / create / modify）。173 個 MCP tools。</p>
+      <p style="font-size:13px;">原子操作（query / create / modify）。174 個 MCP tools。</p>
     </div>
   </div>
   <p class="bim-section-desc" style="margin-top:var(--gap-md);">「<strong>不要把每個 Domain 都升級成 Skill</strong>」——這是本專案的核心架構原則。詳見 <a href="philosophy-22-propositions.html">22 命題</a>。</p>

--- a/docs/DOCUMENT_AUDIENCE_INVENTORY.md
+++ b/docs/DOCUMENT_AUDIENCE_INVENTORY.md
@@ -15,7 +15,7 @@ This inventory defines which project documents are for AI agents, human readers,
 
 | Item | Count | Source |
 |---|---:|---|
-| Runtime MCP tools | 173 | `registerRevitTools()` |
+| Runtime MCP tools | 174 | `registerRevitTools()` |
 | Domain SOP files | 76 | `domain/*.md` except README, plus `domain/references/*.md` |
 | Claude skills | 54 | `.claude/skills/*/SKILL.md` |
 

--- a/domain/mep-opening-candidate-scan.md
+++ b/domain/mep-opening-candidate-scan.md
@@ -2,8 +2,8 @@
 name: mep-opening-candidate-scan
 description: "MEP 開孔候選掃描 SOP（scan_opening_candidates）：在 detect_clashes 幾何核心之上，唯讀推導管線穿越結構的開孔候選清單，含建議尺寸、candidate/review_required 狀態與 warningCodes。第一版邊界為掃描專用，不建套管、不建開孔族群、不放預覽標記。當使用者提到開孔候選、開孔預掃、opening candidate、預留孔洞、套管前置檢核、scan opening 時觸發。"
 metadata:
-  version: "1.0"
-  updated: "2026-08-10"
+  version: "1.1"
+  updated: "2026-08-24"
   created: "2026-07-28"
   contributors:
     - "NicheSam (SC REVIT, 待確認真名)"
@@ -20,7 +20,7 @@ metadata:
 
 # MEP 開孔候選掃描 SOP (scan_opening_candidates)
 
-> **狀態：v1 規格已補齊。** 尺寸公式常數、回傳 schema、狀態判定門檻等工程細節已由 @NicheSam（SC REVIT）於 2026-07-30 在 Issue #99 留言（comment id `5128684040`）補值，並回寫本檔。`scan_opening_candidates` 工具本身**尚未**在 `MCP-Server/src/tools/*.ts` 落地實作（見〈已知缺口與後續流程〉）——實作前，任何 AI 代理仍不得對外宣稱此工具已可用於自動建模或自動建套管。
+> **狀態：v1 已實作，並完成 Revit 2024 runtime smoke 驗證。** 尺寸公式常數、回傳 schema、狀態判定門檻等工程細節由 @NicheSam（SC REVIT）於 2026-07-30 在 Issue #99 留言（comment id `5128684040`）補值；MCP 工具定義位於 `MCP-Server/src/tools/clash-tools.ts`，Revit 端候選映射位於 `MCP/Core/OpeningCandidateScanner.cs`。此狀態不等於可自動建模或自動建套管。
 
 ## 目的與第一版邊界
 
@@ -235,4 +235,4 @@ Tool: scan_opening_candidates
 * `domain/sleeve-classification-protocol.md` —— 套管身分識別協議，候選清單下游銜接。
 * `domain/beam-penetration-base.md` —— 梁穿孔檢核基礎協議，`review_required` 中穿樑柱候選的正式檢核依據。
 
-> 註：`scan_opening_candidates` 本身尚未在 `MCP-Server/src/tools/*.ts` 中找到對應實作（已 grep 全目錄確認不存在）。本檔為該工具的**設計契約（v1 規格已補齊，實作尚未串接）**，供實作前對齊 I/O 與狀態機語意；工具落地後，需回頭在本節補上實際檔案位置與 `inputSchema` 對照，並移除本註記。
+> 實作對照：公開 `inputSchema` 與唯讀標註在 `MCP-Server/src/tools/clash-tools.ts`；命令由 `MCP/Core/CommandExecutor.cs` 派發至 `MCP/Core/OpeningCandidateScanner.cs`，後者呼叫既有 `ClashDetector.DetectClashes`，不維護第二套碰撞演算法。2026-08-24 Revit 2024 runtime smoke：`大甲分局_MEP_sc168jobim.rvt`，MEP 主模型、結構 link `13291389`，`clearanceMm=25`、`maxCount=10`，回傳 `totalCandidates=10`、`candidateCount=10`、`reviewRequiredCount=0`、`failedCount=0`，且缺少 `clearanceMm` 時正確拒絕。

--- a/log/2026-08.md
+++ b/log/2026-08.md
@@ -275,3 +275,24 @@ git log --pretty=format:'%an' | sort -u
 ### 下次可接續的起手式
 
 先跑 `.\scripts\verify-qaqc.ps1 -SkipBuild -SkipDeploy` 確認仍是 60 PASS / 0 FAIL，再依優先序擇一：① 若使用者手上有含中文粉刷參數的專案模型 → 補完 #111 的核心演算法驗證（唯一還掛著的「已修但未完整驗證」項目）；② 否則開工 #112（`scan_opening_candidates`，規格最完整、且前置的 `csaSource.linkInstanceId` schema 已補）。動 Revit 前記得：測試模型一律不存檔。
+
+## [2026-08-24] feat | Issue #112 scan_opening_candidates 唯讀候選掃描（Tools 173→174）
+
+- actor: Codex desktop
+- files: `MCP/Core/OpeningCandidateScanner.cs`, `MCP/Core/CommandExecutor.cs`, `MCP-Server/src/tools/clash-tools.ts`, `MCP-Server/scripts/test-opening-candidate-contract.mjs`, `MCP-Server/package.json`, `domain/mep-opening-candidate-scan.md`, counts/docs, `log/2026-08.md`
+- trigger: Issue #112
+- summary: 新增 `scan_opening_candidates` 公開 MCP 工具，`clearanceMm` 明確必填且無預設值，工具標註為唯讀。Revit 端不另寫碰撞引擎，而是呼叫既有 `ClashDetector.DetectClashes` 後映射 candidate contract；輸出主模型／Link lookup、project-coordinate entry/exit/center、建議孔徑、開孔下緣、`candidate` / `review_required` 與 7 種 warningCodes。單筆解析錯誤進入 `failures`，不終止整批。契約測試已先紅後綠；Release.R24 build 0 errors。尚待 R22–R26、QAQC 與 Revit 2024 runtime 驗證，未宣稱模型行為已通過。
+
+## [2026-08-24] verify | Issue #112 靜態驗證完成；runtime 因 Bridge 佔線與未載入新 DLL 待補
+
+- actor: Codex desktop
+- files: `MCP/Core/ClashDetector.cs`, `log/2026-08.md`
+- trigger: Issue #112 final verification
+- summary: 程式審核發現並修正既有 `CollectMepElements` 只對 Link 來源套用 `filters`、主模型來源會靜默忽略的契約不一致；過濾已移到來源分支後共用。修正後 Release.R22/R23/R24/R25/R26 逐版 restore + build 全部 0 errors；MCP Server 完整 build 通過，`scan_opening_candidates` contract test 通過，full/mep/structural profile 均註冊且 readOnlyHint=true；QAQC 60 PASS / 0 FAIL / 0 WARN / 3 SKIP。Revit 2024 runtime 未執行：9686 已被另一個 Codex task 的 BIM Agent Gateway PID 51288 獨占，本 task 握手回 409；目前 Revit session 載入的是既有 BIM Personal Agent bridge，Issue #112 新 DLL 尚未部署／重啟載入。未中斷其他 task、未關閉 Revit、未變更模型。
+
+## [2026-08-24] verify | Issue #112 Revit 2024 runtime smoke 完成（clearanceMm=25）
+
+- actor: Codex desktop
+- files: `domain/mep-opening-candidate-scan.md`, `log/2026-08.md`
+- trigger: user supplied `clearanceMm=25` after Revit restart
+- summary: 部署 Issue #112 `Release.R24` 產物到 `%APPDATA%\Autodesk\Revit\Addins\2024\RevitMCP` 後重啟 Revit 2024，`scripts/status.ps1 -Json` 回報 port 8964 open、runtime tools 174。負向 runtime 驗證：缺少 `clearanceMm` 呼叫 `scan_opening_candidates` 時正確回傳「必須提供明確的 clearanceMm；本工具不會套用預設預留量」。正式唯讀 smoke：`大甲分局_MEP_sc168jobim.rvt`，MEP 主模型，結構 link `大甲細設-主檔.rvt` / `LinkInstanceId=13291389`，參數 `clearanceMm=25`、`maxCount=10`。結果 `Success=true`、`totalCandidates=10`、`candidateCount=10`、`reviewRequiredCount=0`、`failedCount=0`、`clearanceMmPerSide=25`、`mepElementCount=1786`、`structureElementCount=3886`；10 筆皆為主模型 `Pipes` 穿 linked `Floors`，回傳 project-coordinate entry/exit/center、round suggested opening size、opening bottom、lookup identity，`warningCodes=[]`。此 smoke 驗證工具 dispatch、必填檢核、主模型 MEP + linked structure source、候選 schema 與唯讀掃描可用；不宣稱全量模型審核或自動建套管。


### PR DESCRIPTION
## 提交說明

本 PR 是針對 Issue #112 的 code implementation。

依 `CONTRIBUTING.md`，外部 fork PR 原則上僅限 knowledge contribution；但 Issue #112 的交付內容需要修改 `MCP/` 與 `MCP-Server/src/`。因此本 PR 請維護者確認是否接受此外部 fork 的實作 PR，或由維護者 cherry-pick / 轉為 same-repo PR 收編。

## 摘要

完成 #112：新增 `scan_opening_candidates`，用於唯讀掃描 MEP 管線穿越結構的開孔候選。

這次實作只產出候選清單，不建立套管、不建立開孔族群、不放預覽標記，也不修改模型。

## 對照 Issue #112 交付要求

- [x] C# command 實作
- [x] TS 工具定義，含 `title` 與唯讀標註
- [x] `clearanceMm` 必填且無預設值
- [x] 沿用 `detect_clashes` 既有 Curve-to-Solid 碰撞核心，沒有另寫第二套碰撞演算法
- [x] 回傳 `candidate` / `review_required`
- [x] 回傳 7 種 warningCodes
- [x] Tools 計數 173 → 174
- [x] QA/QC
- [x] Revit 2024 runtime smoke test

## C# command 實作

本 PR 新增 Revit 端 command 實作：

- `MCP/Core/OpeningCandidateScanner.cs`
  - 新增 `Scan(JObject parameters)`
  - 驗證 `mepSource`、`structureSource`、`clearanceMm`
  - `clearanceMm` 必填，缺少時直接回錯，不套用預設值
  - 呼叫既有 `ClashDetector.DetectClashes`
  - 將碰撞結果轉成 opening candidates
  - 回傳 `candidate` / `review_required`
  - 回傳 7 種 warningCodes
  - 保持唯讀，不建立任何 Revit 元件

並在既有 command dispatcher 串接：

- `MCP/Core/CommandExecutor.cs`
  - 新增 `case "scan_opening_candidates"`
  - 將請求導向 `OpeningCandidateScanner.Scan(...)`

## TS 工具定義

- `MCP-Server/src/tools/clash-tools.ts`
  - 新增 `scan_opening_candidates`
  - 補上 `title`
  - 補上唯讀工具描述與 annotations
  - `clearanceMm` 在 schema 中維持必填，沒有預設值

## 實機測試

已在 Revit 2024 完成 runtime smoke test。

測試條件：

- 模型：`大甲分局_MEP_sc168jobim.rvt`
- MEP 來源：主模型
- 結構來源：linked model `大甲細設-主檔.rvt`
- `LinkInstanceId`: `13291389`
- `clearanceMm`: 每側 `25 mm`
- `maxCount`: `10`

負向測試：

- 缺少 `clearanceMm` 時，runtime 正確拒絕：
  `必須提供明確的 clearanceMm；本工具不會套用預設預留量`

正式 smoke 結果：

- `Success=true`
- `totalCandidates=10`
- `candidateCount=10`
- `reviewRequiredCount=0`
- `failedCount=0`
- `mepElementCount=1786`
- `structureElementCount=3886`
- 10 筆皆為主模型 `Pipes` 穿 linked `Floors`
- `warningCodes=[]`

## 驗證

- `npm.cmd run test:opening-candidate-contract`：PASS
- `npm.cmd run build`：PASS
- Revit R22 / R23 / R24 / R25 / R26 build：0 errors
- QA/QC：60 PASS / 0 FAIL / 0 WARN / 3 SKIP
- `git diff --check`：無 whitespace error，僅既有 LF→CRLF 提醒

## 邊界

本 PR 不實作自動建套管、開孔族群建立、預覽標記、候選定位或全模型工程審核。

本次 runtime smoke 證明的是：command dispatch、必填參數檢核、主模型 MEP + linked structure source、候選 schema 與唯讀掃描可用；不宣稱所有候選皆可施工或可自動建模。

Closes #112
